### PR TITLE
hcloud_server: Change backups default to None

### DIFF
--- a/changelogs/fragments/hcloud_server_default-backups-to-none.yml
+++ b/changelogs/fragments/hcloud_server_default-backups-to-none.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - hcloud_server backups property defaults to None now instead of False

--- a/plugins/modules/hcloud_server.py
+++ b/plugins/modules/hcloud_server.py
@@ -73,7 +73,6 @@ options:
         description:
             - Enable or disable Backups for the given Server.
         type: bool
-        default: no
     upgrade_disk:
         description:
             - Resize the disk size, when resizing a server.
@@ -605,7 +604,7 @@ class AnsibleHcloudServer(Hcloud):
                 volumes={"type": "list", "elements": "str"},
                 firewalls={"type": "list", "elements": "str"},
                 labels={"type": "dict"},
-                backups={"type": "bool", "default": False},
+                backups={"type": "bool"},
                 upgrade_disk={"type": "bool", "default": False},
                 force_upgrade={"type": "bool", "default": False},
                 allow_deprecated_image={"type": "bool", "default": False},


### PR DESCRIPTION
When the default is set to false, it always disables the backups when a user do not specify the backups to True always. This shouldn't be the case.

Signed-off-by: Lukas Kämmerling <lukas.kaemmerling@hetzner-cloud.de>

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Fixes #https://github.com/ansible-collections/hetzner.hcloud/issues/87
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
- Docs Pull Request
- Feature Pull Request
- New Module Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
