### PR TITLE
Add private_networks_info with info dict containing name and private ip

### DIFF
--- a/plugins/modules/hcloud_server.py
+++ b/plugins/modules/hcloud_server.py
@@ -283,6 +283,12 @@ hcloud_server:
             type: list
             elements: str
             sample: ['my-network', 'another-network', '4711']
+        private_networks_info:
+            description: List of private networks the server is attached to (dict with name and ip)
+            returned: always
+            type: list
+            elements: dict
+            sample: [{'name': 'my-network', 'ip': '192.168.1.1'}, {'name': 'another-network', 'ip': '10.185.50.40'}]
         location:
             description: Name of the location of the server
             returned: always
@@ -369,6 +375,7 @@ class AnsibleHcloudServer(Hcloud):
             "ipv4_address": ipv4_address,
             "ipv6": ipv6,
             "private_networks": [to_native(net.network.name) for net in self.hcloud_server.private_net],
+            "private_networks_info": [{"name": to_native(net.network.name), "ip": net.ip} for net in self.hcloud_server.private_net],
             "image": image,
             "server_type": to_native(self.hcloud_server.server_type.name),
             "datacenter": to_native(self.hcloud_server.datacenter.name),

--- a/plugins/modules/hcloud_server_info.py
+++ b/plugins/modules/hcloud_server_info.py
@@ -93,6 +93,12 @@ hcloud_server_info:
             type: list
             elements: str
             sample: ['my-network', 'another-network']
+        private_networks_info:
+            description: List of private networks the server is attached to (dict with name and ip)
+            returned: always
+            type: list
+            elements: dict
+            sample: [{'name': 'my-network', 'ip': '192.168.1.1'}, {'name': 'another-network', 'ip': '10.185.50.40'}]
         location:
             description: Name of the location of the server
             returned: always
@@ -168,6 +174,7 @@ class AnsibleHcloudServerInfo(Hcloud):
                     "ipv4_address": ipv4_address,
                     "ipv6": ipv6,
                     "private_networks": [to_native(net.network.name) for net in server.private_net],
+                    "private_networks_info": [{"name": to_native(net.network.name), "ip": net.ip} for net in server.private_net],
                     "image": image,
                     "server_type": to_native(server.server_type.name),
                     "datacenter": to_native(server.datacenter.name),


### PR DESCRIPTION
# SUMMARY

Fixes https://github.com/ansible-collections/hetzner.hcloud/issues/169

Returns info about networks with name and internal IP within hcloud_server_info and hcloud_server response.

**Note**: Adapted from [minitriga](https://github.com/minitriga) in original PR https://github.com/ansible-collections/hetzner.hcloud/pull/170

~~~
ok: [localhost] => changed=false 
  hcloud_server_info:
  - backup_window: null
    datacenter: hel1-dc2
    delete_protection: false
    id: '234'
    image: None
    ipv4_address: null
    ipv6: null
    labels: {}
    location: hel1
    name: sa-alex-gittings-ipf-6.0.0.14
    placement_group: null
    private_networks:
    - SA
    private_networks_info:
    - ip: 10.194.50.15
      name: SA
    rebuild_protection: false
    rescue_enabled: false
    server_type: cx41
    status: running
~~~

# ISSUE TYPE

    Feature Pull Request

# COMPONENT NAME

hcloud_server
hcloud_server_info

# ADDITIONAL INFORMATION

