### PR TITLE
ci: fix gitlab pipeline not running 

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,3 +1,8 @@
+include:
+  - project: cloud/integrations/ci
+    file:
+      - default.yml
+
 stages:
   - lint
   - sanity

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -9,7 +9,7 @@ stages:
   - integration
 
 variables:
-  PYTHON_VERSION: "3.9"
+  PYTHON_VERSION: "3.10"
 
 default:
   image: python:$PYTHON_VERSION


### PR DESCRIPTION
##### SUMMARY

The CI pipeline is not running because of a missing tag.

I am moving the default GitLab pipeline config (job tags, job templates) to a shared repository.

Bumping the version of python to match the one used inside the azure pipeline testing container.