### PR TITLE
chore: remove Ansible 2.11 support

### DIFF
--- a/.azure-pipelines/azure-pipelines.yml
+++ b/.azure-pipelines/azure-pipelines.yml
@@ -77,15 +77,6 @@ stages:
             - name: Sanity
               test: '2.12/sanity/1'
 
-  - stage: Ansible_2_11
-    displayName: Sanity 2.11
-    dependsOn: []
-    jobs:
-      - template: templates/matrix.yml
-        parameters:
-          targets:
-            - name: Sanity
-              test: '2.11/sanity/1'
 
 ## Integration tests (remote)
   - stage: Hetzner_devel
@@ -140,20 +131,6 @@ stages:
             - name: hcloud
               test: '2.12/hcloud/3.9'
 
-  - stage: Hetzner_2_11
-    displayName: Hetzner 2.11
-    dependsOn: []
-    jobs:
-      - template: templates/matrix.yml
-        parameters:
-          groups:
-            - 1
-            - 2
-          targets:
-            - name: hcloud
-              test: '2.11/hcloud/3.9'
-
-
 ### Finally
   - stage: Summary
     condition: succeededOrFailed()
@@ -162,11 +139,9 @@ stages:
       - Ansible_2_14
       - Ansible_2_13
       - Ansible_2_12
-      - Ansible_2_11
       - Hetzner_devel
       - Hetzner_2_14
       - Hetzner_2_13
       - Hetzner_2_12
-      - Hetzner_2_11
     jobs:
       - template: templates/coverage.yml

--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -1,4 +1,4 @@
-requires_ansible: '>=2.9.10'
+requires_ansible: '>=2.12.0'
 plugin_routing:
   modules:
     hcloud_location_facts:

--- a/tests/sanity/ignore-2.11.txt
+++ b/tests/sanity/ignore-2.11.txt
@@ -1,2 +1,0 @@
-tests/utils/shippable/check_matrix.py replace-urlopen
-tests/utils/shippable/timing.py shebang


### PR DESCRIPTION
##### SUMMARY

Ansible v2.11 is end-of-life and we do not need to support it anymore.
