### PR TITLE
feat!: drop support for python3.7

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -31,7 +31,7 @@ repos:
     rev: v3.9.0
     hooks:
       - id: pyupgrade
-        args: [--py37-plus]
+        args: [--py38-plus]
 
   - repo: https://github.com/pycqa/isort
     rev: 5.12.0

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Ansible Hetzner Cloud Collection for controlling your Hetzner Cloud Resources.
 
 ### Python version compatibility
 
-This collection depends on the [hcloud](https://github.com/hetznercloud/hcloud-python) library. Due to the [hcloud](https://github.com/hetznercloud/hcloud-python) Python Support Policy this collection requires Python 3.7 or greater.
+This collection depends on the [hcloud](https://github.com/hetznercloud/hcloud-python) library. Due to the [hcloud](https://github.com/hetznercloud/hcloud-python) Python Support Policy this collection requires Python 3.8 or greater.
 
 ## Release notes
 

--- a/changelogs/fragments/drop-support-for-python-3.7.yml
+++ b/changelogs/fragments/drop-support-for-python-3.7.yml
@@ -1,0 +1,2 @@
+breaking_changes:
+  - Drop support for python 3.7

--- a/tests/config.yml
+++ b/tests/config.yml
@@ -1,3 +1,3 @@
 ---
 modules:
-  python_requires: ">=3.7"
+  python_requires: ">=3.8"


### PR DESCRIPTION
##### SUMMARY

Drop support for python 3.7, this is a preparation work to be able to land https://github.com/hetznercloud/hcloud-python/pull/242.


##### ISSUE TYPE

- Feature Pull Request
