### PR TITLE
hcloud_firewall, hcloud_server: fix idempotence

### DIFF
--- a/changelogs/fragments/71-hcloud_firewall_fix_idempotence.yml
+++ b/changelogs/fragments/71-hcloud_firewall_fix_idempotence.yml
@@ -1,0 +1,3 @@
+bugfixes:
+- hcloud_firewall - fix idempotence related to rules comparison (https://github.com/ansible-collections/hetzner.hcloud/pull/71).
+- hcloud_server - fix idempotence related to firewall handling (https://github.com/ansible-collections/hetzner.hcloud/pull/71).

--- a/plugins/modules/hcloud_firewall.py
+++ b/plugins/modules/hcloud_firewall.py
@@ -3,6 +3,7 @@
 
 # Copyright: (c) 2020, Hetzner Cloud GmbH <info@hetzner-cloud.de>
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+#
 
 from __future__ import absolute_import, division, print_function
 

--- a/plugins/modules/hcloud_firewall.py
+++ b/plugins/modules/hcloud_firewall.py
@@ -3,7 +3,6 @@
 
 # Copyright: (c) 2020, Hetzner Cloud GmbH <info@hetzner-cloud.de>
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
-#
 
 from __future__ import absolute_import, division, print_function
 
@@ -253,7 +252,7 @@ class AnsibleHcloudFirewall(Hcloud):
             self._mark_as_changed()
 
         rules = self.module.params.get("rules")
-        if rules is not None and self.hcloud_firewall.rules != rules:
+        if rules is not None and rules != [self._prepare_result_rule(rule) for rule in self.hcloud_firewall.rules]:
             if not self.module.check_mode:
                 new_rules = [
                     FirewallRule(
@@ -298,7 +297,7 @@ class AnsibleHcloudFirewall(Hcloud):
                         protocol={"type": "str", "choices": ["icmp", "udp", "tcp"]},
                         port={"type": "str"},
                         source_ips={"type": "list", "elements": "str"},
-                        destination_ips={"type": "list", "elements": "str"},
+                        destination_ips={"type": "list", "elements": "str", "default": []},
                     ),
                     required_together=[["direction", "protocol", "source_ips"]]
                 ),

--- a/plugins/modules/hcloud_server.py
+++ b/plugins/modules/hcloud_server.py
@@ -3,6 +3,7 @@
 
 # Copyright: (c) 2019, Hetzner Cloud GmbH <info@hetzner-cloud.de>
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+#
 
 from __future__ import absolute_import, division, print_function
 

--- a/tests/integration/targets/hcloud_firewall/tasks/main.yml
+++ b/tests/integration/targets/hcloud_firewall/tasks/main.yml
@@ -1,6 +1,11 @@
 # Copyright: (c) 2020, Hetzner Cloud GmbH <info@hetzner-cloud.de>
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 ---
+- name: setup firewall to be absent
+  hcloud_firewall:
+    name: "{{ hcloud_firewall_name }}"
+    state: absent
+
 - name: test missing required parameters on create firewall
   hcloud_firewall:
   register: result
@@ -46,6 +51,12 @@
 - name: test create firewall idempotence
   hcloud_firewall:
     name: "{{ hcloud_firewall_name }}"
+    rules:
+      - direction: in
+        protocol: icmp
+        source_ips:
+          - 0.0.0.0/0
+          - ::/0
     labels:
       key: value
       my-label: label
@@ -88,6 +99,18 @@
 - name: test update firewall rules idempotence
   hcloud_firewall:
     name: "{{ hcloud_firewall_name }}"
+    rules:
+      - direction: in
+        protocol: icmp
+        source_ips:
+          - 0.0.0.0/0
+          - ::/0
+      - direction: in
+        protocol: tcp
+        port: 80
+        source_ips:
+          - 0.0.0.0/0
+          - ::/0
     labels:
       key: value
       my-label: label
@@ -96,7 +119,6 @@
   assert:
     that:
       - result is not changed
-
 
 - name: test update firewall with check mode
   hcloud_firewall:

--- a/tests/integration/targets/hcloud_server/tasks/main.yml
+++ b/tests/integration/targets/hcloud_server/tasks/main.yml
@@ -609,7 +609,6 @@
       - result_after_test.hcloud_server.delete_protection is sameas true
       - result_after_test.hcloud_server.rebuild_protection is sameas true
 
-
 - name: test delete server fails if it is protected
   hcloud_server:
     name: "{{hcloud_server_name}}"
@@ -647,35 +646,18 @@
     that:
     - result is success
 
-- name: test create firewall
+- name: setup create firewalls
   hcloud_firewall:
-    name: "{{ hcloud_firewall_name }}"
+    name: "{{ item }}"
     rules:
       - direction: in
         protocol: icmp
         source_ips:
           - 0.0.0.0/0
           - ::/0
-  register: firewall
-- name: verify create firewall
-  assert:
-    that:
-      - firewall is changed
-
-- name: test create firewall
-  hcloud_firewall:
-    name: "{{ hcloud_firewall_name }}2"
-    rules:
-      - direction: in
-        protocol: icmp
-        source_ips:
-          - 0.0.0.0/0
-          - ::/0
-  register: firewall2
-- name: verify create firewall
-  assert:
-    that:
-      - firewall2 is changed
+  with_items:
+    - "{{ hcloud_firewall_name }}"
+    - "{{ hcloud_firewall_name }}2"
 
 - name: test create server with firewalls
   hcloud_server:
@@ -688,10 +670,26 @@
       - ci@ansible.hetzner.cloud
     state: present
   register: result
-- name: verify enable backups
+- name: verify test create server with firewalls
   assert:
     that:
       - result is changed
+
+- name: test create server with firewalls idempotence
+  hcloud_server:
+    name: "{{ hcloud_server_name }}"
+    server_type: cpx11
+    firewalls:
+      - "{{ hcloud_firewall_name }}"
+    image: "ubuntu-20.04"
+    ssh_keys:
+      - ci@ansible.hetzner.cloud
+    state: present
+  register: result
+- name: verify test create server with firewalls idempotence
+  assert:
+    that:
+      - result is not changed
 
 - name: test update server with firewalls
   hcloud_server:
@@ -704,27 +702,36 @@
       - ci@ansible.hetzner.cloud
     state: present
   register: result
-- name: verify enable backups
+- name: verify test update server with firewalls
   assert:
     that:
       - result is changed
 
-- name: cleanup test create firewall
-  hcloud_firewall:
-    name: "{{ hcloud_firewall_name }}"
-    state: absent
+- name: test update server with firewalls idempotence
+  hcloud_server:
+    name: "{{ hcloud_server_name }}"
+    server_type: cpx11
+    firewalls:
+      - "{{ hcloud_firewall_name }}2"
+    image: "ubuntu-20.04"
+    ssh_keys:
+      - ci@ansible.hetzner.cloud
+    state: present
   register: result
-- name: verify create firewall
+- name: verify test update server with firewalls idempotence
   assert:
     that:
-      - result is changed
+      - result is not changed
 
-- name: cleanup test create server with firewalls
+- name: cleanup server with firewalls
   hcloud_server:
     name: "{{ hcloud_server_name }}"
     state: absent
-  register: result
-- name: verify cleanup
-  assert:
-    that:
-    - result is success
+
+- name: cleanup test create firewall
+  hcloud_firewall:
+    name: "{{ item }}"
+    state: absent
+  with_items:
+    - "{{ hcloud_firewall_name }}"
+    - "{{ hcloud_firewall_name }}2"


### PR DESCRIPTION
##### SUMMARY
hcloud_firewall:
Fix idempotence for firewall rules, fixes always returned changed. 

IMHO there were 2 issues:
1. desitnation_ip was None if unset and API returns List of strings.
2. comparsion of rules was comparing list of objects between list of dicts which is never equal

hcloud_server:
the firewall handling in server did also return changed. I refactored a bit to make the fix.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
hcloud_firewall
hcloud_server

##### ADDITIONAL INFORMATION
```paste below

```
