### PR TITLE
Inventory plugin: Allow token to be provided through extra-vars.

### DIFF
--- a/plugins/inventory/hcloud.py
+++ b/plugins/inventory/hcloud.py
@@ -86,6 +86,10 @@ EXAMPLES = r"""
 # Minimal example. `HCLOUD_TOKEN` is exposed in environment.
 plugin: hcloud
 
+# Example with templated token, e.g. provided through extra vars.
+plugin: hcloud
+token: "{{ hetzner_apitoken }}"
+
 # Example with locations, types, status and token
 plugin: hcloud
 token: foobar
@@ -129,6 +133,7 @@ class InventoryModule(BaseInventoryPlugin, Constructable):
 
     def _configure_hcloud_client(self):
         self.token_env = self.get_option("token_env")
+        self.templar.available_variables = self._vars
         self.api_token = self.templar.template(self.get_option("token"), fail_on_undefined=False) or os.getenv(self.token_env)
         if self.api_token is None:
             raise AnsibleError(


### PR DESCRIPTION
##### SUMMARY
Allow token to be provided through extra-vars.
Allows "dynamic" insertion of the token without changing the environment variables

Fixes #181 

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
hetzner.hcloud.hcloud

##### ADDITIONAL INFORMATION
Only thing I am not perfectly sure about is, if one can safely use `self._compose` and `self._compose` in a custom plugin.