### PR TITLE
ci: use shared gitlab CI template

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,5 +1,10 @@
+include:
+  - project: cloud/integrations/ci
+    file:
+      - default.yml
+      - pre-commit.yml
+
 stages:
-  - lint
   - sanity
   - integration
 
@@ -8,16 +13,6 @@ variables:
 
 default:
   image: python:$PYTHON_VERSION
-
-pre-commit:
-  stage: lint
-
-  image: python:3.11-alpine
-  before_script:
-    - apk add build-base git
-    - pip install pre-commit
-  script:
-    - pre-commit run --all-files --show-diff-on-failure
 
 sanity:
   stage: sanity

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -9,7 +9,7 @@ stages:
   - integration
 
 variables:
-  PYTHON_VERSION: "3.9"
+  PYTHON_VERSION: "3.10"
 
 default:
   image: python:$PYTHON_VERSION


### PR DESCRIPTION
##### SUMMARY

I am moving the default GitLab pipeline config (job tags, job templates) to a shared repository.
