### PR TITLE
docs: show warning if image_info is used without architecture

### DIFF
--- a/plugins/modules/hcloud_image_info.py
+++ b/plugins/modules/hcloud_image_info.py
@@ -154,6 +154,7 @@ class AnsibleHcloudImageInfo(Hcloud):
                     self.module.params.get("architecture")
                 )]
             elif self.module.params.get("name") is not None:
+                self.module.warn("This module only returns x86 images by default. Please set architecture:x86|arm to hide this message.")
                 self.hcloud_image_info = [self.client.images.get_by_name(
                     self.module.params.get("name")
                 )]


### PR DESCRIPTION
##### SUMMARY

Shows a warning when using `image_info` to get an image by name but without specifying an architecture. @LKaemmerling already requested this for the initial PR #208, but there was no time to get it implemented back then.

This behaviour is equivalent to the cli:

```
➜ hcloud image describe ubuntu-22.04
INFO: This command only returns x86 images by default. Explicitly set the --architecture=x86|arm flag to hide this message.
ID:             67794396
[cut]
➜ hcloud image describe ubuntu-22.04 --architecture x86
ID:             67794396
[cut]
```

##### ISSUE TYPE

- Docs Pull Request


##### COMPONENT NAME

- `hcloud_image_info`
