### PR TITLE
Fix hcloud_network_info failing with Servers without internet connectivity

### DIFF
--- a/plugins/modules/hcloud_network_info.py
+++ b/plugins/modules/hcloud_network_info.py
@@ -136,12 +136,12 @@ hcloud_network_info:
                     type: str
                     sample: cx11
                 ipv4_address:
-                    description: Public IPv4 address of the server
+                    description: Public IPv4 address of the server, None if not existing
                     returned: always
                     type: str
                     sample: 116.203.104.109
                 ipv6:
-                    description: IPv6 network of the server
+                    description: IPv6 network of the server, None if not existing
                     returned: always
                     type: str
                     sample: 2a01:4f8:1c1c:c140::/64
@@ -220,11 +220,13 @@ class AnsibleHcloudNetworkInfo(Hcloud):
                 servers = []
                 for server in network.servers:
                     image = None if server.image is None else to_native(server.image.name)
+                    ipv4_address = None if server.public_net.ipv4 is None else to_native(server.public_net.ipv4.ip)
+                    ipv6 = None if server.public_net.ipv6 is None else to_native(server.public_net.ipv6.ip)
                     prepared_server = {
                         "id": to_native(server.id),
                         "name": to_native(server.name),
-                        "ipv4_address": to_native(server.public_net.ipv4.ip),
-                        "ipv6": to_native(server.public_net.ipv6.ip),
+                        "ipv4_address": ipv4_address,
+                        "ipv6": ipv6,
                         "image": image,
                         "server_type": to_native(server.server_type.name),
                         "datacenter": to_native(server.datacenter.name),


### PR DESCRIPTION
First of all, thank you for providing the Ansible community with an easy way to manage their HCloud infrastructure.
I'm opening this PR on behalf of the company I work for, Peerox GmbH.

Best regards,
Konstantin Köhring

##### SUMMARY
This fixes the behavior if there is a server without direct internet connectivity in the examined network.
Previously, the module would throw an AttributeError because server.public_net.ipv4/ipv6 is None in this case. Now the None propagates correctly.

Fixes #155 

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
hetzner.hcloud.network_info module

##### ADDITIONAL INFORMATION

Steps to reproduce:
1. Create a server with disabled public network (no IPv6 and no IPv4)
2. Attach the server to a private network
3. Try to invoke `hetzner.hcloud.hcloud_network_info` with `{"name": "NAME_OF_THE_PRIVATE_NETWORK"}`

before:
```
exception:
Traceback (most recent call last):
  File "/home/xxx/.ansible/tmp/ansible-tmp-1666777667.2723956-14077-133359966374608/AnsiballZ_hcloud_network_info.py", line 107, in <module>
    _ansiballz_main()
  File "/home/xxx/.ansible/tmp/ansible-tmp-1666777667.2723956-14077-133359966374608/AnsiballZ_hcloud_network_info.py", line 99, in _ansiballz_main
    invoke_module(zipped_mod, temp_path, ANSIBALLZ_PARAMS)
  File "/home/xxx/.ansible/tmp/ansible-tmp-1666777667.2723956-14077-133359966374608/AnsiballZ_hcloud_network_info.py", line 47, in invoke_module
    runpy.run_module(mod_name='ansible_collections.hetzner.hcloud.plugins.modules.hcloud_network_info', init_globals=dict(_module_fqn='ansible_collections.hetzner.hcloud.plugins.modules.hcloud_network_info', _modlib_path=modlib_path),
  File "/usr/lib/python3.10/runpy.py", line 224, in run_module
    return _run_module_code(code, init_globals, run_name, mod_spec)
  File "/usr/lib/python3.10/runpy.py", line 96, in _run_module_code
    _run_code(code, mod_globals, init_globals,
  File "/usr/lib/python3.10/runpy.py", line 86, in _run_code
    exec(code, run_globals)
  File "/tmp/ansible_hetzner.hcloud.hcloud_network_info_payload_x3ovj92h/ansible_hetzner.hcloud.hcloud_network_info_payload.zip/ansible_collections/hetzner/hcloud/plugins/modules/hcloud_network_info.py", line 297, in <module>
  File "/tmp/ansible_hetzner.hcloud.hcloud_network_info_payload_x3ovj92h/ansible_hetzner.hcloud.hcloud_network_info_payload.zip/ansible_collections/hetzner/hcloud/plugins/modules/hcloud_network_info.py", line 289, in main
  File "/tmp/ansible_hetzner.hcloud.hcloud_network_info_payload_x3ovj92h/ansible_hetzner.hcloud.hcloud_network_info_payload.zip/ansible_collections/hetzner/hcloud/plugins/module_utils/hcloud.py", line 63, in get_result
  File "/tmp/ansible_hetzner.hcloud.hcloud_network_info_payload_x3ovj92h/ansible_hetzner.hcloud.hcloud_network_info_payload.zip/ansible_collections/hetzner/hcloud/plugins/modules/hcloud_network_info.py", line 228, in _prepare_result
AttributeError: 'NoneType' object has no attribute 'ip'
```

after:
```
[
    {
        "delete_protection": false,
        "id": "xxxx",
        "ip_range": "10.xx.xx.0/24",
        "labels": {},
        "name": "xxxx",
        "routes": [
            {
                "destination": "0.0.0.0/0",
                "gateway": "10.xx.xx.2"
            }
        ],
        "servers": [
            {
                "backup_window": "None",
                "datacenter": "fsn1-dc14",
                "id": "xxxx",
                "image": "ubuntu-22.04",
                "ipv4_address": null,
                "ipv6": null,
                "labels": {},
                "location": "fsn1",
                "name": "test-no-ipv4",
                "rescue_enabled": false,
                "server_type": "cx11",
                "status": "running"
            }
        ],
        "subnetworks": [
            {
                "gateway": "10.x.x.1",
                "ip_range": "10.x.x.0/24",
                "network_zone": "eu-central",
                "type": "cloud"
            }
        ]
    }
]
```