### PR TITLE
Fix inventory plugin does not work with old configuration files

### DIFF
--- a/changelogs/inventory-allow-usage-of-pre-migration-configuration-fuiles.yml
+++ b/changelogs/inventory-allow-usage-of-pre-migration-configuration-fuiles.yml
@@ -1,0 +1,2 @@
+bugfix:
+  - hcloud inventory plugin - Allow usage of hcloud.yml and hcloud.yaml - this was removed by error within the migration from build-in ansible to our collection

--- a/plugins/inventory/hcloud.py
+++ b/plugins/inventory/hcloud.py
@@ -230,7 +230,7 @@ class InventoryModule(BaseInventoryPlugin, Constructable):
         """Return the possibly of a file being consumable by this plugin."""
         return (
             super(InventoryModule, self).verify_file(path) and
-            path.endswith((self.NAME + ".yaml", self.NAME + ".yml"))
+            path.endswith(("hcloud.yaml", "hcloud.yml"))
         )
 
     def parse(self, inventory, loader, path, cache=True):

--- a/plugins/modules/hcloud_load_balancer.py
+++ b/plugins/modules/hcloud_load_balancer.py
@@ -174,7 +174,7 @@ class AnsibleHcloudLoadBalancer(Hcloud):
             "location": to_native(self.hcloud_load_balancer.location.name),
             "labels": self.hcloud_load_balancer.labels,
             "delete_protection": self.hcloud_load_balancer.protection["delete"],
-            "disable_public_interface": self.hcloud_load_balancer.public_net.enabled
+            "disable_public_interface": False if self.hcloud_load_balancer.public_net.enabled else True,
         }
 
     def _get_load_balancer(self):
@@ -219,7 +219,6 @@ class AnsibleHcloudLoadBalancer(Hcloud):
 
         self._mark_as_changed()
         self._get_load_balancer()
-        self._update_load_balancer()
 
     def _update_load_balancer(self):
         try:
@@ -251,8 +250,10 @@ class AnsibleHcloudLoadBalancer(Hcloud):
     def present_load_balancer(self):
         self._get_load_balancer()
         if self.hcloud_load_balancer is None:
+            self.module.debug(msg="Create")
             self._create_load_balancer()
         else:
+            self.module.debug(msg="Update")
             self._update_load_balancer()
 
     def delete_load_balancer(self):

--- a/plugins/modules/hcloud_load_balancer.py
+++ b/plugins/modules/hcloud_load_balancer.py
@@ -236,7 +236,7 @@ class AnsibleHcloudLoadBalancer(Hcloud):
             self._get_load_balancer()
 
             disable_public_interface = self.module.params.get("disable_public_interface")
-            if disable_public_interface is not None and disable_public_interface != self.hcloud_load_balancer.public_net.enabled:
+            if disable_public_interface is not None and disable_public_interface != (not self.hcloud_load_balancer.public_net.enabled):
                 if not self.module.check_mode:
                     if disable_public_interface is True:
                         self.hcloud_load_balancer.disable_public_interface().wait_until_finished()
@@ -250,10 +250,8 @@ class AnsibleHcloudLoadBalancer(Hcloud):
     def present_load_balancer(self):
         self._get_load_balancer()
         if self.hcloud_load_balancer is None:
-            self.module.debug(msg="Create")
             self._create_load_balancer()
         else:
-            self.module.debug(msg="Update")
             self._update_load_balancer()
 
     def delete_load_balancer(self):
@@ -278,7 +276,7 @@ class AnsibleHcloudLoadBalancer(Hcloud):
                 network_zone={"type": "str"},
                 labels={"type": "dict"},
                 delete_protection={"type": "bool"},
-                disable_public_interface={"type": "bool", "default": False},
+                disable_public_interface={"type": "bool"},
                 state={
                     "choices": ["absent", "present"],
                     "default": "present",

--- a/plugins/modules/hcloud_load_balancer_service.py
+++ b/plugins/modules/hcloud_load_balancer_service.py
@@ -322,7 +322,7 @@ class AnsibleHcloudLoadBalancerService(Hcloud):
                 "response": to_native(self.hcloud_load_balancer_service.health_check.http.response),
                 "certificates": [to_native(status_code) for status_code in
                                  self.hcloud_load_balancer_service.health_check.http.status_codes],
-                "tls": self.hcloud_load_balancer_service.health_check.tls,
+                "tls": self.hcloud_load_balancer_service.health_check.http.tls,
             }
         return {
             "load_balancer": to_native(self.hcloud_load_balancer.name),

--- a/tests/integration/targets/hcloud_load_balancer/tasks/main.yml
+++ b/tests/integration/targets/hcloud_load_balancer/tasks/main.yml
@@ -29,7 +29,7 @@
     state: present
   register: result
   check_mode: yes
-- name: test create Load Balancer Load Balancer
+- name: test create Load Balancer with check mode
   assert:
     that:
       - result is changed
@@ -51,6 +51,8 @@
 - name: test create Load Balancer idempotence
   hcloud_load_balancer:
     name: "{{ hcloud_load_balancer_name }}"
+    load_balancer_type: lb11
+    network_zone: eu-central
     state: present
   register: result
 - name: verify create Load Balancer idempotence

--- a/tests/utils/gitlab/gitlab.sh
+++ b/tests/utils/gitlab/gitlab.sh
@@ -85,7 +85,9 @@ find plugins -type d -empty -print -delete
 ansible-test env --dump --show --timeout "50" --color -v
 
 group="${args[1]}"
-if [[ "${test}" =~ integration ]]; then
+echo $test
+if [[ "${test}" =~ hcloud ]]; then
+  group="${args[3]}"
   bash tests/utils/gitlab/integration.sh "shippable/hcloud/group${group}/"
 else
   bash tests/utils/gitlab/sanity.sh "sanity/${group}"

--- a/tests/utils/gitlab/gitlab.sh
+++ b/tests/utils/gitlab/gitlab.sh
@@ -46,6 +46,7 @@ fi
 export ANSIBLE_COLLECTIONS_PATHS="${HOME}/.ansible"
 SHIPPABLE_RESULT_DIR="$(pwd)/shippable"
 TEST_DIR="${ANSIBLE_COLLECTIONS_PATHS}/ansible_collections/hetzner/hcloud"
+rm -rf  "${TEST_DIR}"
 mkdir -p "${TEST_DIR}"
 cp -r "." "${TEST_DIR}"
 cd "${TEST_DIR}"

--- a/tests/utils/gitlab/integration.sh
+++ b/tests/utils/gitlab/integration.sh
@@ -12,4 +12,4 @@ hcloud_api_token=${HCLOUD_TOKEN}
 export SHIPPABLE="true"
 export SHIPPABLE_BUILD_NUMBER="gl-$(cat prefix.txt)"
 export SHIPPABLE_JOB_NUMBER="$(cat /dev/urandom | tr -dc 'a-zA-Z0-9' | fold -w 2 | head -n 1)"
-ansible-test integration --color --local -vvvvv "${target}" ${COVERAGE:+"$COVERAGE"} ${CHANGED:+"$CHANGED"} ${UNSTABLE:+"$UNSTABLE"}
+ansible-test integration --color --local -vv "${target}" ${COVERAGE:+"$COVERAGE"} ${CHANGED:+"$CHANGED"} ${UNSTABLE:+"$UNSTABLE"}


### PR DESCRIPTION
Bugfix: allow hcloud.yml and hcloud.yaml again as inventory configuration.

Before the migration to the collection the configuration files allowed everything that ends with `hcloud`. The migrations to our collection repo changed that to everything that ends with `hetzner.hcloud.hcloud.yml/hetzner.hcloud.hcloud.yaml`. This reverts that change to allow everything that ends with `hcloud.yml/hcloud.yaml`.
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
hcloud inventory plugin
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
