### PR TITLE
Allow updating hcloud_server_network (alias IPs)

### DIFF
--- a/tests/integration/targets/hcloud_server_network/tasks/main.yml
+++ b/tests/integration/targets/hcloud_server_network/tasks/main.yml
@@ -142,6 +142,41 @@
     - 'serverNetwork.hcloud_server_network.alias_ips[0] == "10.0.2.3"'
     - 'serverNetwork.hcloud_server_network.alias_ips[1] == "10.0.1.2"'
 
+- name: test update server network with alias ips
+  hcloud_server_network:
+    network: "{{ hcloud_network_name }}"
+    server: "{{hcloud_server_name}}"
+    ip: "10.0.0.2"
+    alias_ips:
+      - "10.0.2.3"
+      - "10.0.3.1"
+    state: present
+  register: serverNetwork
+- name: verify create server network with alias ips
+  assert:
+    that:
+    - serverNetwork is changed
+    - serverNetwork.hcloud_server_network.network == hcloud_network_name
+    - serverNetwork.hcloud_server_network.server == hcloud_server_name
+    - serverNetwork.hcloud_server_network.ip == "10.0.0.2"
+    - 'serverNetwork.hcloud_server_network.alias_ips[0] == "10.0.2.3"'
+    - 'serverNetwork.hcloud_server_network.alias_ips[1] == "10.0.3.1"'
+
+- name: test update server network with alias ips idempotency
+  hcloud_server_network:
+    network: "{{ hcloud_network_name }}"
+    server: "{{hcloud_server_name}}"
+    ip: "10.0.0.2"
+    alias_ips:
+      - "10.0.2.3"
+      - "10.0.3.1"
+    state: present
+  register: serverNetwork
+- name: verify create server network with alias ips idempotency
+  assert:
+    that:
+    - serverNetwork is not changed
+
 - name: cleanup create server network with alias ips
   hcloud_server_network:
     network: "{{ hcloud_network_name }}"


### PR DESCRIPTION
Signed-off-by: Lukas Kämmerling <lukas.kaemmerling@hetzner-cloud.de>

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
This MR allows updating hcloud_server_network. Only alias IPs are updateable, all the other values are not updateable without reattachment (deleting hcloud_server_network)
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Fixes #40 
##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
hcloud_server_network
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
