### PR TITLE
lint: fix unused-import errors

### DIFF
--- a/plugins/module_utils/hcloud.py
+++ b/plugins/module_utils/hcloud.py
@@ -12,7 +12,6 @@ from ansible.module_utils.basic import env_fallback, missing_required_lib
 
 try:
     import hcloud
-    from hcloud import APIException
 
     HAS_HCLOUD = True
 except ImportError:

--- a/plugins/modules/hcloud_certificate.py
+++ b/plugins/modules/hcloud_certificate.py
@@ -142,13 +142,6 @@ from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils._text import to_native
 from ansible_collections.hetzner.hcloud.plugins.module_utils.hcloud import Hcloud
 
-try:
-    from hcloud.certificates.domain import Certificate
-    from hcloud.certificates.domain import Server
-    from hcloud import APIException
-except ImportError:
-    APIException = None
-
 
 class AnsibleHcloudCertificate(Hcloud):
     def __init__(self, module):

--- a/plugins/modules/hcloud_certificate_info.py
+++ b/plugins/modules/hcloud_certificate_info.py
@@ -90,11 +90,6 @@ from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils._text import to_native
 from ansible_collections.hetzner.hcloud.plugins.module_utils.hcloud import Hcloud
 
-try:
-    from hcloud import APIException
-except ImportError:
-    APIException = None
-
 
 class AnsibleHcloudCertificateInfo(Hcloud):
     def __init__(self, module):

--- a/plugins/modules/hcloud_datacenter_info.py
+++ b/plugins/modules/hcloud_datacenter_info.py
@@ -85,11 +85,6 @@ from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils._text import to_native
 from ansible_collections.hetzner.hcloud.plugins.module_utils.hcloud import Hcloud
 
-try:
-    from hcloud import APIException
-except ImportError:
-    APIException = None
-
 
 class AnsibleHcloudDatacenterInfo(Hcloud):
     def __init__(self, module):

--- a/plugins/modules/hcloud_floating_ip.py
+++ b/plugins/modules/hcloud_floating_ip.py
@@ -169,11 +169,6 @@ from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils._text import to_native
 from ansible_collections.hetzner.hcloud.plugins.module_utils.hcloud import Hcloud
 
-try:
-    from hcloud import APIException
-except ImportError:
-    APIException = None
-
 
 class AnsibleHcloudFloatingIP(Hcloud):
     def __init__(self, module):

--- a/plugins/modules/hcloud_floating_ip_info.py
+++ b/plugins/modules/hcloud_floating_ip_info.py
@@ -102,11 +102,6 @@ from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils._text import to_native
 from ansible_collections.hetzner.hcloud.plugins.module_utils.hcloud import Hcloud
 
-try:
-    from hcloud import APIException
-except ImportError:
-    APIException = None
-
 
 class AnsibleHcloudFloatingIPInfo(Hcloud):
     def __init__(self, module):

--- a/plugins/modules/hcloud_image_info.py
+++ b/plugins/modules/hcloud_image_info.py
@@ -108,11 +108,6 @@ from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils._text import to_native
 from ansible_collections.hetzner.hcloud.plugins.module_utils.hcloud import Hcloud
 
-try:
-    from hcloud import APIException
-except ImportError:
-    APIException = None
-
 
 class AnsibleHcloudImageInfo(Hcloud):
     def __init__(self, module):

--- a/plugins/modules/hcloud_load_balancer.py
+++ b/plugins/modules/hcloud_load_balancer.py
@@ -149,12 +149,6 @@ from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils._text import to_native
 from ansible_collections.hetzner.hcloud.plugins.module_utils.hcloud import Hcloud
 
-try:
-    from hcloud.load_balancers.domain import LoadBalancer
-    from hcloud import APIException
-except ImportError:
-    APIException = None
-
 
 class AnsibleHcloudLoadBalancer(Hcloud):
     def __init__(self, module):

--- a/plugins/modules/hcloud_load_balancer_info.py
+++ b/plugins/modules/hcloud_load_balancer_info.py
@@ -264,11 +264,6 @@ from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils._text import to_native
 from ansible_collections.hetzner.hcloud.plugins.module_utils.hcloud import Hcloud
 
-try:
-    from hcloud import APIException
-except ImportError:
-    APIException = None
-
 
 class AnsibleHcloudLoadBalancerInfo(Hcloud):
     def __init__(self, module):

--- a/plugins/modules/hcloud_load_balancer_network.py
+++ b/plugins/modules/hcloud_load_balancer_network.py
@@ -99,12 +99,6 @@ from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils._text import to_native
 from ansible_collections.hetzner.hcloud.plugins.module_utils.hcloud import Hcloud
 
-try:
-    from hcloud import APIException
-except ImportError:
-    APIException = None
-    NetworkSubnet = None
-
 
 class AnsibleHcloudLoadBalancerNetwork(Hcloud):
     def __init__(self, module):

--- a/plugins/modules/hcloud_load_balancer_service.py
+++ b/plugins/modules/hcloud_load_balancer_service.py
@@ -288,7 +288,7 @@ from ansible.module_utils._text import to_native
 from ansible_collections.hetzner.hcloud.plugins.module_utils.hcloud import Hcloud
 
 try:
-    from hcloud.load_balancers.domain import LoadBalancer, LoadBalancerService, LoadBalancerServiceHttp, \
+    from hcloud.load_balancers.domain import LoadBalancerService, LoadBalancerServiceHttp, \
         LoadBalancerHealthCheck, LoadBalancerHealtCheckHttp
     from hcloud import APIException
 except ImportError:

--- a/plugins/modules/hcloud_load_balancer_target.py
+++ b/plugins/modules/hcloud_load_balancer_target.py
@@ -144,10 +144,8 @@ from ansible.module_utils._text import to_native
 from ansible_collections.hetzner.hcloud.plugins.module_utils.hcloud import Hcloud
 
 try:
-    from hcloud import APIException
     from hcloud.load_balancers.domain import LoadBalancerTarget, LoadBalancerTargetLabelSelector, LoadBalancerTargetIP
 except ImportError:
-    APIException = None
     LoadBalancerTarget = None
     LoadBalancerTargetLabelSelector = None
     LoadBalancerTargetIP = None

--- a/plugins/modules/hcloud_load_balancer_type_info.py
+++ b/plugins/modules/hcloud_load_balancer_type_info.py
@@ -92,11 +92,6 @@ from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils._text import to_native
 from ansible_collections.hetzner.hcloud.plugins.module_utils.hcloud import Hcloud
 
-try:
-    from hcloud import APIException
-except ImportError:
-    pass
-
 
 class AnsibleHcloudLoadBalancerTypeInfo(Hcloud):
     def __init__(self, module):

--- a/plugins/modules/hcloud_location_info.py
+++ b/plugins/modules/hcloud_location_info.py
@@ -84,11 +84,6 @@ from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils._text import to_native
 from ansible_collections.hetzner.hcloud.plugins.module_utils.hcloud import Hcloud
 
-try:
-    from hcloud import APIException
-except ImportError:
-    APIException = None
-
 
 class AnsibleHcloudLocationInfo(Hcloud):
     def __init__(self, module):

--- a/plugins/modules/hcloud_network.py
+++ b/plugins/modules/hcloud_network.py
@@ -114,11 +114,6 @@ from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils._text import to_native
 from ansible_collections.hetzner.hcloud.plugins.module_utils.hcloud import Hcloud
 
-try:
-    from hcloud import APIException
-except ImportError:
-    APIException = None
-
 
 class AnsibleHcloudNetwork(Hcloud):
     def __init__(self, module):

--- a/plugins/modules/hcloud_network_info.py
+++ b/plugins/modules/hcloud_network_info.py
@@ -184,11 +184,6 @@ from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils._text import to_native
 from ansible_collections.hetzner.hcloud.plugins.module_utils.hcloud import Hcloud
 
-try:
-    from hcloud import APIException
-except ImportError:
-    APIException = None
-
 
 class AnsibleHcloudNetworkInfo(Hcloud):
     def __init__(self, module):

--- a/plugins/modules/hcloud_primary_ip.py
+++ b/plugins/modules/hcloud_primary_ip.py
@@ -139,11 +139,6 @@ from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils._text import to_native
 from ansible_collections.hetzner.hcloud.plugins.module_utils.hcloud import Hcloud
 
-try:
-    from hcloud import APIException
-except ImportError:
-    APIException = None
-
 
 class AnsibleHcloudPrimaryIP(Hcloud):
     def __init__(self, module):

--- a/plugins/modules/hcloud_rdns.py
+++ b/plugins/modules/hcloud_rdns.py
@@ -143,11 +143,6 @@ from ansible.module_utils._text import to_native
 from ansible_collections.hetzner.hcloud.plugins.module_utils.hcloud import Hcloud
 from ansible_collections.ansible.netcommon.plugins.module_utils.network.common import utils
 
-try:
-    from hcloud import APIException
-except ImportError:
-    APIException = None
-
 
 class AnsibleHcloudReverseDNS(Hcloud):
     def __init__(self, module):

--- a/plugins/modules/hcloud_route.py
+++ b/plugins/modules/hcloud_route.py
@@ -96,10 +96,8 @@ from ansible.module_utils._text import to_native
 from ansible_collections.hetzner.hcloud.plugins.module_utils.hcloud import Hcloud
 
 try:
-    from hcloud import APIException
     from hcloud.networks.domain import NetworkRoute
 except ImportError:
-    APIException = None
     NetworkRoute = None
 
 

--- a/plugins/modules/hcloud_server.py
+++ b/plugins/modules/hcloud_server.py
@@ -342,18 +342,13 @@ try:
     from hcloud.volumes.domain import Volume
     from hcloud.ssh_keys.domain import SSHKey
     from hcloud.servers.domain import Server, ServerCreatePublicNetwork
-    from hcloud.firewalls.domain import Firewall, FirewallResource
-    from hcloud.primary_ips.domain import PrimaryIP
-    from hcloud import APIException
+    from hcloud.firewalls.domain import FirewallResource
 except ImportError:
-    APIException = None
     Volume = None
     SSHKey = None
     Server = None
     ServerCreatePublicNetwork = None
-    Firewall = None
     FirewallResource = None
-    PrimaryIP = None
 
 
 class AnsibleHcloudServer(Hcloud):

--- a/plugins/modules/hcloud_server_info.py
+++ b/plugins/modules/hcloud_server_info.py
@@ -147,11 +147,6 @@ from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils._text import to_native
 from ansible_collections.hetzner.hcloud.plugins.module_utils.hcloud import Hcloud
 
-try:
-    from hcloud import APIException
-except ImportError:
-    APIException = None
-
 
 class AnsibleHcloudServerInfo(Hcloud):
     def __init__(self, module):

--- a/plugins/modules/hcloud_server_type_info.py
+++ b/plugins/modules/hcloud_server_type_info.py
@@ -99,11 +99,6 @@ from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils._text import to_native
 from ansible_collections.hetzner.hcloud.plugins.module_utils.hcloud import Hcloud
 
-try:
-    from hcloud import APIException
-except ImportError:
-    APIException = None
-
 
 class AnsibleHcloudServerTypeInfo(Hcloud):
     def __init__(self, module):

--- a/plugins/modules/hcloud_ssh_key.py
+++ b/plugins/modules/hcloud_ssh_key.py
@@ -118,14 +118,6 @@ from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils._text import to_native
 from ansible_collections.hetzner.hcloud.plugins.module_utils.hcloud import Hcloud
 
-try:
-    from hcloud.volumes.domain import Volume
-    from hcloud.ssh_keys.domain import SSHKey
-    from hcloud.ssh_keys.domain import Server
-    from hcloud import APIException
-except ImportError:
-    APIException = None
-
 
 class AnsibleHcloudSSHKey(Hcloud):
     def __init__(self, module):

--- a/plugins/modules/hcloud_ssh_key_info.py
+++ b/plugins/modules/hcloud_ssh_key_info.py
@@ -84,11 +84,6 @@ from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils._text import to_native
 from ansible_collections.hetzner.hcloud.plugins.module_utils.hcloud import Hcloud
 
-try:
-    from hcloud import APIException
-except ImportError:
-    APIException = None
-
 
 class AnsibleHcloudSSHKeyInfo(Hcloud):
     def __init__(self, module):

--- a/plugins/modules/hcloud_subnetwork.py
+++ b/plugins/modules/hcloud_subnetwork.py
@@ -133,10 +133,8 @@ from ansible.module_utils._text import to_native
 from ansible_collections.hetzner.hcloud.plugins.module_utils.hcloud import Hcloud
 
 try:
-    from hcloud import APIException
     from hcloud.networks.domain import NetworkSubnet
 except ImportError:
-    APIException = None
     NetworkSubnet = None
 
 

--- a/plugins/modules/hcloud_volume.py
+++ b/plugins/modules/hcloud_volume.py
@@ -165,15 +165,6 @@ from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils._text import to_native
 from ansible_collections.hetzner.hcloud.plugins.module_utils.hcloud import Hcloud
 
-try:
-    from hcloud.volumes.domain import Volume
-    from hcloud.servers.domain import Server
-    import hcloud
-except ImportError:
-    APIException = None
-    Volume = None
-    Server = None
-
 
 class AnsibleHcloudVolume(Hcloud):
     def __init__(self, module):

--- a/plugins/modules/hcloud_volume_info.py
+++ b/plugins/modules/hcloud_volume_info.py
@@ -99,11 +99,6 @@ from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils._text import to_native
 from ansible_collections.hetzner.hcloud.plugins.module_utils.hcloud import Hcloud
 
-try:
-    from hcloud import APIException
-except ImportError:
-    APIException = None
-
 
 class AnsibleHcloudVolumeInfo(Hcloud):
     def __init__(self, module):


### PR DESCRIPTION

##### SUMMARY
The linting rule `unused-import` was recently activated in ansible-test.

This commit removes all unused imports to satify the linting rule.

##### ISSUE TYPE

- Bugfix Pull Request
- 
##### ADDITIONAL INFORMATION

See ansible-collections/news-for-maintainers#34