### PR TITLE
docs: add note about python compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,13 @@
 [![Build Status](https://dev.azure.com/ansible/hetzner.hcloud/_apis/build/status/CI?branchName=master)](https://dev.azure.com/ansible/hetzner.hcloud/_build?definitionId=35)
 [![Codecov](https://img.shields.io/codecov/c/github/ansible-collections/hetzner.hcloud)](https://codecov.io/gh/ansible-collections/hetzner.hcloud)
 
-Ansible Collection: hetzner.hcloud
-=================================================
+# Ansible Collection: hetzner.hcloud
 
 Ansible Hetzner Cloud Collection for controlling your Hetzner Cloud Resources.
+
+### Python version compatibility
+
+This collection depends on the [hcloud](https://github.com/hetznercloud/hcloud-python) library. Due to the [hcloud](https://github.com/hetznercloud/hcloud-python) Python Support Policy this collection requires Python 3.7 or greater.
 
 ## Release notes
 


### PR DESCRIPTION
##### SUMMARY

Similarly to https://github.com/ansible-collections/amazon.aws#python-version-compatibility, add note about the python compatibility for the collection.

https://docs.ansible.com/ansible/devel/community/collection_contributors/collection_requirements.html#python-requirements

##### ISSUE TYPE

- Docs
