### PR TITLE
feat(inventory): handle servers that dont work with connect_with setting [2/3]

### DIFF
--- a/changelogs/fragments/inventory-handle-invalid-connect-with.yml
+++ b/changelogs/fragments/inventory-handle-invalid-connect-with.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - inventory plugin - Log warning instead of crashing when some servers do not work with global connect_with setting.


### PR DESCRIPTION
##### SUMMARY

Currently if any of the servers in the inventory do not work with the selected `connect_with` mode, the script exits and returns 0 servers. This can happen for example if one of your servers does not have a public ipv4 address, but you set `connect_with: public_ipv4` (default).

This commit changes the behaviour to log a warning message, and just skip setting `ansible_host` for this server. This server will not be reachable by ansible by default, but users can use `compose` to override the `ansible_host` that we set based on the other variables.

Related to #178

Rebased on #186

Part of a 3 PR series:
- #186
- #187 
- #188

##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME

Inventory Plugin

##### ADDITIONAL INFORMATION
/
