### PR TITLE
chore: setup the `stable-1` release branch

### DIFF
--- a/.azure-pipelines/azure-pipelines.yml
+++ b/.azure-pipelines/azure-pipelines.yml
@@ -1,22 +1,19 @@
 trigger:
   batch: true
   branches:
-    include:
-      - main
+    include: [main, stable-1]
 
 pr:
   autoCancel: true
   branches:
-    include:
-      - main
+    include: [main, stable-1]
 
 schedules:
   - cron: 0 9 * * *
     displayName: Nightly
     always: true
     branches:
-      include:
-        - main
+      include: [main, stable-1]
 
 variables:
   - name: checkoutPath

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -2,7 +2,7 @@ name: Lint
 
 on:
   push:
-    branches: [main]
+    branches: [main, stable-1]
   pull_request:
 
 jobs:

--- a/README.md
+++ b/README.md
@@ -13,6 +13,10 @@ This collection depends on the [hcloud](https://github.com/hetznercloud/hcloud-p
 
 See [here](https://github.com/ansible-collections/hetzner.hcloud/tree/master/CHANGELOG.rst).
 
+### Release policy
+
+The `main` branch is used for the development of the latest versions of the collections, and may contain breaking changes. The `stable-*` branches (e.g. `stable-1` for the `1.x.y` releases) are used to cut additional minor or patch releases if needed, but we do not provide official support for multiple versions of the collection.
+
 ## Documentation
 
 The documentation for all modules are available through `ansible-doc`.


### PR DESCRIPTION
##### SUMMARY

Now that the main branch is used to for the coming 2.x releases, the `stable-1` branch is used to allow any additional 1.x release.

This PR enables CI for the `stable-1` branch.