### PR TITLE
loadbalancer_: improve error handlings

### DIFF
--- a/plugins/modules/hcloud_load_balancer_network.py
+++ b/plugins/modules/hcloud_load_balancer_network.py
@@ -122,8 +122,18 @@ class AnsibleHcloudLoadBalancerNetwork(Hcloud):
 
     def _get_load_balancer_and_network(self):
         try:
-            self.hcloud_network = self.client.networks.get_by_name(self.module.params.get("network"))
-            self.hcloud_load_balancer = self.client.load_balancers.get_by_name(self.module.params.get("load_balancer"))
+            network = self.module.params.get("network")
+            self.hcloud_network = self.client.networks.get_by_name(network)
+            if not self.hcloud_network:
+                self.module.fail_json(msg="Network does not exist: %s" % network)
+
+            load_balancer_name = self.module.params.get("load_balancer")
+            self.hcloud_load_balancer = self.client.load_balancers.get_by_name(
+                load_balancer_name
+            )
+            if not self.hcloud_load_balancer:
+                self.module.fail_json(msg="Load balancer does not exist: %s" % load_balancer_name)
+
             self.hcloud_load_balancer_network = None
         except Exception as e:
             self.module.fail_json(msg=e.message)

--- a/plugins/modules/hcloud_load_balancer_service.py
+++ b/plugins/modules/hcloud_load_balancer_service.py
@@ -340,9 +340,13 @@ class AnsibleHcloudLoadBalancerService(Hcloud):
 
     def _get_load_balancer(self):
         try:
+            load_balancer_name = self.module.params.get("load_balancer")
             self.hcloud_load_balancer = self.client.load_balancers.get_by_name(
-                self.module.params.get("load_balancer")
+                load_balancer_name
             )
+            if not self.hcloud_load_balancer:
+                self.module.fail_json(msg="Load balancer does not exist: %s" % load_balancer_name)
+
             self._get_load_balancer_service()
         except Exception as e:
             self.module.fail_json(msg=e.message)

--- a/plugins/modules/hcloud_load_balancer_target.py
+++ b/plugins/modules/hcloud_load_balancer_target.py
@@ -177,9 +177,19 @@ class AnsibleHcloudLoadBalancerTarget(Hcloud):
 
     def _get_load_balancer_and_target(self):
         try:
-            self.hcloud_load_balancer = self.client.load_balancers.get_by_name(self.module.params.get("load_balancer"))
+            load_balancer_name = self.module.params.get("load_balancer")
+            self.hcloud_load_balancer = self.client.load_balancers.get_by_name(
+                load_balancer_name
+            )
+            if not self.hcloud_load_balancer:
+                self.module.fail_json(msg="Load balancer does not exist: %s" % load_balancer_name)
+
             if self.module.params.get("type") == "server":
-                self.hcloud_server = self.client.servers.get_by_name(self.module.params.get("server"))
+                server_name = self.module.params.get("server")
+                self.hcloud_server = self.client.servers.get_by_name(server_name)
+                if not self.hcloud_server:
+                    self.module.fail_json(msg="Server not found: %s" % server_name)
+
             self.hcloud_load_balancer_target = None
         except Exception as e:
             self.module.fail_json(msg=e.message)

--- a/tests/integration/targets/hcloud_load_balancer_network/tasks/main.yml
+++ b/tests/integration/targets/hcloud_load_balancer_network/tasks/main.yml
@@ -48,6 +48,32 @@
       - result is failed
       - 'result.msg == "missing required arguments: load_balancer, network"'
 
+- name: test fail load balancer does not exist
+  hetzner.hcloud.hcloud_load_balancer_network:
+    network: "{{ hcloud_network_name }}"
+    load_balancer: does-not-exist
+    state: present
+  register: result
+  ignore_errors: true
+- name: verify test fail load_balancer does not exist
+  assert:
+    that:
+      - result is failed
+      - "result.msg == 'Load balancer does not exist: does-not-exist'"
+
+- name: test fail network does not exist
+  hetzner.hcloud.hcloud_load_balancer_network:
+    network: does-not-exist
+    load_balancer: "{{ hcloud_load_balancer_name }}"
+    state: present
+  register: result
+  ignore_errors: true
+- name: verify test fail network does not exist
+  assert:
+    that:
+      - result is failed
+      - "result.msg == 'Network does not exist: does-not-exist'"
+
 - name: test create load_balancer network with checkmode
   hcloud_load_balancer_network:
     network: "{{ hcloud_network_name }}"

--- a/tests/integration/targets/hcloud_load_balancer_network/tasks/main.yml
+++ b/tests/integration/targets/hcloud_load_balancer_network/tasks/main.yml
@@ -46,7 +46,7 @@
   assert:
     that:
       - result is failed
-      - 'result.msg == "missing required arguments: load_balancer, network"'
+      - '"missing required arguments:" in result.msg'
 
 - name: test fail load balancer does not exist
   hetzner.hcloud.hcloud_load_balancer_network:

--- a/tests/integration/targets/hcloud_load_balancer_service/tasks/main.yml
+++ b/tests/integration/targets/hcloud_load_balancer_service/tasks/main.yml
@@ -13,6 +13,20 @@
     that:
       - load_balancer is success
 
+- name: test fail load balancer does not exist
+  hetzner.hcloud.hcloud_load_balancer_service:
+    load_balancer: does-not-exist
+    protocol: http
+    listen_port: 80
+    state: present
+  register: result
+  ignore_errors: true
+- name: verify test fail load_balancer does not exist
+  assert:
+    that:
+      - result is failed
+      - "result.msg == 'Load balancer does not exist: does-not-exist'"
+
 - name: test create load_balancer service with checkmode
   hcloud_load_balancer_service:
     load_balancer: "{{hcloud_load_balancer_name}}"

--- a/tests/integration/targets/hcloud_load_balancer_target/tasks/main.yml
+++ b/tests/integration/targets/hcloud_load_balancer_target/tasks/main.yml
@@ -139,10 +139,9 @@
     name: "{{ hcloud_load_balancer_name }}"
     state: absent
   register: result
-- name: verify cleanup load_balancer
-  assert:
-    that:
-    - result is success
+  until: result is not failed
+  retries: 5
+  delay: 2
 
 - name: cleanup
   hcloud_server:

--- a/tests/integration/targets/hcloud_load_balancer_target/tasks/main.yml
+++ b/tests/integration/targets/hcloud_load_balancer_target/tasks/main.yml
@@ -26,6 +26,32 @@
     that:
       - load_balancer is success
 
+- name: test fail load balancer does not exist
+  hetzner.hcloud.hcloud_load_balancer_target:
+    type: server
+    load_balancer: does-not-exist
+    server: "{{ hcloud_server_name }}"
+  register: result
+  ignore_errors: true
+- name: verify test fail load_balancer does not exist
+  assert:
+    that:
+      - result is failed
+      - "result.msg == 'Load balancer does not exist: does-not-exist'"
+
+- name: test fail server does not exist
+  hetzner.hcloud.hcloud_load_balancer_target:
+    type: server
+    load_balancer: "{{ hcloud_load_balancer_name }}"
+    server: does-not-exist
+  register: result
+  ignore_errors: true
+- name: verify test fail server does not exist
+  assert:
+    that:
+      - result is failed
+      - "result.msg == 'Server not found: does-not-exist'"
+
 - name: test create load_balancer target with checkmode
   hcloud_load_balancer_target:
     type: "server"


### PR DESCRIPTION
##### SUMMARY

Traceback if loadbalancer does not exist:

```
failed: [xyz -> localhost] (item={'protocol': 'http', 'port': 80}) => {"ansible_loop_var": "service", "changed": false, "module_stderr": "Traceback (most recent call last):\n  File \"/tmp/ansible_hetzner.hcloud.hcloud_load_balancer_service_payload_fi4sysuo/ansible_hetzner.hcloud.hcloud_load_balancer_service_payload.zip/ansible_collections/hetzner/hcloud/plugins/modules/hcloud_load_balancer_service.py\", line 346, in _get_load_balancer\n  File \"/tmp/ansible_hetzner.hcloud.hcloud_load_balancer_service_payload_fi4sysuo/ansible_hetzner.hcloud.hcloud_load_balancer_service_payload.zip/ansible_collections/hetzner/hcloud/plugins/modules/hcloud_load_balancer_service.py\", line 486, in _get_load_balancer_service\nAttributeError: 'NoneType' object has no attribute 'services'\
```
##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
