### PR TITLE
hcloud_volume: Force detaching volume on deletion

### DIFF
--- a/changelogs/fragments/hcloud_volume-force-detach-before-deletion.yml
+++ b/changelogs/fragments/hcloud_volume-force-detach-before-deletion.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - hcloud_volume Force detaching of volumes on servers before deletion

--- a/plugins/modules/hcloud_volume.py
+++ b/plugins/modules/hcloud_volume.py
@@ -294,6 +294,8 @@ class AnsibleHcloudVolume(Hcloud):
             self._get_volume()
             if self.hcloud_volume is not None:
                 if not self.module.check_mode:
+                    if self.hcloud_volume.server is not None:
+                        self.hcloud_volume.detach().wait_until_finished()
                     self.client.volumes.delete(self.hcloud_volume)
                 self._mark_as_changed()
             self.hcloud_volume = None


### PR DESCRIPTION
Force detaching of volumes before deleting when they are still attached to a server. This makes it easier for tools like molecule to see the correct state.

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Fixes #47 

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
