### PR TITLE
feat(inventory): connect via public ipv6 address

### DIFF
--- a/changelogs/fragments/inventory-connect-via-ipv6.yml
+++ b/changelogs/fragments/inventory-connect-via-ipv6.yml
@@ -1,0 +1,4 @@
+minor_changes:
+  - inventory plugin - Add new connect_with setting public_ipv6 to connect to discovered servers via public IPv6 address.
+breaking_changes:
+  - inventory plugin - Python v3.5+ is now required.


### PR DESCRIPTION


##### SUMMARY
Add a new `connect_with` option `public_ipv6` that uses the first address from the servers publically-routed ipv6 network.

Fixes #173

##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME

inventory-plugin

##### ADDITIONAL INFORMATION

