### PR TITLE
Increase rebuild wait_until_finished() timeout

### DIFF
--- a/plugins/modules/hcloud_server.py
+++ b/plugins/modules/hcloud_server.py
@@ -826,7 +826,7 @@ class AnsibleHcloudServer(Hcloud):
         try:
             if not self.module.check_mode:
                 image = self._get_image()
-                self.client.servers.rebuild(self.hcloud_server, image).wait_until_finished()
+                self.client.servers.rebuild(self.hcloud_server, image).wait_until_finished(1000)  # When we rebuild the server progress takes some more time.
             self._mark_as_changed()
 
             self._get_server()


### PR DESCRIPTION
##### SUMMARY
Increase `wait_until_finished` timeout for server rebuild because default of `100` is too low.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
module: hcloud_server

##### ADDITIONAL INFORMATION
Default's `wait_unit_finished()` timeout is `100`, see https://github.com/hetznercloud/hcloud-python/blob/32bd2ecea280aebee62305fb7e4a2d0aa90540b8/hcloud/actions/client.py#L10. Increasing this to 1000 (just like 
https://github.com/ansible-collections/hetzner.hcloud/blob/2589783e1925290876793420c675a5f33ef0d575/plugins/modules/hcloud_server.py#L734-L737
will solve the problem.
Code is tested by rebuilding a CPX31 using a 2GB snapshot.
```
Traceback (most recent call last):
  File "/tmp/ansible_hcloud_server_payload_yww09ltp/ansible_hcloud_server_payload.zip/ansible_collections/hetzner/hcloud/plugins/modules/hcloud_server.py", line 829, in rebuild_server
  File "/work/.pip/lib/python3.8/site-packages/hcloud/actions/client.py", line 24, in wait_until_finished
    raise ActionTimeoutException(action=self)
hcloud.actions.domain.ActionTimeoutException

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/work/.ansible/tmp/ansible-tmp-1675159266.1650631-148-140601086676991/AnsiballZ_hcloud_server.py", line 107, in <module>
    _ansiballz_main()
  File "/work/.ansible/tmp/ansible-tmp-1675159266.1650631-148-140601086676991/AnsiballZ_hcloud_server.py", line 99, in _ansiballz_main
    invoke_module(zipped_mod, temp_path, ANSIBALLZ_PARAMS)
  File "/work/.ansible/tmp/ansible-tmp-1675159266.1650631-148-140601086676991/AnsiballZ_hcloud_server.py", line 47, in invoke_module
    runpy.run_module(mod_name='ansible_collections.hetzner.hcloud.plugins.modules.hcloud_server', init_globals=dict(_module_fqn='ansible_collections.hetzner.hcloud.plugins.modules.hcloud_server', _modlib_path=modlib_path),
  File "/usr/lib64/python3.8/runpy.py", line 207, in run_module
    return _run_module_code(code, init_globals, run_name, mod_spec)
  File "/usr/lib64/python3.8/runpy.py", line 97, in _run_module_code
    _run_code(code, mod_globals, init_globals,
  File "/usr/lib64/python3.8/runpy.py", line 87, in _run_code
    exec(code, run_globals)
  File "/tmp/ansible_hcloud_server_payload_yww09ltp/ansible_hcloud_server_payload.zip/ansible_collections/hetzner/hcloud/plugins/modules/hcloud_server.py", line 923, in <module>
  File "/tmp/ansible_hcloud_server_payload_yww09ltp/ansible_hcloud_server_payload.zip/ansible_collections/hetzner/hcloud/plugins/modules/hcloud_server.py", line 917, in main
  File "/tmp/ansible_hcloud_server_payload_yww09ltp/ansible_hcloud_server_payload.zip/ansible_collections/hetzner/hcloud/plugins/modules/hcloud_server.py", line 834, in rebuild_server
AttributeError: 'ActionTimeoutException' object has no attribute 'message'
fatal: [pilot-09defd999490e742 -> 127.0.0.1]: FAILED! => {
    "changed": false,
    "module_stderr": "Traceback (most recent call last):\n  File \"/tmp/ansible_hcloud_server_payload_yww09ltp/ansible_hcloud_server_payload.zip/ansible_collections/hetzner/hcloud/plugins/modules/hcloud_server.py\", line 829, in rebuild_server\n  File \"/work/.pip/lib/python3.8/site-packages/hcloud/actions/client.py\", line 24, in wait_until_finished\n    raise ActionTimeoutException(action=self)\nhcloud.actions.domain.ActionTimeoutException\n\nDuring handling of the above exception, another exception occurred:\n\nTraceback (most recent call last):\n  File \"/work/.ansible/tmp/ansible-tmp-1675159266.1650631-148-140601086676991/AnsiballZ_hcloud_server.py\", line 107, in <module>\n    _ansiballz_main()\n  File \"/work/.ansible/tmp/ansible-tmp-1675159266.1650631-148-140601086676991/AnsiballZ_hcloud_server.py\", line 99, in _ansiballz_main\n    invoke_module(zipped_mod, temp_path, ANSIBALLZ_PARAMS)\n  File \"/work/.ansible/tmp/ansible-tmp-1675159266.1650631-148-140601086676991/AnsiballZ_hcloud_server.py\", line 47, in invoke_module\n    runpy.run_module(mod_name='ansible_collections.hetzner.hcloud.plugins.modules.hcloud_server', init_globals=dict(_module_fqn='ansible_collections.hetzner.hcloud.plugins.modules.hcloud_server', _modlib_path=modlib_path),\n  File \"/usr/lib64/python3.8/runpy.py\", line 207, in run_module\n    return _run_module_code(code, init_globals, run_name, mod_spec)\n  File \"/usr/lib64/python3.8/runpy.py\", line 97, in _run_module_code\n    _run_code(code, mod_globals, init_globals,\n  File \"/usr/lib64/python3.8/runpy.py\", line 87, in _run_code\n    exec(code, run_globals)\n  File \"/tmp/ansible_hcloud_server_payload_yww09ltp/ansible_hcloud_server_payload.zip/ansible_collections/hetzner/hcloud/plugins/modules/hcloud_server.py\", line 923, in <module>\n  File \"/tmp/ansible_hcloud_server_payload_yww09ltp/ansible_hcloud_server_payload.zip/ansible_collections/hetzner/hcloud/plugins/modules/hcloud_server.py\", line 917, in main\n  File \"/tmp/ansible_hcloud_server_payload_yww09ltp/ansible_hcloud_server_payload.zip/ansible_collections/hetzner/hcloud/plugins/modules/hcloud_server.py\", line 834, in rebuild_server\nAttributeError: 'ActionTimeoutException' object has no attribute 'message'\n",
    "module_stdout": "",
    "msg": "MODULE FAILURE\nSee stdout/stderr for the exact error",
    "rc": 1
}
```
