### PR TITLE
hcloud_server Improve error handling when using not existing server types

### DIFF
--- a/changelogs/fragments/hcloud-server-server-type.yaml
+++ b/changelogs/fragments/hcloud-server-server-type.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - hcloud_server Improve error handling when using not existing server types

--- a/tests/integration/targets/hcloud_server/tasks/main.yml
+++ b/tests/integration/targets/hcloud_server/tasks/main.yml
@@ -20,6 +20,21 @@
     that:
       - result is failed
       - 'result.msg == "missing required arguments: server_type, image"'
+
+- name: test create server with not existing server type
+  hcloud_server:
+    name: "{{ hcloud_server_name }}"
+    server_type: not-existing-server-type
+    image: ubuntu-20.04
+    state: present
+  register: result
+  ignore_errors: yes
+- name: verify fail test create server with not existing server type
+  assert:
+    that:
+      - result is failed
+      - 'result.msg == "server_type not-existing-server-type was not found"'
+
 - name: test create server with not existing image
   hcloud_server:
     name: "{{ hcloud_server_name }}"


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Improves the error handling when an unknown server type is given. Before the module crashed when passing the data to the create/resize calls.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
hcloud_server
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
