### PR TITLE
test: fix ansible-tests requirements file

### DIFF
--- a/tests/requirements.yml
+++ b/tests/requirements.yml
@@ -1,3 +1,3 @@
-integration_tests_dependencies:
+collections:
   - community.general
   - ansible.netcommon


### PR DESCRIPTION
##### SUMMARY

ansible-lint seem to complain about the yaml key used, if we want to have those requirements only for the integration tests, we should probably move the requirements.yml file inside the test/integrations folder.
