### PR TITLE
test: flaky test for hcloud_server private_network_only

### DIFF
--- a/tests/integration/targets/hcloud_server/tasks/private_network_only.yml
+++ b/tests/integration/targets/hcloud_server/tasks/private_network_only.yml
@@ -1,6 +1,21 @@
 # Copyright: (c) 2022, Hetzner Cloud GmbH <info@hetzner-cloud.de>
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 ---
+- name: setup network 1 to be absent
+  hcloud_network:
+    name: "{{ hcloud_network_name }}-1"
+    state: absent
+
+- name: setup network 2 to be absent
+  hcloud_network:
+    name: "{{ hcloud_network_name }}-2"
+    state: absent
+
+- name: setup server to be absent
+  hcloud_server:
+    name: "{{ hcloud_server_name }}"
+    state: absent
+
 - name: setup create network
   hcloud_network:
     name: "{{ hcloud_network_name }}-1"


### PR DESCRIPTION
##### SUMMARY

The server that was being handled could still exist from previous tests running in the same suite. This can be fixed by making sure that the server does not exist at the start of this test suite.

Related to #203

##### ISSUE TYPE

- Test Pull Request

##### COMPONENT NAME

`hcloud_server`

##### ADDITIONAL INFORMATION

Example logs from [failed CI pipeline](https://dev.azure.com/ansible/hetzner.hcloud/_build/results?buildId=72745&view=logs&j=d01ff689-4e85-566d-4792-f9984acde0cb&t=38074baf-391d-5150-7bd1-d2de1d57686f&l=1589):

```paste below
06:28 TASK [hcloud_server : test create server with primary network and no internet] ***
06:29 An exception occurred during task execution. To see the full traceback, use -vvv. The error was: TypeError: Value of unknown type: <class 'hcloud.hcloud.APIException'>, Server must be offline when unassigning a Primary IP
06:29 fatal: [testhost]: FAILED! => {"changed": false, "module_stderr": "Traceback (most recent call last):\n  File \"/tmp/ansible_hcloud_server_payload_dtc9ehr3/ansible_hcloud_server_payload.zip/ansible_collections/hetzner/hcloud/plugins/modules/hcloud_server.py\", line 661, in _update_server\n  File \"/usr/local/lib/python3.9/dist-packages/hcloud/primary_ips/client.py\", line 72, in unassign\n    return self._client.unassign(self)\n  File \"/usr/local/lib/python3.9/dist-packages/hcloud/primary_ips/client.py\", line 309, in unassign\n    response = self._client.request(\n  File \"/usr/local/lib/python3.9/dist-packages/hcloud/hcloud.py\", line 240, in request\n    self._raise_exception_from_json_content(json_content)\n  File \"/usr/local/lib/python3.9/dist-packages/hcloud/hcloud.py\", line 204, in _raise_exception_from_json_content\n    raise APIException(\nhcloud.hcloud.APIException: Server must be offline when unassigning a Primary IP\n\nDuring handling of the above exception, another exception occurred:\n\nTraceback (most recent call last):\n  File \"<stdin>\", line 133, in <module>\n  File \"<stdin>\", line 125, in _ansiballz_main\n  File \"<stdin>\", line 73, in invoke_module\n  File \"/usr/lib/python3.9/runpy.py\", line 210, in run_module\n    return _run_module_code(code, init_globals, run_name, mod_spec)\n  File \"/usr/lib/python3.9/runpy.py\", line 97, in _run_module_code\n    _run_code(code, mod_globals, init_globals,\n  File \"/usr/lib/python3.9/runpy.py\", line 87, in _run_code\n    exec(code, run_globals)\n  File \"/tmp/ansible_hcloud_server_payload_dtc9ehr3/ansible_hcloud_server_payload.zip/ansible_collections/hetzner/hcloud/plugins/modules/hcloud_server.py\", line 925, in <module>\n  File \"/tmp/ansible_hcloud_server_payload_dtc9ehr3/ansible_hcloud_server_payload.zip/ansible_collections/hetzner/hcloud/plugins/modules/hcloud_server.py\", line 911, in main\n  File \"/tmp/ansible_hcloud_server_payload_dtc9ehr3/ansible_hcloud_server_payload.zip/ansible_collections/hetzner/hcloud/plugins/modules/hcloud_server.py\", line 843, in present_server\n  File \"/tmp/ansible_hcloud_server_payload_dtc9ehr3/ansible_hcloud_server_payload.zip/ansible_collections/hetzner/hcloud/plugins/modules/hcloud_server.py\", line 770, in _update_server\n  File \"/tmp/ansible_hcloud_server_payload_dtc9ehr3/ansible_hcloud_server_payload.zip/ansible/module_utils/basic.py\", line 1533, in fail_json\n  File \"/tmp/ansible_hcloud_server_payload_dtc9ehr3/ansible_hcloud_server_payload.zip/ansible/module_utils/basic.py\", line 1506, in _return_formatted\n  File \"/tmp/ansible_hcloud_server_payload_dtc9ehr3/ansible_hcloud_server_payload.zip/ansible/module_utils/common/parameters.py\", line 887, in remove_values\n  File \"/tmp/ansible_hcloud_server_payload_dtc9ehr3/ansible_hcloud_server_payload.zip/ansible/module_utils/common/parameters.py\", line 461, in _remove_values_conditions\nTypeError: Value of unknown type: <class 'hcloud.hcloud.APIException'>, Server must be offline when unassigning a Primary IP\n", "module_stdout": "", "msg": "MODULE FAILURE\nSee stdout/stderr for the exact error", "rc": 1}
```
