### PR TITLE
hcloud_server_info: Add missing support for flexible networks

### DIFF
--- a/changelogs/fragments/flexible-networks-hcloud-server-info.yml
+++ b/changelogs/fragments/flexible-networks-hcloud-server-info.yml
@@ -1,0 +1,3 @@
+bugfixes:
+  - hcloud_server_info - fix crash when having servers without IPs (flexible networks)
+  - hcloud_server - When state stopped and server is created, do not start the server

--- a/plugins/modules/hcloud_server.py
+++ b/plugins/modules/hcloud_server.py
@@ -433,6 +433,8 @@ class AnsibleHcloudServer(Hcloud):
                 self.module.params.get("datacenter")
             )
 
+        if self.module.params.get("state") == "stopped":
+            params["start_after_create"] = False
         if not self.module.check_mode:
             try:
                 resp = self.client.servers.create(**params)

--- a/plugins/modules/hcloud_server_info.py
+++ b/plugins/modules/hcloud_server_info.py
@@ -153,11 +153,13 @@ class AnsibleHcloudServerInfo(Hcloud):
             if server is not None:
                 image = None if server.image is None else to_native(server.image.name)
                 placement_group = None if server.placement_group is None else to_native(server.placement_group.name)
+                ipv4_address = None if server.public_net.ipv4 is None else to_native(server.public_net.ipv4.ip)
+                ipv6 = None if server.public_net.ipv6 is None else to_native(server.public_net.ipv6.ip)
                 tmp.append({
                     "id": to_native(server.id),
                     "name": to_native(server.name),
-                    "ipv4_address": to_native(server.public_net.ipv4.ip),
-                    "ipv6": to_native(server.public_net.ipv6.ip),
+                    "ipv4_address": ipv4_address,
+                    "ipv6": ipv6,
                     "image": image,
                     "server_type": to_native(server.server_type.name),
                     "datacenter": to_native(server.datacenter.name),

--- a/tests/integration/targets/hcloud_server_info/tasks/main.yml
+++ b/tests/integration/targets/hcloud_server_info/tasks/main.yml
@@ -11,7 +11,7 @@
   hcloud_server:
     name: "{{ hcloud_server_name }}"
     server_type: cx11
-    image: ubuntu-18.04
+    image: ubuntu-22.04
     state: started
     labels:
       key: value
@@ -28,69 +28,100 @@
 
 - name: test gather hcloud server infos in check mode
   hcloud_server_info:
-  register: hcloud_server
+  register: server
   check_mode: yes
 
 - name: verify test gather hcloud server infos in check mode
   assert:
     that:
-      - hcloud_server.hcloud_server_info|selectattr('name','equalto','{{ hcloud_server_name }}') | list | count == 1
+      - server.hcloud_server_info|selectattr('name','equalto','{{ hcloud_server_name }}') | list | count == 1
 
 
 - name: test gather hcloud server infos with correct label selector
   hcloud_server_info:
     label_selector: "key=value"
-  register: hcloud_server
+  register: server
 - name: verify test gather hcloud server infos with correct label selector
   assert:
     that:
-      - hcloud_server.hcloud_server_info|selectattr('name','equalto','{{ hcloud_server_name }}') | list | count == 1
+      - server.hcloud_server_info|selectattr('name','equalto','{{ hcloud_server_name }}') | list | count == 1
 
 - name: test gather hcloud server infos with wrong label selector
   hcloud_server_info:
     label_selector: "key!=value"
-  register: hcloud_server
+  register: server
 - name: verify test gather hcloud server infos with wrong label selector
   assert:
     that:
-      - hcloud_server.hcloud_server_info | list | count == 0
+      - server.hcloud_server_info | list | count == 0
 
 - name: test gather hcloud server infos with correct name
   hcloud_server_info:
     name: "{{hcloud_server_name}}"
-  register: hcloud_server
+  register: server
 - name: verify test gather hcloud server infos with correct name
   assert:
     that:
-      - hcloud_server.hcloud_server_info|selectattr('name','equalto','{{ hcloud_server_name }}') | list | count == 1
+      - server.hcloud_server_info|selectattr('name','equalto','{{ hcloud_server_name }}') | list | count == 1
 
 - name: test gather hcloud server infos with wrong name
   hcloud_server_info:
       name: "{{hcloud_server_name}}1"
-  register: hcloud_server
+  register: server
 - name: verify test gather hcloud server infos with wrong name
   assert:
     that:
-      - hcloud_server.hcloud_server_info | list | count == 0
+      - server.hcloud_server_info | list | count == 0
 
 - name: test gather hcloud server infos with correct id
   hcloud_server_info:
     id: "{{main_server.hcloud_server.id}}"
-  register: hcloud_server
+  register: server
 - name: verify test gather hcloud server infos with correct id
   assert:
     that:
-      - hcloud_server.hcloud_server_info|selectattr('name','equalto','{{ hcloud_server_name }}') | list | count == 1
+      - server.hcloud_server_info|selectattr('name','equalto','{{ hcloud_server_name }}') | list | count == 1
 
 - name: test gather hcloud server infos with wrong id
   hcloud_server_info:
       name: "4711"
-  register: hcloud_server
+  register: server
 - name: verify test gather hcloud server infos with wrong id
   assert:
     that:
-      - hcloud_server.hcloud_server_info | list | count == 0
+      - server.hcloud_server_info | list | count == 0
 
+- name: cleanup
+  hcloud_server:
+    name: "{{ hcloud_server_name }}"
+    state: absent
+
+- name: create server without ips
+  hcloud_server:
+    name: "{{ hcloud_server_name }}"
+    server_type: cx11
+    image: ubuntu-22.04
+    state: stopped
+    labels:
+      key: value
+    enable_ipv4: no
+    enable_ipv6: no
+  register: main_server
+- name: verify create server
+  assert:
+    that:
+      - main_server is changed
+      - main_server.hcloud_server.name == "{{ hcloud_server_name }}"
+      - main_server.hcloud_server.server_type == "cx11"
+      - main_server.root_password != ""
+- name: test gather hcloud server infos with correct id
+  hcloud_server_info:
+    id: "{{main_server.hcloud_server.id}}"
+  register: server
+- name: verify test gather hcloud server infos with correct id
+  assert:
+    that:
+      - server.hcloud_server_info|selectattr('name','equalto','{{ hcloud_server_name }}') | list | count == 1
 - name: cleanup
   hcloud_server:
     name: "{{ hcloud_server_name }}"


### PR DESCRIPTION
  - hcloud_server_info - fix crash when having servers without IPs (flexible networks)
  - hcloud_server - When state stopped and server is created, do not start the server

Signed-off-by: Lukas Kämmerling <lukas.kaemmerling@hetzner-cloud.de>

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Fixes #142 This was overseen while developing the changes for flexible networks

Additionally, it fixes a smaller bug in the hcloud_server module that might cause confusion again with the flexible networks options (The API returns an error when you try to create a server without any connectivity without `start_after_create=False`, this case is now covered when using `state=stopped`).
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
