### PR TITLE
fix(server): server still locked after placement_group attach

### DIFF
--- a/changelogs/fragments/server-race-condition-pg-attach.yml
+++ b/changelogs/fragments/server-race-condition-pg-attach.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - hcloud_server - Server locked after attaching to placement group

--- a/plugins/modules/hcloud_server.py
+++ b/plugins/modules/hcloud_server.py
@@ -652,7 +652,7 @@ class AnsibleHcloudServer(Hcloud):
                     ):
                         self.stop_server_if_forced()
                         if not self.module.check_mode:
-                            self.hcloud_server.add_to_placement_group(placement_group)
+                            self.hcloud_server.add_to_placement_group(placement_group).wait_until_finished()
                         self._mark_as_changed()
 
             if "ipv4" in self.module.params:


### PR DESCRIPTION
##### SUMMARY
In some cases the server was still marked as locked after attaching it to a placement_group. This caused potential follow up tasks that use the server to fail.

This happened because the action returned by `add_to_placement_group()` was not waited upon.

For the detach case this is handled correctly.

##### ISSUE TYPE
- Bugfix Pull Request


##### COMPONENT NAME
`hcloud_server` module

##### ADDITIONAL INFORMATION

I noticed this because the integration test for `hcloud_placement_group` was failing in our internal CI.
