### PR TITLE
Added new command hcloud_isos_info.py to get informations from all IS…

### DIFF
--- a/plugins/modules/hcloud_isos_info.py
+++ b/plugins/modules/hcloud_isos_info.py
@@ -1,0 +1,151 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2022, Patrice Le Guyader
+# heavily inspired by the work of @LKaemmerling
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+DOCUMENTATION = '''
+---
+module: hcloud_isos_info
+
+short_description: Gather infos about the Hetzner Cloud isos list.
+
+
+description:
+    - Gather infos about the Hetzner Cloud isos list.
+
+author:
+    - Patrice Le Guyader (@patlegu)
+    - Lukas Kaemmerling (@LKaemmerling)
+
+options:
+    id:
+        description:
+            - The ID of the iso image you want to get.
+        type: int
+    name:
+        description:
+            - The description of the iso you want to get.
+        type: str
+extends_documentation_fragment:
+- hetzner.hcloud.hcloud
+
+'''
+
+EXAMPLES = """
+- name: Gather hcloud isos type infos
+  hcloud_isos_info:
+  register: output
+
+- name: Print the gathered infos
+  debug:
+    var: output.hcloud_isos_info
+"""
+
+RETURN = """
+hcloud_isos_info:
+    description: The isos type infos as list
+    returned: always
+    type: complex
+    contains:
+        id:
+            description: ID of the ISO
+            returned: always
+            type: int
+            sample: 1937415
+        name:
+            description: Unique identifier of the ISO. Only set for public ISOs
+            returned: always
+            type: str
+            sample: fsn1
+        description:
+            description: DDescription of the ISO
+            returned: always
+            type: str
+            sample: Falkenstein DC Park 1
+        type:
+            description: Type of the ISO. Choices: `public`, `private`
+            returned: always
+            type: str
+            sample: 1
+        deprecated:
+            description: ISO 8601 timestamp of deprecation, None if ISO is still available. After the deprecation time it will no longer be possible to attach the ISO to servers.
+            returned: always
+            type: datetime, None
+            sample: 1
+"""
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils._text import to_native
+from ansible_collections.hetzner.hcloud.plugins.module_utils.hcloud import Hcloud
+
+try:
+    from hcloud import APIException
+except ImportError:
+    APIException = None
+
+
+class AnsibleHcloudIsosInfo(Hcloud):
+    def __init__(self, module):
+        Hcloud.__init__(self, module, "hcloud_isos_info")
+        self.hcloud_isos_info = None
+
+    def _prepare_result(self):
+        tmp = []
+
+        for iso_info in self.hcloud_isos_info:
+            if iso_info is not None:
+                tmp.append({
+                    "id": to_native(iso_info.id),
+                    "name": to_native(iso_info.name),
+                    "description": to_native(iso_info.description),
+                    "type": iso_info.type,
+                    "deprecated": iso_info.deprecated
+                })
+        return tmp
+
+    def get_isos_infos(self):
+        try:
+            if self.module.params.get("id") is not None:
+                self.hcloud_isos_info = [self.client.isos.get_by_id(
+                    self.module.params.get("id")
+                )]
+            elif self.module.params.get("name") is not None:
+                self.hcloud_isos_info = [self.client.isos.get_by_name(
+                    self.module.params.get("name")
+                )]
+            else:
+                self.hcloud_isos_info = self.client.isos.get_all()
+
+        except Exception as e:
+            self.module.fail_json(msg=e.message)
+
+    @staticmethod
+    def define_module():
+        return AnsibleModule(
+            argument_spec=dict(
+                id={"type": "int"},
+                name={"type": "str"},
+                **Hcloud.base_module_arguments()
+            ),
+            supports_check_mode=True,
+        )
+
+
+def main():
+    module = AnsibleHcloudIsosInfo.define_module()
+    hcloud = AnsibleHcloudIsosInfo(module)
+    hcloud.get_isos_infos()
+    result = hcloud.get_result()
+    ansible_info = {
+        'hcloud_isos_info': result['hcloud_isos_info']
+    }
+    module.exit_json(**ansible_info)
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
…Os on HETZNER cloud.

##### SUMMARY
New module to query the ISOs files instead of the images files created.

##### ISSUE TYPE
- New Module Pull Request

##### COMPONENT NAME
hcloud_isos_info.py

##### ADDITIONAL INFORMATION
### Some ansible code and result :
`
---
- name: Gathering Ubuntu images dictionaries
  ansible.builtin.set_fact:
    no_log: false
    ubuntu_isos_list: "{{ ubuntu_isos_list | default([]) + [{'id': item.id, 'name': item.name, 'description': item.description }] }}"
  loop:
    "{{ hcloud_isos_info.hcloud_isos_info | select('match','.+description.+:.+Ubuntu.+')|list }}"

- name: Debugging Ubuntu images list
  ansible.builtin.debug:
    msg:
      - '--------------------'
      - "{{ ubuntu_isos_list }}"
      - '--------------------'
  when: ansible_debug

`
### the result of the query:
`
TASK [Gathering Ubuntu images dictionaries] ***************************************************************************************************************************************************************************************************************************
Sunday 24 July 2022  07:47:42 +0000 (0:00:00.078)       0:00:07.108 ***********
included: /hetzner_servers_ansible/tasks/subtasks/hcloud_ubuntu_isos_infos.yml for localhost

TASK [Gathering Ubuntu images dictionaries] ***************************************************************************************************************************************************************************************************************************
Sunday 24 July 2022  07:47:42 +0000 (0:00:00.077)       0:00:07.185 ***********
ok: [localhost] => (item={'id': '3483', 'name': 'ubuntu-18.04.4-server-amd64.iso', 'description': 'Ubuntu 18.04.4 (amd64)', 'type': 'public', 'deprecated': None})
ok: [localhost] => (item={'id': '11955', 'name': 'ubuntu-20.04.4-live-server-amd64.iso', 'description': 'Ubuntu 20.04.4 Live Server (amd64)', 'type': 'public', 'deprecated': None})
ok: [localhost] => (item={'id': '13195', 'name': 'ubuntu-22.04-live-server-amd64.iso', 'description': 'Ubuntu 22.04 Live Server (amd64)', 'type': 'public', 'deprecated': None})

TASK [Debugging Ubuntu images list] ***********************************************************************************************************************************************************************************************************************************
Sunday 24 July 2022  07:47:42 +0000 (0:00:00.091)       0:00:07.277 ***********
ok: [localhost] => {
    "changed": false,
    "msg": [
        "--------------------",
        [
            {
                "description": "Ubuntu 18.04.4 (amd64)",
                "id": "3483",
                "name": "ubuntu-18.04.4-server-amd64.iso"
            },
            {
                "description": "Ubuntu 20.04.4 Live Server (amd64)",
                "id": "11955",
                "name": "ubuntu-20.04.4-live-server-amd64.iso"
            },
            {
                "description": "Ubuntu 22.04 Live Server (amd64)",
                "id": "13195",
                "name": "ubuntu-22.04-live-server-amd64.iso"
            }
        ],
        "--------------------"
    ]
}

`
```
