### PR TITLE
feat(inventory): add all private networks as variables [1/3]

### DIFF
--- a/changelogs/fragments/inventory-private-network-info.yml
+++ b/changelogs/fragments/inventory-private-network-info.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - inventory plugin - Add list of all private networks to server variables.

--- a/plugins/inventory/hcloud.py
+++ b/plugins/inventory/hcloud.py
@@ -222,8 +222,18 @@ class InventoryModule(BaseInventoryPlugin, Constructable):
             self.inventory.set_variable(server.name, "ipv6_network", to_native(server.public_net.ipv6.network))
             self.inventory.set_variable(server.name, "ipv6_network_mask", to_native(server.public_net.ipv6.network_mask))
 
+        self.inventory.set_variable(
+            server.name,
+            "private_networks",
+            [
+                {"name": n.network.name, "id": n.network.id, "ip": n.ip}
+                for n in server.private_net
+            ],
+        )
+
         if self.get_option("network"):
             for server_private_network in server.private_net:
+                # Set private_ipv4 if user filtered for one network
                 if server_private_network.network.id == self.network.id:
                     self.inventory.set_variable(server.name, "private_ipv4", to_native(server_private_network.ip))
 


### PR DESCRIPTION
##### SUMMARY

This can be used in the `compose`, `groups` and `keyed_groups` settings to dynamically build the inventory.

It also makes it possible for the user to override the `ansible_host` in `compose`, based on whether or not the server has a public ipv4 address, with fallback to the address in a specific private network.


Closes #184 #185

Related to #178 

Part of a 3 PR series:
- #186
- #187 
- #188

##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME

Inventory Plugin

##### ADDITIONAL INFORMATION
/
