### PR TITLE
hcloud_server: fix traceback in check mode

### DIFF
--- a/changelogs/fragments/64-hcloud_server_fix_checkmode_state_started.yml
+++ b/changelogs/fragments/64-hcloud_server_fix_checkmode_state_started.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - hcloud_server - fix a crash related to check mode if ``state=started`` or ``state=stopped`` (https://github.com/ansible-collections/hetzner.hcloud/issues/54).

--- a/plugins/modules/hcloud_server.py
+++ b/plugins/modules/hcloud_server.py
@@ -500,21 +500,23 @@ class AnsibleHcloudServer(Hcloud):
 
     def start_server(self):
         try:
-            if self.hcloud_server.status != Server.STATUS_RUNNING:
-                if not self.module.check_mode:
-                    self.client.servers.power_on(self.hcloud_server).wait_until_finished()
-                self._mark_as_changed()
-            self._get_server()
+            if self.hcloud_server:
+                if self.hcloud_server.status != Server.STATUS_RUNNING:
+                    if not self.module.check_mode:
+                        self.client.servers.power_on(self.hcloud_server).wait_until_finished()
+                    self._mark_as_changed()
+                self._get_server()
         except Exception as e:
             self.module.fail_json(msg=e.message)
 
     def stop_server(self):
         try:
-            if self.hcloud_server.status != Server.STATUS_OFF:
-                if not self.module.check_mode:
-                    self.client.servers.power_off(self.hcloud_server).wait_until_finished()
-                self._mark_as_changed()
-            self._get_server()
+            if self.hcloud_server:
+                if self.hcloud_server.status != Server.STATUS_OFF:
+                    if not self.module.check_mode:
+                        self.client.servers.power_off(self.hcloud_server).wait_until_finished()
+                    self._mark_as_changed()
+                self._get_server()
         except Exception as e:
             self.module.fail_json(msg=e.message)
 


### PR DESCRIPTION
Closes #54 

```
An exception occurred during task execution. To see the full traceback, use -vvv. The error was: TypeError: Value of unknown type: <class 'AttributeError'>, 'NoneType' object has no attribute 'status'
fatal: [mon1.ngine.ch]: FAILED! => {"changed": false, "module_stderr": "Traceback (most recent call last):\n  File \"/tmp/ansible_hcloud_server_payload_uyrhr_4g/ansible_hcloud_server_payload.zip/ansible_collections/hetzner/hcloud/plugins/modules/hcloud_server.py\", line 503, in start_server\nAttributeError: 'NoneType' object has no attribute 'status'\n\nDuring handling of the above exception, another exception occurred:\n\nTraceback (most recent call last):\n  File \"<stdin>\", line 102, in <module>\n  File \"<stdin>\", line 94, in _ansiballz_main\n  File \"<stdin>\", line 40, in invoke_module\n  File \"/usr/lib/python3.8/runpy.py\", line 207, in run_module\n    return _run_module_code(code, init_globals, run_name, mod_spec)\n  File \"/usr/lib/python3.8/runpy.py\", line 97, in _run_module_code\n    _run_code(code, mod_globals, init_globals,\n  File \"/usr/lib/python3.8/runpy.py\", line 87, in _run_code\n    exec(code, run_globals)\n  File \"/tmp/ansible_hcloud_server_payload_uyrhr_4g/ansible_hcloud_server_payload.zip/ansible_collections/hetzner/hcloud/plugins/modules/hcloud_server.py\", line 615, in <module>\n  File \"/tmp/ansible_hcloud_server_payload_uyrhr_4g/ansible_hcloud_server_payload.zip/ansible_collections/hetzner/hcloud/plugins/modules/hcloud_server.py\", line 599, in main\n  File \"/tmp/ansible_hcloud_server_payload_uyrhr_4g/ansible_hcloud_server_payload.zip/ansible_collections/hetzner/hcloud/plugins/modules/hcloud_server.py\", line 509, in start_server\n  File \"/tmp/ansible_hcloud_server_payload_uyrhr_4g/ansible_hcloud_server_payload.zip/ansible/module_utils/basic.py\", line 2220, in fail_json\n  File \"/tmp/ansible_hcloud_server_payload_uyrhr_4g/ansible_hcloud_server_payload.zip/ansible/module_utils/basic.py\", line 2193, in _return_formatted\n  File \"/tmp/ansible_hcloud_server_payload_uyrhr_4g/ansible_hcloud_server_payload.zip/ansible/module_utils/basic.py\", line 420, in remove_values\n  File \"/tmp/ansible_hcloud_server_payload_uyrhr_4g/ansible_hcloud_server_payload.zip/ansible/module_utils/basic.py\", line 397, in _remove_values_conditions\nTypeError: Value of unknown type: <class 'AttributeError'>, 'NoneType' object has no attribute 'status'\n", "module_stdout": "", "msg": "MODULE FAILURE\nSee stdout/stderr for the exact error", "rc": 1}
```