### PR TITLE
Fix image NoneType exception in hcloud_network_info

### DIFF
--- a/plugins/modules/hcloud_network_info.py
+++ b/plugins/modules/hcloud_network_info.py
@@ -219,12 +219,13 @@ class AnsibleHcloudNetworkInfo(Hcloud):
 
                 servers = []
                 for server in network.servers:
+                    image = None if server.image is None else to_native(server.image.name)
                     prepared_server = {
                         "id": to_native(server.id),
                         "name": to_native(server.name),
                         "ipv4_address": to_native(server.public_net.ipv4.ip),
                         "ipv6": to_native(server.public_net.ipv6.ip),
-                        "image": to_native(server.image.name),
+                        "image": image,
                         "server_type": to_native(server.server_type.name),
                         "datacenter": to_native(server.datacenter.name),
                         "location": to_native(server.datacenter.location.name),


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
This was brought up by a customer via Ticket. When a server was created from a (now) deleted image, the image within the API is returned as "null/None". In all other modules we handled this correctly, only the hcloud_network_info module was missing.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
hcloud_network_info

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
