### PR TITLE
test: ensure ressources are not shared across tests

### DIFF
--- a/tests/integration/targets/hcloud_certificate/defaults/main.yml
+++ b/tests/integration/targets/hcloud_certificate/defaults/main.yml
@@ -2,5 +2,5 @@
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 ---
 hcloud_prefix: "tests"
-hcloud_certificate_name: "{{hcloud_prefix}}-integration"
+hcloud_certificate_name: "{{hcloud_prefix}}-{{ role_name }}"
 hcloud_dns_test_domain: "{{hcloud_prefix | truncate(19, False, 'ans')}}-{{100 | random }}.hc-certs.de"

--- a/tests/integration/targets/hcloud_firewall/defaults/main.yml
+++ b/tests/integration/targets/hcloud_firewall/defaults/main.yml
@@ -2,4 +2,4 @@
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 ---
 hcloud_prefix: "tests"
-hcloud_firewall_name: "{{hcloud_prefix}}-integration"
+hcloud_firewall_name: "{{hcloud_prefix}}-{{ role_name }}"

--- a/tests/integration/targets/hcloud_floating_ip/defaults/main.yml
+++ b/tests/integration/targets/hcloud_floating_ip/defaults/main.yml
@@ -2,5 +2,5 @@
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 ---
 hcloud_prefix: "tests"
-hcloud_floating_ip_name: "{{hcloud_prefix}}-i"
-hcloud_server_name: "{{ hcloud_prefix | truncate(45, True, '', 0) }}-fip-t"
+hcloud_floating_ip_name: "{{hcloud_prefix}}-{{ role_name }}"
+hcloud_server_name: "{{ hcloud_prefix | truncate(45, True, '', 0) }}-{{ role_name }}"

--- a/tests/integration/targets/hcloud_floating_ip_info/defaults/main.yml
+++ b/tests/integration/targets/hcloud_floating_ip_info/defaults/main.yml
@@ -2,4 +2,4 @@
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 ---
 hcloud_prefix: "tests"
-hcloud_floating_ip_name: "{{hcloud_prefix}}-i"
+hcloud_floating_ip_name: "{{hcloud_prefix}}-{{ role_name }}"

--- a/tests/integration/targets/hcloud_load_balancer/defaults/main.yml
+++ b/tests/integration/targets/hcloud_load_balancer/defaults/main.yml
@@ -2,4 +2,4 @@
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 ---
 hcloud_prefix: "tests"
-hcloud_load_balancer_name: "{{hcloud_prefix}}-i"
+hcloud_load_balancer_name: "{{hcloud_prefix}}-{{ role_name }}"

--- a/tests/integration/targets/hcloud_load_balancer_info/defaults/main.yml
+++ b/tests/integration/targets/hcloud_load_balancer_info/defaults/main.yml
@@ -2,5 +2,5 @@
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 ---
 hcloud_prefix: "tests"
-hcloud_load_balancer_name: "{{hcloud_prefix}}-i"
-hcloud_server_name: "{{ hcloud_prefix | truncate(45, True, '', 0) }}-lb-i"
+hcloud_load_balancer_name: "{{hcloud_prefix}}-{{ role_name }}"
+hcloud_server_name: "{{ hcloud_prefix | truncate(45, True, '', 0) }}-{{ role_name }}"

--- a/tests/integration/targets/hcloud_load_balancer_network/defaults/main.yml
+++ b/tests/integration/targets/hcloud_load_balancer_network/defaults/main.yml
@@ -2,5 +2,5 @@
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 ---
 hcloud_prefix: "tests"
-hcloud_network_name: "{{hcloud_prefix}}-lb-n"
-hcloud_load_balancer_name: "{{hcloud_prefix}}-lb-n"
+hcloud_network_name: "{{hcloud_prefix}}-{{ role_name }}"
+hcloud_load_balancer_name: "{{hcloud_prefix}}-{{ role_name }}"

--- a/tests/integration/targets/hcloud_load_balancer_service/defaults/main.yml
+++ b/tests/integration/targets/hcloud_load_balancer_service/defaults/main.yml
@@ -2,4 +2,4 @@
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 ---
 hcloud_prefix: "tests"
-hcloud_load_balancer_name: "{{hcloud_prefix}}-lb-target"
+hcloud_load_balancer_name: "{{hcloud_prefix}}-{{ role_name }}"

--- a/tests/integration/targets/hcloud_load_balancer_target/defaults/main.yml
+++ b/tests/integration/targets/hcloud_load_balancer_target/defaults/main.yml
@@ -2,6 +2,6 @@
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 ---
 hcloud_prefix: "tests"
-hcloud_server_name: "{{ hcloud_prefix | truncate(45, True, '', 0) }}-lb-t"
-hcloud_load_balancer_name: "{{hcloud_prefix}}-lb-target"
+hcloud_server_name: "{{ hcloud_prefix | truncate(45, True, '', 0) }}-{{ role_name }}"
+hcloud_load_balancer_name: "{{hcloud_prefix}}-{{ role_name }}"
 hcloud_testing_ip: "176.9.59.39"

--- a/tests/integration/targets/hcloud_network/defaults/main.yml
+++ b/tests/integration/targets/hcloud_network/defaults/main.yml
@@ -2,6 +2,6 @@
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 ---
 hcloud_prefix: "tests"
-hcloud_network_name: "{{hcloud_prefix}}-i"
+hcloud_network_name: "{{hcloud_prefix}}-{{ role_name }}"
 
-hcloud_network_name_with_vswitch: "{{hcloud_prefix}}-i-vswitch"
+hcloud_network_name_with_vswitch: "{{hcloud_prefix}}-{{ role_name }}-vswitch"

--- a/tests/integration/targets/hcloud_network_info/defaults/main.yml
+++ b/tests/integration/targets/hcloud_network_info/defaults/main.yml
@@ -2,4 +2,4 @@
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 ---
 hcloud_prefix: "tests"
-hcloud_network_name: "{{hcloud_prefix}}-integration"
+hcloud_network_name: "{{hcloud_prefix}}-{{ role_name }}"

--- a/tests/integration/targets/hcloud_placement_group/defaults/main.yml
+++ b/tests/integration/targets/hcloud_placement_group/defaults/main.yml
@@ -2,5 +2,5 @@
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 ---
 hcloud_prefix: "tests"
-hcloud_placement_group_name: "{{hcloud_prefix}}-i"
-hcloud_server_name: "{{ hcloud_prefix | truncate(45, True, '', 0) }}-i"
+hcloud_placement_group_name: "{{hcloud_prefix}}-{{ role_name }}"
+hcloud_server_name: "{{ hcloud_prefix | truncate(45, True, '', 0) }}-{{ role_name }}"

--- a/tests/integration/targets/hcloud_primary_ip/defaults/main.yml
+++ b/tests/integration/targets/hcloud_primary_ip/defaults/main.yml
@@ -2,5 +2,5 @@
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 ---
 hcloud_prefix: "tests"
-hcloud_primary_ip_name: "{{hcloud_prefix}}-i"
-hcloud_server_name: "{{ hcloud_prefix | truncate(45, True, '', 0) }}-fip-t"
+hcloud_primary_ip_name: "{{hcloud_prefix}}-{{ role_name }}"
+hcloud_server_name: "{{ hcloud_prefix | truncate(45, True, '', 0) }}-{{ role_name }}"

--- a/tests/integration/targets/hcloud_primary_ip_info/defaults/main.yml
+++ b/tests/integration/targets/hcloud_primary_ip_info/defaults/main.yml
@@ -2,4 +2,4 @@
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 ---
 hcloud_prefix: "tests"
-hcloud_primary_ip_name: "{{hcloud_prefix}}-i"
+hcloud_primary_ip_name: "{{hcloud_prefix}}-{{ role_name }}"

--- a/tests/integration/targets/hcloud_rdns/defaults/main.yml
+++ b/tests/integration/targets/hcloud_rdns/defaults/main.yml
@@ -2,7 +2,7 @@
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 ---
 hcloud_prefix: "tests"
-hcloud_server_name: "{{ hcloud_prefix | truncate(45, True, '', 0) }}"
-hcloud_floating_ip_name: "{{hcloud_prefix}}"
-hcloud_primary_ip_name: "{{hcloud_prefix}}"
-hcloud_load_balancer_name: "{{hcloud_prefix}}"
+hcloud_server_name: "{{ hcloud_prefix | truncate(45, True, '', 0) }}-{{ role_name }}"
+hcloud_floating_ip_name: "{{hcloud_prefix}}-{{ role_name }}"
+hcloud_primary_ip_name: "{{hcloud_prefix}}-{{ role_name }}"
+hcloud_load_balancer_name: "{{hcloud_prefix}}-{{ role_name }}"

--- a/tests/integration/targets/hcloud_route/defaults/main.yml
+++ b/tests/integration/targets/hcloud_route/defaults/main.yml
@@ -2,4 +2,4 @@
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 ---
 hcloud_prefix: "tests"
-hcloud_network_name: "{{hcloud_prefix}}-ro"
+hcloud_network_name: "{{hcloud_prefix}}-{{ role_name }}"

--- a/tests/integration/targets/hcloud_server/defaults/main.yml
+++ b/tests/integration/targets/hcloud_server/defaults/main.yml
@@ -2,7 +2,7 @@
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 ---
 hcloud_prefix: "tests"
-hcloud_server_name: "{{ hcloud_prefix | truncate(45, True, '', 0) }}-i"
-hcloud_firewall_name: "{{hcloud_prefix}}-i"
-hcloud_primary_ip_name: "{{hcloud_prefix}}-i"
-hcloud_network_name: "{{hcloud_prefix}}-i"
+hcloud_server_name: "{{ hcloud_prefix | truncate(45, True, '', 0) }}-{{ role_name }}"
+hcloud_firewall_name: "{{hcloud_prefix}}-{{ role_name }}"
+hcloud_primary_ip_name: "{{hcloud_prefix}}-{{ role_name }}"
+hcloud_network_name: "{{hcloud_prefix}}-{{ role_name }}"

--- a/tests/integration/targets/hcloud_server_info/defaults/main.yml
+++ b/tests/integration/targets/hcloud_server_info/defaults/main.yml
@@ -2,4 +2,4 @@
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 ---
 hcloud_prefix: "tests"
-hcloud_server_name: "{{ hcloud_prefix | truncate(45, True, '', 0) }}-ii"
+hcloud_server_name: "{{ hcloud_prefix | truncate(45, True, '', 0) }}-{{ role_name }}"

--- a/tests/integration/targets/hcloud_server_network/defaults/main.yml
+++ b/tests/integration/targets/hcloud_server_network/defaults/main.yml
@@ -2,5 +2,5 @@
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 ---
 hcloud_prefix: "tests"
-hcloud_network_name: "{{hcloud_prefix}}-sn"
-hcloud_server_name: "{{ hcloud_prefix | truncate(45, True, '', 0) }}-sn"
+hcloud_network_name: "{{hcloud_prefix}}-{{ role_name }}"
+hcloud_server_name: "{{ hcloud_prefix | truncate(45, True, '', 0) }}-{{ role_name }}"

--- a/tests/integration/targets/hcloud_ssh_key/defaults/main.yml
+++ b/tests/integration/targets/hcloud_ssh_key/defaults/main.yml
@@ -2,8 +2,8 @@
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 ---
 hcloud_prefix: "tests"
-hcloud_server_name: "{{ hcloud_prefix | truncate(45, True, '', 0) }}"
-hcloud_ssh_key_name: "{{hcloud_prefix}}"
+hcloud_server_name: "{{ hcloud_prefix | truncate(45, True, '', 0) }}-{{ role_name }}"
+hcloud_ssh_key_name: "{{hcloud_prefix}}-{{ role_name }}"
 hcloud_ssh_key_public_key: "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDnaTPfKaX1QKcRLOfr34buVLh5FhJAThI9NYB0xNdXsMd4Y0zLyyCQzHbx4eWCVZxym/s6csWSeLaAhO1GOHeAw3hQFMqf1oTBx6Y8g0pKpeotKPa/PDSUzdZF9Lc+DadtpQd8kFVHAu1Kd3zoEUnk1u6kP7I4qu4Z/6F9qBDF+M3aobiPVxdS7GwaVRW3nZu+FcQDLiBiNOjuRDyjHcDfEUkoh2SOu25RrFtGPzFu5mGmBJwotKpWAocLGfHzyn/fAHxgw3jKZVH/t+XWQFnl82Ie8yE3Z1EZ7oDkNRqFQT9AdXEQOLycTTYTQMJZpgeFTv3sAo6lPRCusiFmmLcf ci@ansible.hetzner.cloud"
 hcloud_ssh_key_fingerprint: "56:89:c4:d6:a7:4a:79:82:f4:c2:58:9c:e1:d2:2d:4e"
 

--- a/tests/integration/targets/hcloud_ssh_key_info/defaults/main.yml
+++ b/tests/integration/targets/hcloud_ssh_key_info/defaults/main.yml
@@ -2,4 +2,4 @@
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 ---
 hcloud_prefix: "tests"
-hcloud_ssh_key_name: "{{hcloud_prefix}}-f"
+hcloud_ssh_key_name: "{{hcloud_prefix}}-{{ role_name }}"

--- a/tests/integration/targets/hcloud_subnetwork/defaults/main.yml
+++ b/tests/integration/targets/hcloud_subnetwork/defaults/main.yml
@@ -2,5 +2,5 @@
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 ---
 hcloud_prefix: "tests"
-hcloud_network_name: "{{hcloud_prefix}}-s"
+hcloud_network_name: "{{hcloud_prefix}}-{{ role_name }}"
 hetzner_vswitch_id: 15311

--- a/tests/integration/targets/hcloud_volume/defaults/main.yml
+++ b/tests/integration/targets/hcloud_volume/defaults/main.yml
@@ -2,5 +2,5 @@
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 ---
 hcloud_prefix: "tests"
-hcloud_volume_name: "{{ hcloud_prefix | truncate(60, True, '', 0) }}-i"
-hcloud_server_name: "{{ hcloud_prefix | truncate(45, True, '', 0) }}-vs"
+hcloud_volume_name: "{{ hcloud_prefix | truncate(60, True, '', 0) }}-{{ role_name }}"
+hcloud_server_name: "{{ hcloud_prefix | truncate(45, True, '', 0) }}-{{ role_name }}"

--- a/tests/integration/targets/hcloud_volume_info/defaults/main.yml
+++ b/tests/integration/targets/hcloud_volume_info/defaults/main.yml
@@ -2,4 +2,4 @@
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 ---
 hcloud_prefix: "tests"
-hcloud_volume_name: "{{ hcloud_prefix | truncate(60, True, '', 0) }}-i"
+hcloud_volume_name: "{{ hcloud_prefix | truncate(60, True, '', 0) }}-{{ role_name }}"


### PR DESCRIPTION
##### SUMMARY

This should reduce the amount of duplicate/overlapping resources names across tests.

