### PR TITLE
[security] hcloud_certificate, hcloud_server: define no_log values for private_key and ssh_keys parameters

### DIFF
--- a/changelogs/fragments/70-no_log_security_fixes.yml
+++ b/changelogs/fragments/70-no_log_security_fixes.yml
@@ -1,0 +1,2 @@
+security_fixes:
+- hcloud_certificate - mark the ``private_key`` parameter as ``no_log`` to prevent potential leaking of secret values (https://github.com/ansible-collections/hetzner.hcloud/pull/70).

--- a/plugins/modules/hcloud_certificate.py
+++ b/plugins/modules/hcloud_certificate.py
@@ -232,7 +232,7 @@ class AnsibleHcloudCertificate(Hcloud):
                 id={"type": "int"},
                 name={"type": "str"},
                 certificate={"type": "str"},
-                private_key={"type": "str"},
+                private_key={"type": "str", "no_log": True},
                 labels={"type": "dict"},
                 state={
                     "choices": ["absent", "present"],

--- a/plugins/modules/hcloud_server.py
+++ b/plugins/modules/hcloud_server.py
@@ -563,7 +563,7 @@ class AnsibleHcloudServer(Hcloud):
                 location={"type": "str"},
                 datacenter={"type": "str"},
                 user_data={"type": "str"},
-                ssh_keys={"type": "list", "elements": "str"},
+                ssh_keys={"type": "list", "elements": "str", "no_log": False},
                 volumes={"type": "list", "elements": "str"},
                 firewalls={"type": "list", "elements": "str"},
                 labels={"type": "dict"},


### PR DESCRIPTION
##### SUMMARY
Fix sanity https://github.com/ansible-collections/hetzner.hcloud/pull/69

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request