### PR TITLE
add private ip in returned response

### DIFF
--- a/plugins/modules/hcloud_server.py
+++ b/plugins/modules/hcloud_server.py
@@ -280,8 +280,8 @@ hcloud_server:
             description: List of private networks the server is attached to (name or ID)
             returned: always
             type: list
-            elements: str
-            sample: ['my-network', 'another-network', '4711']
+            elements: dict
+            sample: [{'name': 'my-network', 'ip': '192.168.1.1'}, {'name': 'another-network', 'ip': '10.185.50.40'}]
         location:
             description: Name of the location of the server
             returned: always
@@ -367,7 +367,7 @@ class AnsibleHcloudServer(Hcloud):
             "name": to_native(self.hcloud_server.name),
             "ipv4_address": ipv4_address,
             "ipv6": ipv6,
-            "private_networks": [to_native(net.network.name) for net in self.hcloud_server.private_net],
+            "private_networks": [{"name": to_native(net.network.name), "ip": net.ip} for net in self.hcloud_server.private_net],
             "image": image,
             "server_type": to_native(self.hcloud_server.server_type.name),
             "datacenter": to_native(self.hcloud_server.datacenter.name),

--- a/plugins/modules/hcloud_server_info.py
+++ b/plugins/modules/hcloud_server_info.py
@@ -91,8 +91,8 @@ hcloud_server_info:
             description: List of private networks the server is attached to (name)
             returned: always
             type: list
-            elements: str
-            sample: ['my-network', 'another-network']
+            elements: dict
+            sample: [{'name': 'my-network', 'ip': '192.168.1.1'}, {'name': 'another-network', 'ip': '10.185.50.40'}]
         location:
             description: Name of the location of the server
             returned: always
@@ -167,7 +167,7 @@ class AnsibleHcloudServerInfo(Hcloud):
                     "name": to_native(server.name),
                     "ipv4_address": ipv4_address,
                     "ipv6": ipv6,
-                    "private_networks": [to_native(net.network.name) for net in server.private_net],
+                    "private_networks": [{"name": to_native(net.network.name), "ip": net.ip} for net in server.private_net],
                     "image": image,
                     "server_type": to_native(server.server_type.name),
                     "datacenter": to_native(server.datacenter.name),


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Fixes #169 

Returns private IP within `hcloud_server_info` and `hcloud_server` response. 

```
ok: [localhost] => changed=false 
  hcloud_server_info:
  - backup_window: null
    datacenter: hel1-dc2
    delete_protection: false
    id: '234'
    image: None
    ipv4_address: null
    ipv6: null
    labels: {}
    location: hel1
    name: sa-alex-gittings-ipf-6.0.0.14
    placement_group: null
    private_networks:
    - ip: 10.194.50.15
      name: SA
    rebuild_protection: false
    rescue_enabled: false
    server_type: cx41
    status: running
```
##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
hcloud_server
hcloud_server_info

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
