### PR TITLE
document private_ipv4 connect_with option

### DIFF
--- a/plugins/inventory/hcloud.py
+++ b/plugins/inventory/hcloud.py
@@ -37,6 +37,7 @@ DOCUMENTATION = r'''
                 - public_ipv4
                 - hostname
                 - ipv4_dns_ptr
+                - private_ipv4
         locations:
           description: Populate inventory with instances in this location.
           default: []


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

the private_ipv4 option was missing from the connect_with documentation section

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Docs Pull Request

