### PR TITLE
ci: ubuntu-18.04 is deprecated/EOL

### DIFF
--- a/plugins/modules/hcloud_image_info.py
+++ b/plugins/modules/hcloud_image_info.py
@@ -87,7 +87,7 @@ hcloud_image_info:
             description: Name of the image
             returned: always
             type: str
-            sample: ubuntu-18.04
+            sample: ubuntu-22.04
         description:
             description: Detail description of the image
             returned: always

--- a/plugins/modules/hcloud_server.py
+++ b/plugins/modules/hcloud_server.py
@@ -164,14 +164,14 @@ EXAMPLES = """
   hcloud_server:
     name: my-server
     server_type: cx11
-    image: ubuntu-18.04
+    image: ubuntu-22.04
     state: present
 
 - name: Create a basic server with ssh key
   hcloud_server:
     name: my-server
     server_type: cx11
-    image: ubuntu-18.04
+    image: ubuntu-22.04
     location: fsn1
     ssh_keys:
       - me@myorganisation
@@ -213,7 +213,7 @@ EXAMPLES = """
 - name: Ensure the server is rebuild
   hcloud_server:
     name: my-server
-    image: ubuntu-18.04
+    image: ubuntu-22.04
     state: rebuild
 
 - name: Add server to placement group

--- a/tests/integration/targets/hcloud_floating_ip/tasks/main.yml
+++ b/tests/integration/targets/hcloud_floating_ip/tasks/main.yml
@@ -5,7 +5,7 @@
   hcloud_server:
     name: "{{ hcloud_server_name }}"
     server_type: cx11
-    image: ubuntu-18.04
+    image: ubuntu-22.04
     state: started
     location: "fsn1"
   register: main_server
@@ -18,7 +18,7 @@
   hcloud_server:
     name: "{{ hcloud_server_name }}2"
     server_type: cx11
-    image: ubuntu-18.04
+    image: ubuntu-22.04
     state: started
   register: main_server2
 - name: verify setup another server

--- a/tests/integration/targets/hcloud_load_balancer_info/tasks/main.yml
+++ b/tests/integration/targets/hcloud_load_balancer_info/tasks/main.yml
@@ -9,7 +9,7 @@
   hcloud_server:
     name: "{{hcloud_server_name}}"
     server_type: cx11
-    image: ubuntu-20.04
+    image: ubuntu-22.04
     state: started
   register: server
 - name: verify setup server

--- a/tests/integration/targets/hcloud_load_balancer_target/tasks/main.yml
+++ b/tests/integration/targets/hcloud_load_balancer_target/tasks/main.yml
@@ -5,7 +5,7 @@
   hcloud_server:
     name: "{{hcloud_server_name}}"
     server_type: cx11
-    image: ubuntu-20.04
+    image: ubuntu-22.04
     state: started
     location: "fsn1"
   register: server

--- a/tests/integration/targets/hcloud_placement_group/tasks/main.yml
+++ b/tests/integration/targets/hcloud_placement_group/tasks/main.yml
@@ -66,7 +66,7 @@
     name: "{{ hcloud_server_name }}"
     server_type: cpx11
     placement_group: "{{ hcloud_placement_group_name }}"
-    image: "ubuntu-20.04"
+    image: "ubuntu-22.04"
     ssh_keys:
       - ci@ansible.hetzner.cloud
     state: present

--- a/tests/integration/targets/hcloud_server/tasks/basic.yml
+++ b/tests/integration/targets/hcloud_server/tasks/basic.yml
@@ -2,7 +2,7 @@
   hcloud_server:
     name: "{{ hcloud_server_name }}"
     server_type: cx11
-    image: ubuntu-20.04
+    image: ubuntu-22.04
     state: present
   register: result
   check_mode: yes
@@ -15,7 +15,7 @@
   hcloud_server:
     name: "{{ hcloud_server_name}}"
     server_type: cx11
-    image: ubuntu-20.04
+    image: ubuntu-22.04
     enable_ipv6: False
     state: started
   register: main_server
@@ -232,7 +232,7 @@
 - name: test rebuild server
   hcloud_server:
     name: "{{ hcloud_server_name }}"
-    image: ubuntu-20.04
+    image: ubuntu-22.04
     state: rebuild
   register: result_after_test
 - name: verify rebuild server
@@ -244,7 +244,7 @@
 - name: test rebuild server with check mode
   hcloud_server:
     name: "{{ hcloud_server_name }}"
-    image: ubuntu-20.04
+    image: ubuntu-22.04
     state: rebuild
   register: result_after_test
   check_mode: true
@@ -320,7 +320,7 @@
 - name: test rebuild server fails if it is protected
   hcloud_server:
     name: "{{hcloud_server_name}}"
-    image: ubuntu-20.04
+    image: ubuntu-22.04
     state: rebuild
   ignore_errors: yes
   register: result
@@ -359,7 +359,7 @@
   hcloud_server:
     name: "{{ hcloud_server_name}}"
     server_type: cx11
-    image: "ubuntu-20.04"
+    image: "ubuntu-22.04"
     ssh_keys:
       - ci@ansible.hetzner.cloud
     state: started
@@ -441,7 +441,7 @@
   hcloud_server:
     name: "{{ hcloud_server_name}}"
     server_type: cx11
-    image: "ubuntu-20.04"
+    image: "ubuntu-22.04"
     ssh_keys:
       - ci@ansible.hetzner.cloud
     rescue_mode: "linux64"
@@ -471,7 +471,7 @@
   hcloud_server:
     name: "{{ hcloud_server_name}}"
     server_type: cx11
-    image: "ubuntu-20.04"
+    image: "ubuntu-22.04"
     ssh_keys:
       - ci@ansible.hetzner.cloud
     labels:
@@ -490,7 +490,7 @@
   hcloud_server:
     name: "{{ hcloud_server_name}}"
     server_type: cx11
-    image: "ubuntu-20.04"
+    image: "ubuntu-22.04"
     ssh_keys:
       - ci@ansible.hetzner.cloud
     labels:
@@ -509,7 +509,7 @@
   hcloud_server:
     name: "{{ hcloud_server_name}}"
     server_type: cx11
-    image: "ubuntu-20.04"
+    image: "ubuntu-22.04"
     ssh_keys:
       - ci@ansible.hetzner.cloud
     labels:
@@ -537,7 +537,7 @@
     name: "{{ hcloud_server_name }}"
     server_type: cpx11
     backups: true
-    image: "ubuntu-20.04"
+    image: "ubuntu-22.04"
     ssh_keys:
       - ci@ansible.hetzner.cloud
     state: present
@@ -564,7 +564,7 @@
     delete_protection: true
     rebuild_protection: true
     server_type: cpx11
-    image: "ubuntu-20.04"
+    image: "ubuntu-22.04"
     ssh_keys:
       - ci@ansible.hetzner.cloud
     state: present

--- a/tests/integration/targets/hcloud_server/tasks/firewalls.yml
+++ b/tests/integration/targets/hcloud_server/tasks/firewalls.yml
@@ -33,7 +33,7 @@
     server_type: cpx11
     firewalls:
       - "{{ hcloud_firewall_name }}"
-    image: "ubuntu-20.04"
+    image: "ubuntu-22.04"
     ssh_keys:
       - ci@ansible.hetzner.cloud
     state: present
@@ -49,7 +49,7 @@
     server_type: cpx11
     firewalls:
       - "{{ hcloud_firewall_name }}"
-    image: "ubuntu-20.04"
+    image: "ubuntu-22.04"
     ssh_keys:
       - ci@ansible.hetzner.cloud
     state: present
@@ -65,7 +65,7 @@
     server_type: cpx11
     firewalls:
       - "{{ hcloud_firewall_name }}2"
-    image: "ubuntu-20.04"
+    image: "ubuntu-22.04"
     ssh_keys:
       - ci@ansible.hetzner.cloud
     state: present
@@ -81,7 +81,7 @@
     server_type: cpx11
     firewalls:
       - "{{ hcloud_firewall_name }}2"
-    image: "ubuntu-20.04"
+    image: "ubuntu-22.04"
     ssh_keys:
       - ci@ansible.hetzner.cloud
     state: present

--- a/tests/integration/targets/hcloud_server/tasks/primary_ips.yml
+++ b/tests/integration/targets/hcloud_server/tasks/primary_ips.yml
@@ -27,7 +27,7 @@
     name: "{{ hcloud_server_name }}"
     server_type: cpx11
     datacenter: "fsn1-dc14"
-    image: "ubuntu-20.04"
+    image: "ubuntu-22.04"
     ipv4: "{{primaryIPv4.hcloud_primary_ip.id}}"
     ipv6: "{{primaryIPv6.hcloud_primary_ip.id}}"
     ssh_keys:
@@ -44,7 +44,7 @@
     name: "{{ hcloud_server_name }}"
     server_type: cpx11
     datacenter: "fsn1-dc14"
-    image: "ubuntu-20.04"
+    image: "ubuntu-22.04"
     ipv4: "{{secondPrimaryIPv4.hcloud_primary_ip.id}}"
     ipv6: ""
     enable_ipv6: no

--- a/tests/integration/targets/hcloud_server/tasks/private_network_only.yml
+++ b/tests/integration/targets/hcloud_server/tasks/private_network_only.yml
@@ -65,7 +65,7 @@
     name: "{{ hcloud_server_name }}"
     server_type: cpx11
     datacenter: "fsn1-dc14"
-    image: "ubuntu-20.04"
+    image: "ubuntu-22.04"
     enable_ipv4: no
     enable_ipv6: no
     private_networks:
@@ -84,7 +84,7 @@
     name: "{{ hcloud_server_name }}"
     server_type: cpx11
     datacenter: "fsn1-dc14"
-    image: "ubuntu-20.04"
+    image: "ubuntu-22.04"
     enable_ipv4: no
     enable_ipv6: no
     private_networks:
@@ -104,7 +104,7 @@
     name: "{{ hcloud_server_name }}"
     server_type: cpx11
     datacenter: "fsn1-dc14"
-    image: "ubuntu-20.04"
+    image: "ubuntu-22.04"
     enable_ipv4: no
     enable_ipv6: no
     private_networks:

--- a/tests/integration/targets/hcloud_server/tasks/validation.yml
+++ b/tests/integration/targets/hcloud_server/tasks/validation.yml
@@ -26,7 +26,7 @@
   hcloud_server:
     name: "{{ hcloud_server_name }}"
     server_type: not-existing-server-type
-    image: ubuntu-20.04
+    image: ubuntu-22.04
     state: present
   register: result
   ignore_errors: yes

--- a/tests/integration/targets/hcloud_server_network/tasks/main.yml
+++ b/tests/integration/targets/hcloud_server_network/tasks/main.yml
@@ -29,7 +29,7 @@
   hcloud_server:
     name: "{{hcloud_server_name}}"
     server_type: cx11
-    image: ubuntu-18.04
+    image: ubuntu-22.04
     state: started
     location: "fsn1"
   register: server

--- a/tests/integration/targets/hcloud_ssh_key/tasks/main.yml
+++ b/tests/integration/targets/hcloud_ssh_key/tasks/main.yml
@@ -113,7 +113,7 @@
   hcloud_server:
     name: "{{ hcloud_server_name }}"
     server_type: cx11
-    image: "ubuntu-20.04"
+    image: "ubuntu-22.04"
     ssh_keys:
       - "{{ hcloud_ssh_key_name }}"
     state: started

--- a/tests/integration/targets/hcloud_volume/tasks/main.yml
+++ b/tests/integration/targets/hcloud_volume/tasks/main.yml
@@ -5,7 +5,7 @@
   hcloud_server:
     name: "{{hcloud_server_name}}"
     server_type: cx11
-    image: ubuntu-18.04
+    image: ubuntu-22.04
     state: started
     location: "fsn1"
   register: vol_server


### PR DESCRIPTION


##### SUMMARY
Update all references to ubuntu-18.04 (and 20.04) to 22.04, as ubuntu 18.04 is EOL and deprecated in Hetzner Cloud. This causes a CI failure in the main branch:

https://dev.azure.com/ansible/hetzner.hcloud/_build/results?buildId=80941&view=logs&j=fdb818b8-39d8-529a-d9da-324e304604bc&t=2d52cce2-88ce-5057-da88-145e92cee00f&l=1094
##### ISSUE TYPE

- Bugfix Pull Request


##### COMPONENT NAME
- CI

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->

CI Jobs fail with:

```
You try to use a deprecated image. The image ubuntu-18.04 will continue to be available until 2023-08-29. If you want to use this image use allow_deprecated_image=yes.
```
