### PR TITLE
Allow setting Floating IP RDNS entries with hcloud_rdns

### DIFF
--- a/plugins/modules/hcloud_rdns.py
+++ b/plugins/modules/hcloud_rdns.py
@@ -132,9 +132,9 @@ class AnsibleHcloudReverseDNS(Hcloud):
         }
 
         if self.module.params.get("server"):
-            result["server"] = to_native(self.hcloud_resource.name),
+            result["server"] = to_native(self.hcloud_resource.name)
         elif self.module.params.get("floating_ip"):
-            result["floating_ip"] = to_native(self.hcloud_resource.name),
+            result["floating_ip"] = to_native(self.hcloud_resource.name)
         return result
 
     def _get_resource(self):
@@ -144,7 +144,7 @@ class AnsibleHcloudReverseDNS(Hcloud):
                     self.module.params.get("server")
                 )
             elif self.module.params.get("floating_ip"):
-                self.hcloud_resource = self.client.floating_ip.get_by_name(
+                self.hcloud_resource = self.client.floating_ips.get_by_name(
                     self.module.params.get("floating_ip")
                 )
         except APIException as e:
@@ -168,7 +168,7 @@ class AnsibleHcloudReverseDNS(Hcloud):
                         "dns_ptr": self.hcloud_resource.dns_ptr[0]["dns_ptr"],
                     }
                 else:
-                    self.module.fail_json(msg="The selected server does not have this IP address")
+                    self.module.fail_json(msg="The selected Floating IP does not have this IP address")
 
         elif utils.validate_ip_v6_address(ip_address):
             if self.module.params.get("server"):
@@ -200,7 +200,6 @@ class AnsibleHcloudReverseDNS(Hcloud):
         if not self.module.check_mode:
             self.hcloud_resource.change_dns_ptr(**params).wait_until_finished()
 
-        self.log("created rdns", type(self.hcloud_resource))
         self._mark_as_changed()
         self._get_resource()
         self._get_rdns()

--- a/plugins/modules/hcloud_rdns.py
+++ b/plugins/modules/hcloud_rdns.py
@@ -200,6 +200,7 @@ class AnsibleHcloudReverseDNS(Hcloud):
         if not self.module.check_mode:
             self.hcloud_resource.change_dns_ptr(**params).wait_until_finished()
 
+        self.log("created rdns", type(self.hcloud_resource))
         self._mark_as_changed()
         self._get_resource()
         self._get_rdns()

--- a/plugins/modules/hcloud_rdns.py
+++ b/plugins/modules/hcloud_rdns.py
@@ -132,9 +132,9 @@ class AnsibleHcloudReverseDNS(Hcloud):
         }
 
         if self.module.params.get("server"):
-            result["server"] = to_native(self.hcloud_resource.name),
+            result.server = to_native(self.hcloud_resource.name),
         elif self.module.params.get("floating_ip"):
-            result["floating_ip"] = to_native(self.hcloud_resource.name),
+            result.floating_ip = to_native(self.hcloud_resource.name),
         return result
 
     def _get_resource(self):
@@ -145,7 +145,7 @@ class AnsibleHcloudReverseDNS(Hcloud):
                 )
             elif self.module.params.get("floating_ip"):
                 self.hcloud_resource = self.client.floating_ip.get_by_name(
-                    self.module.params.get("server")
+                    self.module.params.get("floating_ip")
                 )
         except APIException as e:
             self.module.fail_json(msg=e.message)

--- a/plugins/modules/hcloud_rdns.py
+++ b/plugins/modules/hcloud_rdns.py
@@ -132,9 +132,9 @@ class AnsibleHcloudReverseDNS(Hcloud):
         }
 
         if self.module.params.get("server"):
-            result.server = to_native(self.hcloud_resource.name),
+            result["server"] = to_native(self.hcloud_resource.name),
         elif self.module.params.get("floating_ip"):
-            result.floating_ip = to_native(self.hcloud_resource.name),
+            result["floating_ip"] = to_native(self.hcloud_resource.name),
         return result
 
     def _get_resource(self):

--- a/plugins/modules/hcloud_rdns.py
+++ b/plugins/modules/hcloud_rdns.py
@@ -179,7 +179,7 @@ class AnsibleHcloudReverseDNS(Hcloud):
                             "dns_ptr": ipv6_address_dns_ptr["dns_ptr"],
                         }
             elif self.module.params.get("floating_ip"):
-                for ipv6_address_dns_ptr in self.hcloud_resource.dns_ptr :
+                for ipv6_address_dns_ptr in self.hcloud_resource.dns_ptr:
                     if ipv6_address_dns_ptr["ip"] == ip_address:
                         self.hcloud_rdns = {
                             "ip_address": ipv6_address_dns_ptr["ip"],

--- a/plugins/modules/hcloud_rdns.py
+++ b/plugins/modules/hcloud_rdns.py
@@ -135,7 +135,7 @@ class AnsibleHcloudReverseDNS(Hcloud):
             result["server"] = to_native(self.hcloud_resource.name),
         elif self.module.params.get("floating_ip"):
             result["floating_ip"] = to_native(self.hcloud_resource.name),
-        return
+        return result
 
     def _get_resource(self):
         try:
@@ -179,7 +179,7 @@ class AnsibleHcloudReverseDNS(Hcloud):
                             "dns_ptr": ipv6_address_dns_ptr["dns_ptr"],
                         }
             elif self.module.params.get("floating_ip"):
-                for ipv6_address_dns_ptr in self.hcloud_resource.dns_ptr:
+                for ipv6_address_dns_ptr in self.hcloud_resource.dns_ptr :
                     if ipv6_address_dns_ptr["ip"] == ip_address:
                         self.hcloud_rdns = {
                             "ip_address": ipv6_address_dns_ptr["ip"],

--- a/tests/integration/targets/hcloud_rdns/defaults/main.yml
+++ b/tests/integration/targets/hcloud_rdns/defaults/main.yml
@@ -3,3 +3,4 @@
 ---
 hcloud_prefix: "tests"
 hcloud_server_name: "{{hcloud_prefix}}-rdns"
+hcloud_floating_ip_name: "{{hcloud_prefix}}-rdns"

--- a/tests/integration/targets/hcloud_rdns/tasks/main.yml
+++ b/tests/integration/targets/hcloud_rdns/tasks/main.yml
@@ -15,6 +15,17 @@
     that:
     - setup is success
 
+- name: test create Floating IP
+  hcloud_floating_ip:
+    name: "{{ hcloud_floating_ip_name }}"
+    type: ipv4
+    home_location: "fsn1"
+  register: floatingIP
+- name: verify test create Floating IP
+  assert:
+    that:
+      - floatingIP is success
+
 - name: test missing required parameter
   hcloud_rdns:
     state: present
@@ -24,20 +35,7 @@
   assert:
     that:
       - result is failed
-      - 'result.msg == "missing required arguments: ip_address, server" or result.msg == "missing required arguments: server, ip_address"'
-
-- name: test create rdns with checkmode
-  hcloud_rdns:
-    server: "{{ hcloud_server_name }}"
-    ip_address: "{{ setup.hcloud_server.ipv6 | ansible.netcommon.ipaddr('next_usable') }}"
-    dns_ptr: "example.com"
-    state: present
-  register: result
-  check_mode: yes
-- name: verify test create rdns with checkmode
-  assert:
-    that:
-    - result is changed
+      - 'result.msg == "missing required arguments: ip_address"'
 
 - name: test create rdns
   hcloud_rdns:
@@ -106,9 +104,34 @@
     - rdns.hcloud_rdns.ip_address == "{{ setup.hcloud_server.ipv4_address }}"
     - rdns.hcloud_rdns.dns_ptr != "example.com"
 
+- name: test create rdns with floating IP
+  hcloud_rdns:
+    floating_ip: "{{ hcloud_floating_ip_name }}"
+    ip_address: "{{ floatingIP.hcloud_floating_ip.ip}}"
+    dns_ptr: "example.com"
+    state: present
+  register: rdns
+- name: verify create rdns
+  assert:
+    that:
+    - rdns is changed
+    - rdns.hcloud_rdns.server == "{{ hcloud_floating_ip_name }}"
+    - rdns.hcloud_rdns.ip_address == "{{ floatingIP.hcloud_floating_ip.ip}}"
+    - rdns.hcloud_rdns.dns_ptr == "example.com"
+
 - name: cleanup
   hcloud_server:
-    name: "{{hcloud_server_name}}"
+    name: "{{ hcloud_server_name }}"
+    state: absent
+  register: result
+- name: verify cleanup
+  assert:
+    that:
+      - result is success
+
+- name: cleanup
+  hcloud_floating_ip:
+    name: "{{ hcloud_floating_ip_name }}"
     state: absent
   register: result
 - name: verify cleanup

--- a/tests/integration/targets/hcloud_rdns/tasks/main.yml
+++ b/tests/integration/targets/hcloud_rdns/tasks/main.yml
@@ -115,7 +115,7 @@
   assert:
     that:
     - rdns is changed
-    - rdns.hcloud_rdns.server == "{{ hcloud_floating_ip_name }}"
+    - rdns.hcloud_rdns.floating_ip == "{{ hcloud_floating_ip_name }}"
     - rdns.hcloud_rdns.ip_address == "{{ floatingIP.hcloud_floating_ip.ip}}"
     - rdns.hcloud_rdns.dns_ptr == "example.com"
 

--- a/tests/integration/targets/hcloud_rdns/tasks/main.yml
+++ b/tests/integration/targets/hcloud_rdns/tasks/main.yml
@@ -40,7 +40,7 @@
 - name: test create rdns
   hcloud_rdns:
     server: "{{ hcloud_server_name }}"
-    ip_address: "{{ setup.hcloud_server.ipv6 | ansible.netcommon.ipaddr('next_usable') }}"
+    ip_address: "{{ setup.hcloud_server.ipv4_address }}"
     dns_ptr: "example.com"
     state: present
   register: rdns
@@ -49,13 +49,13 @@
     that:
     - rdns is changed
     - rdns.hcloud_rdns.server == "{{ hcloud_server_name }}"
-    - rdns.hcloud_rdns.ip_address == "{{ setup.hcloud_server.ipv6 | ansible.netcommon.ipaddr('next_usable') }}"
+    - rdns.hcloud_rdns.ip_address == "{{ setup.hcloud_server.ipv4_address }}"
     - rdns.hcloud_rdns.dns_ptr == "example.com"
 
 - name: test create rdns idempotency
   hcloud_rdns:
     server: "{{ hcloud_server_name }}"
-    ip_address: "{{ setup.hcloud_server.ipv6 | ansible.netcommon.ipaddr('next_usable') }}"
+    ip_address: "{{ setup.hcloud_server.ipv4_address }}"
     dns_ptr: "example.com"
     state: present
   register: result
@@ -67,7 +67,7 @@
 - name: test absent rdns
   hcloud_rdns:
     server: "{{ hcloud_server_name }}"
-    ip_address: "{{ setup.hcloud_server.ipv6 | ansible.netcommon.ipaddr('next_usable') }}"
+    ip_address: "{{ setup.hcloud_server.ipv4_address }}"
     state: absent
   register: result
 - name: verify test absent rdns

--- a/tests/integration/targets/hcloud_rdns/tasks/main.yml
+++ b/tests/integration/targets/hcloud_rdns/tasks/main.yml
@@ -40,7 +40,7 @@
 - name: test create rdns
   hcloud_rdns:
     server: "{{ hcloud_server_name }}"
-    ip_address: "{{ setup.hcloud_server.ipv4_address }}"
+    ip_address: "{{ setup.hcloud_server.ipv6 | ansible.netcommon.ipaddr('next_usable') }}"
     dns_ptr: "example.com"
     state: present
   register: rdns
@@ -49,13 +49,13 @@
     that:
     - rdns is changed
     - rdns.hcloud_rdns.server == "{{ hcloud_server_name }}"
-    - rdns.hcloud_rdns.ip_address == "{{ setup.hcloud_server.ipv4_address }}"
+    - rdns.hcloud_rdns.ip_address == "{{ setup.hcloud_server.ipv6 | ansible.netcommon.ipaddr('next_usable') }}"
     - rdns.hcloud_rdns.dns_ptr == "example.com"
 
 - name: test create rdns idempotency
   hcloud_rdns:
     server: "{{ hcloud_server_name }}"
-    ip_address: "{{ setup.hcloud_server.ipv4_address }}"
+    ip_address: "{{ setup.hcloud_server.ipv6 | ansible.netcommon.ipaddr('next_usable') }}"
     dns_ptr: "example.com"
     state: present
   register: result
@@ -67,7 +67,7 @@
 - name: test absent rdns
   hcloud_rdns:
     server: "{{ hcloud_server_name }}"
-    ip_address: "{{ setup.hcloud_server.ipv4_address }}"
+    ip_address: "{{ setup.hcloud_server.ipv6 | ansible.netcommon.ipaddr('next_usable') }}"
     state: absent
   register: result
 - name: verify test absent rdns


### PR DESCRIPTION
Signed-off-by: Lukas Kämmerling <lukas.kaemmerling@hetzner-cloud.de>

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
hcloud_rdns
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
This came up with #25. We planned to have the Floating IPs within the `hcloud_rdns` module but just missed to add the functionality while implementing the `hcloud_floating_ip` modules
<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
