### PR TITLE
Check if public ip exists before trying to set ansible_host

### DIFF
--- a/plugins/inventory/hcloud.py
+++ b/plugins/inventory/hcloud.py
@@ -220,7 +220,7 @@ class InventoryModule(BaseInventoryPlugin, Constructable):
                 if server_private_network.network.id == self.network.id:
                     self.inventory.set_variable(server.name, "private_ipv4", to_native(server_private_network.ip))
 
-        if self.get_option("connect_with") == "public_ipv4":
+        if self.get_option("connect_with") == "public_ipv4" and server.public_net.ipv4:
             self.inventory.set_variable(server.name, "ansible_host", to_native(server.public_net.ipv4.ip))
         elif self.get_option("connect_with") == "hostname":
             self.inventory.set_variable(server.name, "ansible_host", to_native(server.name))


### PR DESCRIPTION
##### SUMMARY
I have a project in hetzner cloud containing N vms where only some of them have a public ip. I need to be able to connect to thouse VMs with a public IP. Without this fix, I get the following warning:

```
[WARNING]:  * Failed to parse hcloud.yml with auto plugin: 'NoneType' object has no attribute 'ip'
```



##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
ansible dynamic inventory with hcloud

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
