### PR TITLE
ci: add tests for ansible 2.15

### DIFF
--- a/.azure-pipelines/azure-pipelines.yml
+++ b/.azure-pipelines/azure-pipelines.yml
@@ -49,6 +49,16 @@ stages:
             - name: Sanity
               test: 'devel/sanity/1'
 
+
+  - stage: Ansible_2_15
+    displayName: Sanity 2.15
+    dependsOn: []
+    jobs:
+      - template: templates/matrix.yml
+        parameters:
+          targets:
+            - name: Sanity
+              test: '2.15/sanity/1'
   - stage: Ansible_2_14
     displayName: Sanity 2.14
     dependsOn: []
@@ -88,9 +98,24 @@ stages:
           groups:
             - 1
             - 2
+            - 3
           targets:
             - name: hcloud
               test: 'devel/hcloud/3.9'
+
+  - stage: Hetzner_2_15
+    displayName: Hetzner 2.15
+    dependsOn: []
+    jobs:
+      - template: templates/matrix.yml
+        parameters:
+          groups:
+            - 1
+            - 2
+            - 3
+          targets:
+            - name: hcloud
+              test: '2.15/hcloud/3.9'
 
   - stage: Hetzner_2_14
     displayName: Hetzner 2.14
@@ -101,6 +126,7 @@ stages:
           groups:
             - 1
             - 2
+            - 3
           targets:
             - name: hcloud
               test: '2.14/hcloud/3.9'
@@ -114,6 +140,7 @@ stages:
           groups:
             - 1
             - 2
+            - 3
           targets:
             - name: hcloud
               test: '2.13/hcloud/3.9'
@@ -127,6 +154,7 @@ stages:
           groups:
             - 1
             - 2
+            - 3
           targets:
             - name: hcloud
               test: '2.12/hcloud/3.9'
@@ -136,10 +164,12 @@ stages:
     condition: succeededOrFailed()
     dependsOn:
       - Ansible_devel
+      - Ansible_2_15
       - Ansible_2_14
       - Ansible_2_13
       - Ansible_2_12
       - Hetzner_devel
+      - Hetzner_2_15
       - Hetzner_2_14
       - Hetzner_2_13
       - Hetzner_2_12

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -15,7 +15,7 @@ sanity:
     - tags
   parallel:
     matrix:
-      - ANSIBLE_VERSION: ["devel", "2.12", "2.13", "2.14"]
+      - ANSIBLE_VERSION: ["devel", "2.12", "2.13", "2.14", "2.15"]
         GROUP: [1]
   script:
     - bash tests/utils/gitlab/gitlab.sh ${ANSIBLE_VERSION}/sanity/${GROUP}

--- a/tests/sanity/ignore-2.16.txt
+++ b/tests/sanity/ignore-2.16.txt
@@ -1,0 +1,2 @@
+tests/utils/shippable/check_matrix.py replace-urlopen
+tests/utils/shippable/timing.py shebang


### PR DESCRIPTION
##### SUMMARY

- Add tests for Ansible 2.15
- Add sanity ignore file for 2.16, as thats used by devel now
- Configure azure pipelines to also run group 3 of the integration tests

Related to https://github.com/ansible-collections/news-for-maintainers/issues/41