### PR TITLE
fix(server): prevent backups from being disabled when undefined

### DIFF
--- a/changelogs/fragments/server-fix-backups.yml
+++ b/changelogs/fragments/server-fix-backups.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - hcloud_server - Prevent backups from being disabled when undefined

--- a/plugins/modules/hcloud_server.py
+++ b/plugins/modules/hcloud_server.py
@@ -590,11 +590,12 @@ class AnsibleHcloudServer(Hcloud):
                     self.hcloud_server.disable_rescue().wait_until_finished()
                 self._mark_as_changed()
 
-            if self.module.params.get("backups") and self.hcloud_server.backup_window is None:
+            backups = self.module.params.get("backups")
+            if backups and self.hcloud_server.backup_window is None:
                 if not self.module.check_mode:
                     self.hcloud_server.enable_backup().wait_until_finished()
                 self._mark_as_changed()
-            elif not self.module.params.get("backups") and self.hcloud_server.backup_window is not None:
+            elif backups is not None and not backups and self.hcloud_server.backup_window is not None:
                 if not self.module.check_mode:
                     self.hcloud_server.disable_backup().wait_until_finished()
                 self._mark_as_changed()

--- a/tests/integration/targets/hcloud_server/tasks/basic.yml
+++ b/tests/integration/targets/hcloud_server/tasks/basic.yml
@@ -214,6 +214,21 @@
       - result is not changed
       - result.hcloud_server.backup_window != ""
 
+- name: test backups are not accidentally disabled
+  hcloud_server:
+    name: "{{ hcloud_server_name }}"
+    # Make sure that backups are not disabled because a partial server object without "backups" was supplied somewhere
+    # to update some unrelated properties.
+    # Regression test for https://github.com/ansible-collections/hetzner.hcloud/pull/196
+    # backups: true
+    state: stopped
+  register: result
+- name: verify backups are not accidentally disabled
+  assert:
+    that:
+      - result is not changed
+      - result.hcloud_server.backup_window != ""
+
 - name: test rebuild server
   hcloud_server:
     name: "{{ hcloud_server_name }}"

--- a/tests/integration/targets/hcloud_server/tasks/main.yml
+++ b/tests/integration/targets/hcloud_server/tasks/main.yml
@@ -2,7 +2,7 @@
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 ---
 #- ansible.builtin.include_tasks: validation.yml
-#- ansible.builtin.include_tasks: basic.yml
+- ansible.builtin.include_tasks: basic.yml
 #- ansible.builtin.include_tasks: firewalls.yml
 - ansible.builtin.include_tasks: primary_ips.yml
 - ansible.builtin.include_tasks: private_network_only.yml


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
With an existing server with backups enabled and the state being either present, started, stopped, restarted or rebuild and the backups module parameter not set, the module would disable backups and in turn delete all existing backups.

The correct behaviour (leave backups untouched when parameter not set) is implemented by this commit. Strong typing would have prevented this.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
`hetzner.hcloud.hcloud_server`
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
