### PR TITLE
fix(server): TypeError when using deprecated image

### DIFF
--- a/changelogs/fragments/server_error_deprecated_image.yml
+++ b/changelogs/fragments/server_error_deprecated_image.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - hcloud_server - TypeError when trying to use deprecated image with allow_deprecated_image

--- a/plugins/modules/hcloud_server.py
+++ b/plugins/modules/hcloud_server.py
@@ -516,8 +516,8 @@ class AnsibleHcloudServer(Hcloud):
             available_until = image.deprecated + timedelta(days=90)
             if self.module.params.get("allow_deprecated_image"):
                 self.module.warn(
-                    "You try to use a deprecated image. The image %s will continue to be available until %s.") % (
-                    image.name, available_until.strftime('%Y-%m-%d'))
+                    "You try to use a deprecated image. The image %s will continue to be available until %s." % (
+                        image.name, available_until.strftime('%Y-%m-%d')))
             else:
                 self.module.fail_json(
                     msg=("You try to use a deprecated image. The image %s will continue to be available until %s." +


### PR DESCRIPTION
##### SUMMARY
When using a deprecated image with the `allow_deprecated_image` flag, the script would crash because the string interpolation was not done correctly. The parentheses were in the wrong place.

Error would look like this:

    An exception occurred during task execution. To see the full traceback, use -vvv. The error was: TypeError: unsupported operand type(s) for %: 'NoneType' and 'str'
    fatal: [localhost]: FAILED! => {"changed": false, "module_stderr": "Traceback (most recent call last):\n  File \"/home/julian/.ansible/tmp/ansible-tmp-1686564668.6136558-165294-192879183382787/AnsiballZ_hcloud_server.py\", line 107, in <module>\n    _ansiballz_main()\n  File \"/home/julian/.ansible/tmp/ansible-tmp-1686564668.6136558-165294-192879183382787/AnsiballZ_hcloud_server.py\", line 99, in _ansiballz_main\n    invoke_module(zipped_mod, temp_path, ANSIBALLZ_PARAMS)\n  File \"/home/julian/.ansible/tmp/ansible-tmp-1686564668.6136558-165294-192879183382787/AnsiballZ_hcloud_server.py\", line 47, in invoke_module\n    runpy.run_module(mod_name='ansible_collections.hetzner.hcloud.plugins.modules.hcloud_server', init_globals=dict(_module_fqn='ansible_collections.hetzner.hcloud.plugins.modules.hcloud_server', _modlib_path=modlib_path),\n  File \"/nix/store/95cxzy2hpizr23343b8bskl4yacf4b3l-python3-3.10.11/lib/python3.10/runpy.py\", line 224, in run_module\n    return _run_module_code(code, init_globals, run_name, mod_spec)\n  File \"/nix/store/95cxzy2hpizr23343b8bskl4yacf4b3l-python3-3.10.11/lib/python3.10/runpy.py\", line 96, in _run_module_code\n    _run_code(code, mod_globals, init_globals,\n  File \"/nix/store/95cxzy2hpizr23343b8bskl4yacf4b3l-python3-3.10.11/lib/python3.10/runpy.py\", line 86, in _run_code\n    exec(code, run_globals)\n  File \"/run/user/1000/ansible_hcloud_server_payload_1g2rf66q/ansible_hcloud_server_payload.zip/ansible_collections/hetzner/hcloud/plugins/modules/hcloud_server.py\", line 927, in <module>\n  File \"/run/user/1000/ansible_hcloud_server_payload_1g2rf66q/ansible_hcloud_server_payload.zip/ansible_collections/hetzner/hcloud/plugins/modules/hcloud_server.py\", line 908, in main\n  File \"/run/user/1000/ansible_hcloud_server_payload_1g2rf66q/ansible_hcloud_server_payload.zip/ansible_collections/hetzner/hcloud/plugins/modules/hcloud_server.py\", line 843, in present_server\n  File \"/run/user/1000/ansible_hcloud_server_payload_1g2rf66q/ansible_hcloud_server_payload.zip/ansible_collections/hetzner/hcloud/plugins/modules/hcloud_server.py\", line 411, in _create_server\n  File \"/run/user/1000/ansible_hcloud_server_payload_1g2rf66q/ansible_hcloud_server_payload.zip/ansible_collections/hetzner/hcloud/plugins/modules/hcloud_server.py\", line 518, in _get_image\nTypeError: unsupported operand type(s) for %: 'NoneType' and 'str'\n", "module_stdout": "", "msg": "MODULE FAILURE\nSee stdout/stderr for the exact error", "rc": 1}

##### ISSUE TYPE

- Bugfix Pull Request


##### COMPONENT NAME
`hcloud_server`

##### ADDITIONAL INFORMATION

Reproducible right now (will change with deprecated image availability) with this playbook on 1.12.0:

```yaml
---
- name: Broken deprecated image
  hosts: localhost

  tasks:
    - name: Create a basic server with ssh key
      hcloud_server:
        allow_deprecated_image: true
        name: "broken"
        server_type: "cpx11"
        image: "ubuntu-18.04"
        location: "hel1"
```
