### PR TITLE
Restore Python 2.7 support

### DIFF
--- a/plugins/inventory/hcloud.py
+++ b/plugins/inventory/hcloud.py
@@ -237,12 +237,12 @@ class InventoryModule(BaseInventoryPlugin, Constructable):
     def verify_file(self, path):
         """Return the possibly of a file being consumable by this plugin."""
         return (
-            super().verify_file(path) and
+            super(InventoryModule, self).verify_file(path) and
             path.endswith(("hcloud.yaml", "hcloud.yml"))
         )
 
     def parse(self, inventory, loader, path, cache=True):
-        super().parse(inventory, loader, path, cache)
+        super(InventoryModule, self).parse(inventory, loader, path, cache)
         self._read_config_data(path)
         self._configure_hcloud_client()
         self._test_hcloud_token()


### PR DESCRIPTION
Signed-off-by: Lukas Kämmerling <lukas.kaemmerling@hetzner-cloud.de>

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Fixes #44. The support was unintentionally dropped because of a pylint warning within our own CI, that was fixed by using the same version as Ansible itself does.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
Dynamic Inventory
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
