### PR TITLE
feat(inventory): add variable for ipv6 address [3/3]

### DIFF
--- a/changelogs/fragments/inventory-ipv6-adress-variable.yml
+++ b/changelogs/fragments/inventory-ipv6-adress-variable.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - inventory plugin - Add public IPv6 address to server variables.

--- a/plugins/inventory/hcloud.py
+++ b/plugins/inventory/hcloud.py
@@ -225,6 +225,7 @@ class InventoryModule(BaseInventoryPlugin, Constructable):
         if server.public_net.ipv6:
             self.inventory.set_variable(server.name, "ipv6_network", to_native(server.public_net.ipv6.network))
             self.inventory.set_variable(server.name, "ipv6_network_mask", to_native(server.public_net.ipv6.network_mask))
+            self.inventory.set_variable(server.name, "ipv6", to_native(self._first_ipv6_address(server.public_net.ipv6.ip)))
 
         self.inventory.set_variable(
             server.name,


### PR DESCRIPTION
##### SUMMARY
This variable matches the `ansible_host` variable that we set when `connect_with: public_ipv6`, and allows the user to dynamically choose the connection method in `compose`.

Related to #178 

Rebased on #187 

Part of a 3 PR series:
- #186
- #187 
- #188

##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME
Inventory Plugin

##### ADDITIONAL INFORMATION
/
