### PR TITLE
hcloud_rdns improve error message on not existing server/Floating IP

### DIFF
--- a/changelogs/fragments/hcloud_rdns-improve-validation-of-input.yml
+++ b/changelogs/fragments/hcloud_rdns-improve-validation-of-input.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - hcloud_rdns improve error message on not existing server/Floating IP

--- a/plugins/modules/hcloud_rdns.py
+++ b/plugins/modules/hcloud_rdns.py
@@ -143,10 +143,14 @@ class AnsibleHcloudReverseDNS(Hcloud):
                 self.hcloud_resource = self.client.servers.get_by_name(
                     self.module.params.get("server")
                 )
+                if self.hcloud_resource is None:
+                    self.module.fail_json(msg="The selected server does not exist")
             elif self.module.params.get("floating_ip"):
                 self.hcloud_resource = self.client.floating_ips.get_by_name(
                     self.module.params.get("floating_ip")
                 )
+                if self.hcloud_resource is None:
+                    self.module.fail_json(msg="The selected Floating IP does not exist")
         except Exception as e:
             self.module.fail_json(msg=e.message)
 

--- a/tests/integration/targets/hcloud_rdns/tasks/main.yml
+++ b/tests/integration/targets/hcloud_rdns/tasks/main.yml
@@ -36,7 +36,18 @@
     that:
       - result is failed
       - 'result.msg == "missing required arguments: ip_address"'
-
+- name: test fail on not existing resource
+  hcloud_rdns:
+    server: "not-existing"
+    ip_address: "127.0.0.1"
+    state: present
+  register: result
+  ignore_errors: yes
+- name: verify fail on not existing resou
+  assert:
+    that:
+      - result is failed
+      - 'result.msg == "The selected server does not exist"'
 - name: test create rdns
   hcloud_rdns:
     server: "{{ hcloud_server_name }}"


### PR DESCRIPTION
This came up in #98. When specifying a resource that does not exist we currently fail in an ugly way (NoneType Exception). This shouldn't be the case.

Signed-off-by: Lukas Kämmerling <lukas.kaemmerling@hetzner-cloud.de>

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Fixes #98 
##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
hcloud_rdns
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
