### PR TITLE
Expand template instructions in 'token' property

### DIFF
--- a/plugins/inventory/hcloud.py
+++ b/plugins/inventory/hcloud.py
@@ -112,7 +112,7 @@ class InventoryModule(BaseInventoryPlugin, Constructable):
 
     def _configure_hcloud_client(self):
         self.token_env = self.get_option("token_env")
-        self.api_token = self.get_option("token") or os.getenv(self.token_env)
+        self.api_token = self.templar.template(self.get_option("token"), fail_on_undefined=False) or os.getenv(self.token_env)
         if self.api_token is None:
             raise AnsibleError(
                 "Please specify a token, via the option token, via environment variable HCLOUD_TOKEN "


### PR DESCRIPTION


##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

This change passes the `token` property through the jinja templating engine so that the token can for example be retrieved via a lookup plugin (password store, etc.). 

Fixes #48

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

hcloud inventory_plugin

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->

