### PR TITLE
Allow the creation of servers with enabled backups

### DIFF
--- a/changelogs/fragments/gh7-allow-enabling-of-backups-on-server-creation.yml
+++ b/changelogs/fragments/gh7-allow-enabling-of-backups-on-server-creation.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - hcloud_server Allow the creation of servers with enabled backups

--- a/plugins/modules/hcloud_server.py
+++ b/plugins/modules/hcloud_server.py
@@ -352,6 +352,11 @@ class AnsibleHcloudServer(Hcloud):
                 self._get_server()
                 self._set_rescue_mode(rescue_mode)
 
+            backups = self.module.params.get("backups")
+            if backups:
+                self._get_server()
+                self.hcloud_server.enable_backup().wait_until_finished()
+
         self._mark_as_changed()
         self._get_server()
 

--- a/tests/integration/targets/hcloud_server/tasks/main.yml
+++ b/tests/integration/targets/hcloud_server/tasks/main.yml
@@ -563,3 +563,29 @@
   assert:
     that:
     - result is success
+
+- name: test create server with enabled backups
+  hcloud_server:
+    name: "{{ hcloud_server_name }}"
+    server_type: cpx11
+    backups: true
+    image: "ubuntu-18.04"
+    ssh_keys:
+      - ci@ansible.hetzner.cloud
+    state: present
+  register: result
+- name: verify enable backups
+  assert:
+    that:
+      - result is changed
+      - result.hcloud_server.backup_window != ""
+
+- name: test create server with enabled backups
+  hcloud_server:
+    name: "{{ hcloud_server_name }}"
+    state: absent
+  register: result
+- name: verify cleanup
+  assert:
+    that:
+    - result is success


### PR DESCRIPTION
Signed-off-by: Lukas Kämmerling <lukas.kaemmerling@hetzner-cloud.de>

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
This allows the creation of Servers with backups enabled in one step instead of needing an additional step just for enabling the backups.

Fixes: #7 
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request
##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
hcloud_server
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
