### PR TITLE
chore: add renovate regex manager for hcloud upgrades

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -6,5 +6,13 @@
 
     ":semanticCommitTypeAll(deps)",
     ":semanticCommitScopeDisabled"
+  ],
+  "regexManagers": [
+    {
+      "fileMatch": ["^scripts/vendor.py$"],
+      "matchStrings": ["HCLOUD_VERSION = \"v(?<currentValue>.*)\""],
+      "datasourceTemplate": "pypi",
+      "depNameTemplate": "hcloud"
+    }
   ]
 }


### PR DESCRIPTION
##### SUMMARY

Add a basic Renovate configuration file and instruct Renovate to upgrade the version of hcloud when a new version is available.

Related to #244

Renovate is not enabled on this repository, this PR is only relevant if we can run Renovate against this repository, either using the Github App or from an external setup.

Here is how it looks like: https://github.com/jooola/hetzner.hcloud/pull/1
