### PR TITLE
chore: use fqcn module names

### DIFF
--- a/plugins/modules/hcloud_certificate.py
+++ b/plugins/modules/hcloud_certificate.py
@@ -68,14 +68,14 @@ extends_documentation_fragment:
 
 EXAMPLES = """
 - name: Create a basic certificate
-  hcloud_certificate:
+  hetzner.hcloud.hcloud_certificate:
     name: my-certificate
     certificate: "ssh-rsa AAAjjk76kgf...Xt"
     private_key: "ssh-rsa AAAjjk76kgf...Xt"
     state: present
 
 - name: Create a certificate with labels
-  hcloud_certificate:
+  hetzner.hcloud.hcloud_certificate:
     name: my-certificate
     certificate: "ssh-rsa AAAjjk76kgf...Xt"
     private_key: "ssh-rsa AAAjjk76kgf...Xt"
@@ -85,7 +85,7 @@ EXAMPLES = """
     state: present
 
 - name: Ensure the certificate is absent (remove if needed)
-  hcloud_certificate:
+  hetzner.hcloud.hcloud_certificate:
     name: my-certificate
     state: absent
 """

--- a/plugins/modules/hcloud_certificate_info.py
+++ b/plugins/modules/hcloud_certificate_info.py
@@ -32,7 +32,7 @@ extends_documentation_fragment:
 
 EXAMPLES = """
 - name: Gather hcloud certificate infos
-  hcloud_certificate_info:
+  hetzner.hcloud.hcloud_certificate_info:
   register: output
 - name: Print the gathered infos
   debug:

--- a/plugins/modules/hcloud_datacenter_info.py
+++ b/plugins/modules/hcloud_datacenter_info.py
@@ -32,7 +32,7 @@ extends_documentation_fragment:
 
 EXAMPLES = """
 - name: Gather hcloud datacenter info
-  hcloud_datacenter_info:
+  hetzner.hcloud.hcloud_datacenter_info:
   register: output
 - name: Print the gathered info
   debug:

--- a/plugins/modules/hcloud_firewall.py
+++ b/plugins/modules/hcloud_firewall.py
@@ -80,12 +80,12 @@ extends_documentation_fragment:
 
 EXAMPLES = """
 - name: Create a basic firewall
-  hcloud_firewall:
+  hetzner.hcloud.hcloud_firewall:
     name: my-firewall
     state: present
 
 - name: Create a firewall with rules
-  hcloud_firewall:
+  hetzner.hcloud.hcloud_firewall:
     name: my-firewall
     rules:
        - direction: in
@@ -97,7 +97,7 @@ EXAMPLES = """
     state: present
 
 - name: Create a firewall with labels
-  hcloud_firewall:
+  hetzner.hcloud.hcloud_firewall:
     name: my-firewall
     labels:
         key: value
@@ -105,7 +105,7 @@ EXAMPLES = """
     state: present
 
 - name: Ensure the firewall is absent (remove if needed)
-  hcloud_firewall:
+  hetzner.hcloud.hcloud_firewall:
     name: my-firewall
     state: absent
 """

--- a/plugins/modules/hcloud_floating_ip.py
+++ b/plugins/modules/hcloud_floating_ip.py
@@ -77,30 +77,30 @@ extends_documentation_fragment:
 
 EXAMPLES = """
 - name: Create a basic IPv4 Floating IP
-  hcloud_floating_ip:
+  hetzner.hcloud.hcloud_floating_ip:
     name: my-floating-ip
     home_location: fsn1
     type: ipv4
     state: present
 - name: Create a basic IPv6 Floating IP
-  hcloud_floating_ip:
+  hetzner.hcloud.hcloud_floating_ip:
     name: my-floating-ip
     home_location: fsn1
     type: ipv6
     state: present
 - name: Assign a Floating IP to a server
-  hcloud_floating_ip:
+  hetzner.hcloud.hcloud_floating_ip:
     name: my-floating-ip
     server: 1234
     state: present
 - name: Assign a Floating IP to another server
-  hcloud_floating_ip:
+  hetzner.hcloud.hcloud_floating_ip:
     name: my-floating-ip
     server: 1234
     force: true
     state: present
 - name: Floating IP should be absent
-  hcloud_floating_ip:
+  hetzner.hcloud.hcloud_floating_ip:
     name: my-floating-ip
     state: absent
 """

--- a/plugins/modules/hcloud_floating_ip_info.py
+++ b/plugins/modules/hcloud_floating_ip_info.py
@@ -32,7 +32,7 @@ extends_documentation_fragment:
 
 EXAMPLES = """
 - name: Gather hcloud Floating ip infos
-  hcloud_floating_ip_info:
+  hetzner.hcloud.hcloud_floating_ip_info:
   register: output
 - name: Print the gathered infos
   debug:

--- a/plugins/modules/hcloud_image_info.py
+++ b/plugins/modules/hcloud_image_info.py
@@ -48,7 +48,7 @@ extends_documentation_fragment:
 
 EXAMPLES = """
 - name: Gather hcloud image infos
-  hcloud_image_info:
+  hetzner.hcloud.hcloud_image_info:
   register: output
 
 - name: Print the gathered infos

--- a/plugins/modules/hcloud_iso_info.py
+++ b/plugins/modules/hcloud_iso_info.py
@@ -44,7 +44,7 @@ extends_documentation_fragment:
 
 EXAMPLES = """
 - name: Gather hcloud ISO type infos
-  hcloud_iso_info:
+  hetzner.hcloud.hcloud_iso_info:
   register: output
 
 - name: Print the gathered infos

--- a/plugins/modules/hcloud_load_balancer.py
+++ b/plugins/modules/hcloud_load_balancer.py
@@ -71,14 +71,14 @@ requirements:
 
 EXAMPLES = """
 - name: Create a basic Load Balancer
-  hcloud_load_balancer:
+  hetzner.hcloud.hcloud_load_balancer:
     name: my-Load Balancer
     load_balancer_type: lb11
     location: fsn1
     state: present
 
 - name: Ensure the Load Balancer is absent (remove if needed)
-  hcloud_load_balancer:
+  hetzner.hcloud.hcloud_load_balancer:
     name: my-Load Balancer
     state: absent
 

--- a/plugins/modules/hcloud_load_balancer_info.py
+++ b/plugins/modules/hcloud_load_balancer_info.py
@@ -37,7 +37,7 @@ extends_documentation_fragment:
 
 EXAMPLES = """
 - name: Gather hcloud load_balancer infos
-  hcloud_load_balancer_info:
+  hetzner.hcloud.hcloud_load_balancer_info:
   register: output
 
 - name: Print the gathered infos

--- a/plugins/modules/hcloud_load_balancer_network.py
+++ b/plugins/modules/hcloud_load_balancer_network.py
@@ -49,20 +49,20 @@ extends_documentation_fragment:
 
 EXAMPLES = """
 - name: Create a basic Load Balancer network
-  hcloud_load_balancer_network:
+  hetzner.hcloud.hcloud_load_balancer_network:
     network: my-network
     load_balancer: my-LoadBalancer
     state: present
 
 - name: Create a Load Balancer network and specify the ip address
-  hcloud_load_balancer_network:
+  hetzner.hcloud.hcloud_load_balancer_network:
     network: my-network
     load_balancer: my-LoadBalancer
     ip: 10.0.0.1
     state: present
 
 - name: Ensure the Load Balancer network is absent (remove if needed)
-  hcloud_load_balancer_network:
+  hetzner.hcloud.hcloud_load_balancer_network:
     network: my-network
     load_balancer: my-LoadBalancer
     state: absent

--- a/plugins/modules/hcloud_load_balancer_service.py
+++ b/plugins/modules/hcloud_load_balancer_service.py
@@ -140,14 +140,14 @@ requirements:
 
 EXAMPLES = """
 - name: Create a basic Load Balancer service with Port 80
-  hcloud_load_balancer_service:
+  hetzner.hcloud.hcloud_load_balancer_service:
     load_balancer: my-load-balancer
     protocol: http
     listen_port: 80
     state: present
 
 - name: Ensure the Load Balancer is absent (remove if needed)
-  hcloud_load_balancer_service:
+  hetzner.hcloud.hcloud_load_balancer_service:
     load_balancer: my-Load Balancer
     protocol: http
     listen_port: 80

--- a/plugins/modules/hcloud_load_balancer_type_info.py
+++ b/plugins/modules/hcloud_load_balancer_type_info.py
@@ -33,7 +33,7 @@ extends_documentation_fragment:
 
 EXAMPLES = """
 - name: Gather hcloud Load Balancer type infos
-  hcloud_load_balancer_type_info:
+  hetzner.hcloud.hcloud_load_balancer_type_info:
   register: output
 
 - name: Print the gathered infos

--- a/plugins/modules/hcloud_location_info.py
+++ b/plugins/modules/hcloud_location_info.py
@@ -33,7 +33,7 @@ extends_documentation_fragment:
 
 EXAMPLES = """
 - name: Gather hcloud location infos
-  hcloud_location_info:
+  hetzner.hcloud.hcloud_location_info:
   register: output
 
 - name: Print the gathered infos

--- a/plugins/modules/hcloud_network.py
+++ b/plugins/modules/hcloud_network.py
@@ -64,13 +64,13 @@ extends_documentation_fragment:
 
 EXAMPLES = """
 - name: Create a basic network
-  hcloud_network:
+  hetzner.hcloud.hcloud_network:
     name: my-network
     ip_range: 10.0.0.0/8
     state: present
 
 - name: Ensure the Network is absent (remove if needed)
-  hcloud_network:
+  hetzner.hcloud.hcloud_network:
     name: my-network
     state: absent
 """

--- a/plugins/modules/hcloud_placement_group.py
+++ b/plugins/modules/hcloud_placement_group.py
@@ -52,13 +52,13 @@ extends_documentation_fragment:
 
 EXAMPLES = """
 - name: Create a basic placement group
-  hcloud_placement_group:
+  hetzner.hcloud.hcloud_placement_group:
     name: my-placement-group
     state: present
     type: spread
 
 - name: Create a placement group with labels
-  hcloud_placement_group:
+  hetzner.hcloud.hcloud_placement_group:
     name: my-placement-group
     type: spread
     labels:
@@ -67,7 +67,7 @@ EXAMPLES = """
     state: present
 
 - name: Ensure the placement group is absent (remove if needed)
-  hcloud_placement_group:
+  hetzner.hcloud.hcloud_placement_group:
     name: my-placement-group
     state: absent
 """

--- a/plugins/modules/hcloud_primary_ip.py
+++ b/plugins/modules/hcloud_primary_ip.py
@@ -69,19 +69,19 @@ extends_documentation_fragment:
 
 EXAMPLES = """
 - name: Create a basic IPv4 Primary IP
-  hcloud_primary_ip:
+  hetzner.hcloud.hcloud_primary_ip:
     name: my-primary-ip
     datacenter: fsn1-dc14
     type: ipv4
     state: present
 - name: Create a basic IPv6 Primary IP
-  hcloud_primary_ip:
+  hetzner.hcloud.hcloud_primary_ip:
     name: my-primary-ip
     datacenter: fsn1-dc14
     type: ipv6
     state: present
 - name: Primary IP should be absent
-  hcloud_primary_ip:
+  hetzner.hcloud.hcloud_primary_ip:
     name: my-primary-ip
     state: absent
 """

--- a/plugins/modules/hcloud_primary_ip_info.py
+++ b/plugins/modules/hcloud_primary_ip_info.py
@@ -37,21 +37,21 @@ extends_documentation_fragment:
 
 EXAMPLES = """
 - name: Gather hcloud Primary IP infos
-  hcloud_primary_ip_info:
+  hetzner.hcloud.hcloud_primary_ip_info:
   register: output
 
 - name: Gather hcloud Primary IP infos by id
-  hcloud_primary_ip_info:
+  hetzner.hcloud.hcloud_primary_ip_info:
     id: 673954
   register: output
 
 - name: Gather hcloud Primary IP infos by name
-  hcloud_primary_ip_info:
+  hetzner.hcloud.hcloud_primary_ip_info:
     name: srv1-v4
   register: output
 
 - name: Gather hcloud Primary IP infos by label
-  hcloud_primary_ip_info:
+  hetzner.hcloud.hcloud_primary_ip_info:
     label_selector: srv03-ips
   register: output
 

--- a/plugins/modules/hcloud_rdns.py
+++ b/plugins/modules/hcloud_rdns.py
@@ -61,35 +61,35 @@ extends_documentation_fragment:
 
 EXAMPLES = """
 - name: Create a reverse DNS entry for a server
-  hcloud_rdns:
+  hetzner.hcloud.hcloud_rdns:
     server: my-server
     ip_address: 123.123.123.123
     dns_ptr: example.com
     state: present
 
 - name: Create a reverse DNS entry for a Floating IP
-  hcloud_rdns:
+  hetzner.hcloud.hcloud_rdns:
     floating_ip: my-floating-ip
     ip_address: 123.123.123.123
     dns_ptr: example.com
     state: present
 
 - name: Create a reverse DNS entry for a Primary IP
-  hcloud_rdns:
+  hetzner.hcloud.hcloud_rdns:
     primary_ip: my-primary-ip
     ip_address: 123.123.123.123
     dns_ptr: example.com
     state: present
 
 - name: Create a reverse DNS entry for a Load Balancer
-  hcloud_rdns:
+  hetzner.hcloud.hcloud_rdns:
     load_balancer: my-load-balancer
     ip_address: 123.123.123.123
     dns_ptr: example.com
     state: present
 
 - name: Ensure the reverse DNS entry is absent (remove if needed)
-  hcloud_rdns:
+  hetzner.hcloud.hcloud_rdns:
     server: my-server
     ip_address: 123.123.123.123
     dns_ptr: example.com

--- a/plugins/modules/hcloud_route.py
+++ b/plugins/modules/hcloud_route.py
@@ -50,14 +50,14 @@ extends_documentation_fragment:
 
 EXAMPLES = """
 - name: Create a basic route
-  hcloud_route:
+  hetzner.hcloud.hcloud_route:
     network: my-network
     destination: 10.100.1.0/24
     gateway: 10.0.1.1
     state: present
 
 - name: Ensure the route is absent
-  hcloud_route:
+  hetzner.hcloud.hcloud_route:
     network: my-network
     destination: 10.100.1.0/24
     gateway: 10.0.1.1

--- a/plugins/modules/hcloud_server.py
+++ b/plugins/modules/hcloud_server.py
@@ -157,14 +157,14 @@ extends_documentation_fragment:
 
 EXAMPLES = """
 - name: Create a basic server
-  hcloud_server:
+  hetzner.hcloud.hcloud_server:
     name: my-server
     server_type: cx11
     image: ubuntu-22.04
     state: present
 
 - name: Create a basic server with ssh key
-  hcloud_server:
+  hetzner.hcloud.hcloud_server:
     name: my-server
     server_type: cx11
     image: ubuntu-22.04
@@ -174,59 +174,59 @@ EXAMPLES = """
     state: present
 
 - name: Resize an existing server
-  hcloud_server:
+  hetzner.hcloud.hcloud_server:
     name: my-server
     server_type: cx21
     upgrade_disk: true
     state: present
 
 - name: Ensure the server is absent (remove if needed)
-  hcloud_server:
+  hetzner.hcloud.hcloud_server:
     name: my-server
     state: absent
 
 - name: Ensure the server is started
-  hcloud_server:
+  hetzner.hcloud.hcloud_server:
     name: my-server
     state: started
 
 - name: Ensure the server is stopped
-  hcloud_server:
+  hetzner.hcloud.hcloud_server:
     name: my-server
     state: stopped
 
 - name: Ensure the server is restarted
-  hcloud_server:
+  hetzner.hcloud.hcloud_server:
     name: my-server
     state: restarted
 
 - name: Ensure the server is will be booted in rescue mode and therefore restarted
-  hcloud_server:
+  hetzner.hcloud.hcloud_server:
     name: my-server
     rescue_mode: linux64
     state: restarted
 
 - name: Ensure the server is rebuild
-  hcloud_server:
+  hetzner.hcloud.hcloud_server:
     name: my-server
     image: ubuntu-22.04
     state: rebuild
 
 - name: Add server to placement group
-  hcloud_server:
+  hetzner.hcloud.hcloud_server:
     name: my-server
     placement_group: my-placement-group
     force: True
     state: present
 
 - name: Remove server from placement group
-  hcloud_server:
+  hetzner.hcloud.hcloud_server:
     name: my-server
     placement_group: null
     state: present
 
 - name: Add server with private network only
-  hcloud_server:
+  hetzner.hcloud.hcloud_server:
     name: my-server
     enable_ipv4: false
     enable_ipv6: false

--- a/plugins/modules/hcloud_server_info.py
+++ b/plugins/modules/hcloud_server_info.py
@@ -37,7 +37,7 @@ extends_documentation_fragment:
 
 EXAMPLES = """
 - name: Gather hcloud server infos
-  hcloud_server_info:
+  hetzner.hcloud.hcloud_server_info:
   register: output
 
 - name: Print the gathered infos

--- a/plugins/modules/hcloud_server_network.py
+++ b/plugins/modules/hcloud_server_network.py
@@ -54,20 +54,20 @@ extends_documentation_fragment:
 
 EXAMPLES = """
 - name: Create a basic server network
-  hcloud_server_network:
+  hetzner.hcloud.hcloud_server_network:
     network: my-network
     server: my-server
     state: present
 
 - name: Create a server network and specify the ip address
-  hcloud_server_network:
+  hetzner.hcloud.hcloud_server_network:
     network: my-network
     server: my-server
     ip: 10.0.0.1
     state: present
 
 - name: Create a server network and add alias ips
-  hcloud_server_network:
+  hetzner.hcloud.hcloud_server_network:
     network: my-network
     server: my-server
     ip: 10.0.0.1
@@ -77,7 +77,7 @@ EXAMPLES = """
     state: present
 
 - name: Ensure the server network is absent (remove if needed)
-  hcloud_server_network:
+  hetzner.hcloud.hcloud_server_network:
     network: my-network
     server: my-server
     state: absent

--- a/plugins/modules/hcloud_server_type_info.py
+++ b/plugins/modules/hcloud_server_type_info.py
@@ -33,7 +33,7 @@ extends_documentation_fragment:
 
 EXAMPLES = """
 - name: Gather hcloud server type infos
-  hcloud_server_type_info:
+  hetzner.hcloud.hcloud_server_type_info:
   register: output
 
 - name: Print the gathered infos

--- a/plugins/modules/hcloud_ssh_key.py
+++ b/plugins/modules/hcloud_ssh_key.py
@@ -55,13 +55,13 @@ extends_documentation_fragment:
 
 EXAMPLES = """
 - name: Create a basic ssh_key
-  hcloud_ssh_key:
+  hetzner.hcloud.hcloud_ssh_key:
     name: my-ssh_key
     public_key: "ssh-rsa AAAjjk76kgf...Xt"
     state: present
 
 - name: Create a ssh_key with labels
-  hcloud_ssh_key:
+  hetzner.hcloud.hcloud_ssh_key:
     name: my-ssh_key
     public_key: "ssh-rsa AAAjjk76kgf...Xt"
     labels:
@@ -70,7 +70,7 @@ EXAMPLES = """
     state: present
 
 - name: Ensure the ssh_key is absent (remove if needed)
-  hcloud_ssh_key:
+  hetzner.hcloud.hcloud_ssh_key:
     name: my-ssh_key
     state: absent
 """

--- a/plugins/modules/hcloud_ssh_key_info.py
+++ b/plugins/modules/hcloud_ssh_key_info.py
@@ -36,7 +36,7 @@ extends_documentation_fragment:
 
 EXAMPLES = """
 - name: Gather hcloud sshkey infos
-  hcloud_ssh_key_info:
+  hetzner.hcloud.hcloud_ssh_key_info:
   register: output
 - name: Print the gathered infos
   debug:

--- a/plugins/modules/hcloud_subnetwork.py
+++ b/plugins/modules/hcloud_subnetwork.py
@@ -61,7 +61,7 @@ extends_documentation_fragment:
 
 EXAMPLES = """
 - name: Create a basic subnetwork
-  hcloud_subnetwork:
+  hetzner.hcloud.hcloud_subnetwork:
     network: my-network
     ip_range: 10.0.0.0/16
     network_zone: eu-central
@@ -69,7 +69,7 @@ EXAMPLES = """
     state: present
 
 - name: Create a basic subnetwork
-  hcloud_subnetwork:
+  hetzner.hcloud.hcloud_subnetwork:
     network: my-vswitch-network
     ip_range: 10.0.0.0/24
     network_zone: eu-central
@@ -78,7 +78,7 @@ EXAMPLES = """
     state: present
 
 - name: Ensure the subnetwork is absent (remove if needed)
-  hcloud_subnetwork:
+  hetzner.hcloud.hcloud_subnetwork:
     network: my-network
     ip_range: 10.0.0.0/8
     network_zone: eu-central

--- a/plugins/modules/hcloud_volume.py
+++ b/plugins/modules/hcloud_volume.py
@@ -75,32 +75,32 @@ extends_documentation_fragment:
 
 EXAMPLES = """
 - name: Create a Volume
-  hcloud_volume:
+  hetzner.hcloud.hcloud_volume:
     name: my-volume
     location: fsn1
     size: 100
     state: present
 - name: Create a Volume and format it with ext4
-  hcloud_volume:
+  hetzner.hcloud.hcloud_volume:
     name: my-volume
     location: fsn
     format: ext4
     size: 100
     state: present
 - name: Mount a existing Volume and automount
-  hcloud_volume:
+  hetzner.hcloud.hcloud_volume:
     name: my-volume
     server: my-server
     automount: true
     state: present
 - name: Mount a existing Volume and automount
-  hcloud_volume:
+  hetzner.hcloud.hcloud_volume:
     name: my-volume
     server: my-server
     automount: true
     state: present
 - name: Ensure the Volume is absent (remove if needed)
-  hcloud_volume:
+  hetzner.hcloud.hcloud_volume:
     name: my-volume
     state: absent
 """

--- a/plugins/modules/hcloud_volume_info.py
+++ b/plugins/modules/hcloud_volume_info.py
@@ -36,7 +36,7 @@ extends_documentation_fragment:
 
 EXAMPLES = """
 - name: Gather hcloud Volume infos
-  hcloud_volume_info:
+  hetzner.hcloud.hcloud_volume_info:
   register: output
 - name: Print the gathered infos
   debug:

--- a/tests/integration/targets/hcloud_certificate/tasks/main.yml
+++ b/tests/integration/targets/hcloud_certificate/tasks/main.yml
@@ -2,7 +2,7 @@
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 ---
 - name: test missing required parameters on create certificate
-  hcloud_certificate:
+  hetzner.hcloud.hcloud_certificate:
     name: "{{ hcloud_certificate_name }}"
   register: result
   ignore_errors: true
@@ -13,7 +13,7 @@
       - 'result.msg == "missing required arguments: certificate, private_key"'
 
 - name: test create certificate with check mode
-  hcloud_certificate:
+  hetzner.hcloud.hcloud_certificate:
     name: "{{ hcloud_certificate_name }}"
     certificate: "{{ certificate_example_com }}"
     private_key: "{{ certificate_example_com_key }}"
@@ -25,7 +25,7 @@
       - result is changed
 
 - name: test create certificate
-  hcloud_certificate:
+  hetzner.hcloud.hcloud_certificate:
     name: "{{ hcloud_certificate_name }}"
     certificate: "{{ certificate_example_com }}"
     private_key: "{{ certificate_example_com_key }}"
@@ -42,7 +42,7 @@
       - certificate.hcloud_certificate.labels.key == "value"
 
 - name: test create certificate idempotence
-  hcloud_certificate:
+  hetzner.hcloud.hcloud_certificate:
     name: "{{ hcloud_certificate_name }}"
     certificate: "{{ certificate_example_com }}"
     private_key: "{{ certificate_example_com_key }}"
@@ -53,7 +53,7 @@
       - result is not changed
 
 - name: test update certificate with check mode
-  hcloud_certificate:
+  hetzner.hcloud.hcloud_certificate:
     id: "{{ certificate.hcloud_certificate.id }}"
     name: "changed-{{ hcloud_certificate_name }}"
   register: result
@@ -64,7 +64,7 @@
       - result is changed
 
 - name: test update certificate
-  hcloud_certificate:
+  hetzner.hcloud.hcloud_certificate:
     id: "{{ certificate.hcloud_certificate.id }}"
     name: "changed-{{ hcloud_certificate_name }}"
     labels:
@@ -77,7 +77,7 @@
       - result.hcloud_certificate.name == "changed-{{ hcloud_certificate_name }}"
 
 - name: test update certificate with same labels
-  hcloud_certificate:
+  hetzner.hcloud.hcloud_certificate:
     id: "{{ certificate.hcloud_certificate.id }}"
     name: "changed-{{ hcloud_certificate_name }}"
     labels:
@@ -89,7 +89,7 @@
       - result is not changed
 
 - name: test update certificate with other labels
-  hcloud_certificate:
+  hetzner.hcloud.hcloud_certificate:
     id: "{{ certificate.hcloud_certificate.id }}"
     name: "changed-{{ hcloud_certificate_name }}"
     labels:
@@ -102,7 +102,7 @@
       - result is changed
 
 - name: test rename certificate
-  hcloud_certificate:
+  hetzner.hcloud.hcloud_certificate:
     id: "{{ certificate.hcloud_certificate.id }}"
     name: "{{ hcloud_certificate_name }}"
   register: result
@@ -113,7 +113,7 @@
       - result.hcloud_certificate.name == "{{ hcloud_certificate_name }}"
 
 - name: absent certificate
-  hcloud_certificate:
+  hetzner.hcloud.hcloud_certificate:
     id: "{{ certificate.hcloud_certificate.id }}"
     state: absent
   register: result
@@ -129,7 +129,7 @@
     hcloud_dns_test_domain: "{{ hcloud_dns_test_domain }}"
 
 - name: test create managed certificate
-  hcloud_certificate:
+  hetzner.hcloud.hcloud_certificate:
     name: "{{ hcloud_certificate_name }}"
     domain_names:
       - "{{ hcloud_dns_test_domain }}"
@@ -145,7 +145,7 @@
       - result.hcloud_certificate.domain_names[0] == "{{ hcloud_dns_test_domain }}"
 
 - name: absent certificate
-  hcloud_certificate:
+  hetzner.hcloud.hcloud_certificate:
     id: "{{ result.hcloud_certificate.id }}"
     state: absent
   register: result

--- a/tests/integration/targets/hcloud_certificate_info/tasks/main.yml
+++ b/tests/integration/targets/hcloud_certificate_info/tasks/main.yml
@@ -2,7 +2,7 @@
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 ---
 - name: create certificate
-  hcloud_certificate:
+  hetzner.hcloud.hcloud_certificate:
     name: "{{ hcloud_certificate_name }}"
     certificate: "{{ certificate_example_com }}"
     private_key: "{{ certificate_example_com_key }}"
@@ -19,7 +19,7 @@
       - certificate.hcloud_certificate.labels.key == "value"
 
 - name: test gather hcloud certificate infos in check mode
-  hcloud_certificate_info:
+  hetzner.hcloud.hcloud_certificate_info:
   register: hcloud_certificate
   check_mode: true
 - name: verify test gather hcloud certificate infos in check mode
@@ -28,7 +28,7 @@
       - hcloud_certificate.hcloud_certificate_info| list | count >= 1
 
 - name: test gather hcloud certificate infos
-  hcloud_certificate_info:
+  hetzner.hcloud.hcloud_certificate_info:
   register: hcloud_certificate
   check_mode: true
 - name: verify test gather hcloud certificate infos
@@ -37,7 +37,7 @@
       - hcloud_certificate.hcloud_certificate_info| list | count >= 1
 
 - name: test gather hcloud certificate infos with correct label selector
-  hcloud_certificate_info:
+  hetzner.hcloud.hcloud_certificate_info:
     label_selector: "key=value"
   register: hcloud_certificate
 - name: verify test gather hcloud certificate infos with correct label selector
@@ -46,7 +46,7 @@
       - hcloud_certificate.hcloud_certificate_info|selectattr('name','equalto','{{ hcloud_certificate_name }}') | list | count == 1
 
 - name: test gather hcloud certificate infos with wrong label selector
-  hcloud_certificate_info:
+  hetzner.hcloud.hcloud_certificate_info:
     label_selector: "key!=value"
   register: hcloud_certificate
 - name: verify test gather hcloud certificate infos with wrong label selector
@@ -55,7 +55,7 @@
       - hcloud_certificate.hcloud_certificate_info | list | count == 0
 
 - name: absent certificate
-  hcloud_certificate:
+  hetzner.hcloud.hcloud_certificate:
     id: "{{ certificate.hcloud_certificate.id }}"
     state: absent
   register: result

--- a/tests/integration/targets/hcloud_datacenter_info/tasks/main.yml
+++ b/tests/integration/targets/hcloud_datacenter_info/tasks/main.yml
@@ -2,7 +2,7 @@
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 ---
 - name: test gather hcloud datacenter infos
-  hcloud_datacenter_info:
+  hetzner.hcloud.hcloud_datacenter_info:
   register: hcloud_datacenters
 
 - name: verify test gather hcloud datacenter infos
@@ -11,7 +11,7 @@
       - hcloud_datacenters.hcloud_datacenter_info| list | count >= 5
 
 - name: test gather hcloud datacenter infos in check mode
-  hcloud_datacenter_info:
+  hetzner.hcloud.hcloud_datacenter_info:
   register: hcloud_datacenters
   check_mode: true
 
@@ -21,7 +21,7 @@
       - hcloud_datacenters.hcloud_datacenter_info| list | count >= 5
 
 - name: test gather hcloud datacenter infos with correct name
-  hcloud_datacenter_info:
+  hetzner.hcloud.hcloud_datacenter_info:
     name: "{{hcloud_datacenter_name}}"
   register: hcloud_datacenter
 - name: verify test gather hcloud datacenter with correct name
@@ -30,7 +30,7 @@
       - hcloud_datacenter.hcloud_datacenter_info|selectattr('name','equalto','{{ hcloud_datacenter_name }}') |selectattr('location','equalto','{{ hcloud_location_name }}') | list | count == 1
 
 - name: test gather hcloud datacenter infos with correct id
-  hcloud_datacenter_info:
+  hetzner.hcloud.hcloud_datacenter_info:
     id: "{{hcloud_datacenter_id}}"
   register: hcloud_datacenter
 - name: verify test gather hcloud datacenter with correct id

--- a/tests/integration/targets/hcloud_firewall/tasks/main.yml
+++ b/tests/integration/targets/hcloud_firewall/tasks/main.yml
@@ -2,12 +2,12 @@
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 ---
 - name: setup firewall to be absent
-  hcloud_firewall:
+  hetzner.hcloud.hcloud_firewall:
     name: "{{ hcloud_firewall_name }}"
     state: absent
 
 - name: test missing required parameters on create firewall
-  hcloud_firewall:
+  hetzner.hcloud.hcloud_firewall:
   register: result
   ignore_errors: true
 - name: verify fail test missing required parameters on create firewall
@@ -17,7 +17,7 @@
       - 'result.msg == "one of the following is required: id, name"'
 
 - name: test create firewall with check mode
-  hcloud_firewall:
+  hetzner.hcloud.hcloud_firewall:
     name: "{{ hcloud_firewall_name }}"
   register: result
   check_mode: true
@@ -27,7 +27,7 @@
       - result is changed
 
 - name: test create firewall
-  hcloud_firewall:
+  hetzner.hcloud.hcloud_firewall:
     name: "{{ hcloud_firewall_name }}"
     rules:
       - direction: in
@@ -51,7 +51,7 @@
       - firewall.hcloud_firewall.rules | selectattr('description', 'equalto', 'allow icmp in') | list | count == 1
 
 - name: test create firewall idempotence
-  hcloud_firewall:
+  hetzner.hcloud.hcloud_firewall:
     name: "{{ hcloud_firewall_name }}"
     rules:
       - direction: in
@@ -70,7 +70,7 @@
       - result is not changed
 
 - name: test update firewall rules
-  hcloud_firewall:
+  hetzner.hcloud.hcloud_firewall:
     name: "{{ hcloud_firewall_name }}"
     rules:
       - direction: in
@@ -109,7 +109,7 @@
       - firewall.hcloud_firewall.rules | selectattr('description', 'equalto', 'allow tcp out') | list | count == 1
 
 - name: test update firewall rules idempotence
-  hcloud_firewall:
+  hetzner.hcloud.hcloud_firewall:
     name: "{{ hcloud_firewall_name }}"
     rules:
       - direction: in
@@ -140,7 +140,7 @@
       - result is not changed
 
 - name: test update firewall with check mode
-  hcloud_firewall:
+  hetzner.hcloud.hcloud_firewall:
     id: "{{ firewall.hcloud_firewall.id }}"
     name: "changed-{{ hcloud_firewall_name }}"
   register: result
@@ -151,7 +151,7 @@
       - result is changed
 
 - name: test update firewall
-  hcloud_firewall:
+  hetzner.hcloud.hcloud_firewall:
     id: "{{ firewall.hcloud_firewall.id }}"
     name: "changed-{{ hcloud_firewall_name }}"
     labels:
@@ -164,7 +164,7 @@
       - result.hcloud_firewall.name == "changed-{{ hcloud_firewall_name }}"
 
 - name: test update firewall with same labels
-  hcloud_firewall:
+  hetzner.hcloud.hcloud_firewall:
     id: "{{ firewall.hcloud_firewall.id }}"
     name: "changed-{{ hcloud_firewall_name }}"
     labels:
@@ -176,7 +176,7 @@
       - result is not changed
 
 - name: test update firewall with other labels
-  hcloud_firewall:
+  hetzner.hcloud.hcloud_firewall:
     id: "{{ firewall.hcloud_firewall.id }}"
     name: "changed-{{ hcloud_firewall_name }}"
     labels:
@@ -189,7 +189,7 @@
       - result is changed
 
 - name: test rename firewall
-  hcloud_firewall:
+  hetzner.hcloud.hcloud_firewall:
     id: "{{ firewall.hcloud_firewall.id }}"
     name: "{{ hcloud_firewall_name }}"
   register: result
@@ -200,7 +200,7 @@
       - result.hcloud_firewall.name == "{{ hcloud_firewall_name }}"
 
 - name: absent firewall
-  hcloud_firewall:
+  hetzner.hcloud.hcloud_firewall:
     id: "{{ firewall.hcloud_firewall.id }}"
     state: absent
   register: result

--- a/tests/integration/targets/hcloud_floating_ip/tasks/main.yml
+++ b/tests/integration/targets/hcloud_floating_ip/tasks/main.yml
@@ -2,22 +2,22 @@
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 ---
 - name: setup ensure server is absent
-  hcloud_server:
+  hetzner.hcloud.hcloud_server:
     name: "{{ hcloud_server_name }}"
     state: absent
 
 - name: setup ensure another server is absent
-  hcloud_server:
+  hetzner.hcloud.hcloud_server:
     name: "{{ hcloud_server_name }}2"
     state: absent
 
 - name: setup ensure floating ip is absent
-  hcloud_floating_ip:
+  hetzner.hcloud.hcloud_floating_ip:
     name: "{{ hcloud_floating_ip_name }}"
     state: absent
 
 - name: setup server
-  hcloud_server:
+  hetzner.hcloud.hcloud_server:
     name: "{{ hcloud_server_name }}"
     server_type: cx11
     image: ubuntu-22.04
@@ -30,7 +30,7 @@
       - main_server is changed
 
 - name: setup another server
-  hcloud_server:
+  hetzner.hcloud.hcloud_server:
     name: "{{ hcloud_server_name }}2"
     server_type: cx11
     image: ubuntu-22.04
@@ -42,7 +42,7 @@
       - main_server2 is changed
 
 - name: test missing type parameter on create Floating IP
-  hcloud_floating_ip:
+  hetzner.hcloud.hcloud_floating_ip:
     name: "{{ hcloud_floating_ip_name }}"
   register: result
   ignore_errors: true
@@ -53,7 +53,7 @@
       - 'result.msg == "missing required arguments: type"'
 
 - name: test missing required parameters on create Floating IP
-  hcloud_floating_ip:
+  hetzner.hcloud.hcloud_floating_ip:
     name: "{{ hcloud_floating_ip_name }}"
     type: ipv4
   register: result
@@ -65,7 +65,7 @@
       - 'result.msg == "one of the following is required: home_location, server"'
 
 - name: test missing type parameter on delete Floating IP
-  hcloud_floating_ip:
+  hetzner.hcloud.hcloud_floating_ip:
     type: ipv4
     home_location: "fsn1"
     state: "absent"
@@ -78,7 +78,7 @@
       - 'result.msg == "one of the following is required: id, name"'
 
 - name: test invalid type
-  hcloud_floating_ip:
+  hetzner.hcloud.hcloud_floating_ip:
     name: "{{ hcloud_floating_ip_name }}"
     type: ipv5
     home_location: "fsn1"
@@ -91,7 +91,7 @@
       - 'result.msg == "value of type must be one of: ipv4, ipv6, got: ipv5"'
 
 - name: test invalid location
-  hcloud_floating_ip:
+  hetzner.hcloud.hcloud_floating_ip:
     name: "{{ hcloud_floating_ip_name }}"
     type: ipv4
     home_location: "abc"
@@ -104,7 +104,7 @@
       - result.msg == "invalid input in fields 'server', 'home_location'"
 
 - name: test create Floating IP with check mode
-  hcloud_floating_ip:
+  hetzner.hcloud.hcloud_floating_ip:
     name: "{{ hcloud_floating_ip_name }}"
     description: "Web Server"
     type: ipv4
@@ -117,7 +117,7 @@
       - floatingIP is changed
 
 - name: test create Floating IP
-  hcloud_floating_ip:
+  hetzner.hcloud.hcloud_floating_ip:
     name: "{{ hcloud_floating_ip_name }}"
     description: "Web Server"
     type: ipv4
@@ -132,7 +132,7 @@
       - floatingIP.hcloud_floating_ip.home_location == "fsn1"
 
 - name: test create Floating IP idempotency
-  hcloud_floating_ip:
+  hetzner.hcloud.hcloud_floating_ip:
     name: "{{ hcloud_floating_ip_name }}"
     description: "Web Server"
     type: ipv4
@@ -144,7 +144,7 @@
       - floatingIP is not changed
 
 - name: test update Floating IP with check mode
-  hcloud_floating_ip:
+  hetzner.hcloud.hcloud_floating_ip:
     name: "{{ hcloud_floating_ip_name }}"
     description: "changed-description"
     type: ipv4
@@ -158,7 +158,7 @@
       - floatingIP.hcloud_floating_ip.description == "Web Server"
 
 - name: test update Floating IP
-  hcloud_floating_ip:
+  hetzner.hcloud.hcloud_floating_ip:
     name: "{{ hcloud_floating_ip_name }}"
     description: "changed-description"
     type: ipv4
@@ -173,7 +173,7 @@
       - floatingIP.hcloud_floating_ip.description == "changed-description"
 
 - name: test update Floating IP idempotency
-  hcloud_floating_ip:
+  hetzner.hcloud.hcloud_floating_ip:
     name: "{{ hcloud_floating_ip_name }}"
     description: "changed-description"
     type: ipv4
@@ -187,7 +187,7 @@
       - floatingIP is not changed
 
 - name: test update Floating IP with same labels
-  hcloud_floating_ip:
+  hetzner.hcloud.hcloud_floating_ip:
     name: "{{ hcloud_floating_ip_name }}"
     type: ipv4
     home_location: "fsn1"
@@ -200,7 +200,7 @@
       - floatingIP is not changed
 
 - name: test update Floating IP with other labels
-  hcloud_floating_ip:
+  hetzner.hcloud.hcloud_floating_ip:
     name: "{{ hcloud_floating_ip_name }}"
     type: ipv4
     home_location: "fsn1"
@@ -214,7 +214,7 @@
       - floatingIP is changed
 
 - name: test update Floating IP with other labels in different order
-  hcloud_floating_ip:
+  hetzner.hcloud.hcloud_floating_ip:
     name: "{{ hcloud_floating_ip_name }}"
     type: ipv4
     home_location: "fsn1"
@@ -228,7 +228,7 @@
       - floatingIP is not changed
 
 - name: test assign Floating IP with checkmode
-  hcloud_floating_ip:
+  hetzner.hcloud.hcloud_floating_ip:
     name: "{{ hcloud_floating_ip_name }}"
     description: "changed-description"
     type: ipv4
@@ -242,7 +242,7 @@
       - floatingIP.hcloud_floating_ip.server != "{{ main_server.hcloud_server.name }}"
 
 - name: test assign Floating IP
-  hcloud_floating_ip:
+  hetzner.hcloud.hcloud_floating_ip:
     name: "{{ hcloud_floating_ip_name }}"
     description: "changed-description"
     type: ipv4
@@ -255,7 +255,7 @@
       - floatingIP.hcloud_floating_ip.server == "{{ main_server.hcloud_server.name }}"
 
 - name: test assign Floating IP idempotency
-  hcloud_floating_ip:
+  hetzner.hcloud.hcloud_floating_ip:
     name: "{{ hcloud_floating_ip_name }}"
     description: "changed-description"
     type: ipv4
@@ -267,7 +267,7 @@
       - floatingIP is not changed
 
 - name: test unassign Floating IP
-  hcloud_floating_ip:
+  hetzner.hcloud.hcloud_floating_ip:
     name: "{{ hcloud_floating_ip_name }}"
     type: ipv4
     home_location: "fsn1"
@@ -279,7 +279,7 @@
       - floatingIP.hcloud_floating_ip.server != "{{ main_server.hcloud_server.name }}"
 
 - name: test unassign Floating IP idempotency
-  hcloud_floating_ip:
+  hetzner.hcloud.hcloud_floating_ip:
     name: "{{ hcloud_floating_ip_name }}"
     type: ipv4
     home_location: "fsn1"
@@ -290,7 +290,7 @@
       - floatingIP is not changed
 
 - name: test assign Floating IP again
-  hcloud_floating_ip:
+  hetzner.hcloud.hcloud_floating_ip:
     name: "{{ hcloud_floating_ip_name }}"
     type: ipv4
     server: "{{ main_server.hcloud_server.name }}"
@@ -302,7 +302,7 @@
       - floatingIP.hcloud_floating_ip.server == "{{ main_server.hcloud_server.name }}"
 
 - name: test already assigned Floating IP assign without force
-  hcloud_floating_ip:
+  hetzner.hcloud.hcloud_floating_ip:
     name: "{{ hcloud_floating_ip_name }}"
     type: ipv4
     server: "{{ main_server2.hcloud_server.name }}"
@@ -314,7 +314,7 @@
       - floatingIP.hcloud_floating_ip.server == "{{ main_server.hcloud_server.name }}"
 
 - name: test already assigned Floating IP assign with force
-  hcloud_floating_ip:
+  hetzner.hcloud.hcloud_floating_ip:
     name: "{{ hcloud_floating_ip_name }}"
     type: ipv4
     force: true
@@ -327,7 +327,7 @@
       - floatingIP.hcloud_floating_ip.server == "{{ main_server2.hcloud_server.name }}"
 
 - name: test update Floating IP delete protection
-  hcloud_floating_ip:
+  hetzner.hcloud.hcloud_floating_ip:
     name: "{{ hcloud_floating_ip_name }}"
     type: ipv4
     delete_protection: true
@@ -339,7 +339,7 @@
       - floatingIP.hcloud_floating_ip.delete_protection is sameas true
 
 - name: test update Floating IP delete protection idempotency
-  hcloud_floating_ip:
+  hetzner.hcloud.hcloud_floating_ip:
     name: "{{ hcloud_floating_ip_name }}"
     type: ipv4
     delete_protection: true
@@ -351,7 +351,7 @@
       - floatingIP.hcloud_floating_ip.delete_protection is sameas true
 
 - name: test Floating IP without delete protection set to be idempotent
-  hcloud_floating_ip:
+  hetzner.hcloud.hcloud_floating_ip:
     name: "{{ hcloud_floating_ip_name }}"
     type: ipv4
   register: floatingIP
@@ -362,7 +362,7 @@
       - floatingIP.hcloud_floating_ip.delete_protection is sameas true
 
 - name: test delete Floating IP fails if it is protected
-  hcloud_floating_ip:
+  hetzner.hcloud.hcloud_floating_ip:
     name: "{{ hcloud_floating_ip_name }}"
     state: "absent"
   register: result
@@ -374,7 +374,7 @@
       - 'result.msg == "Floating IP deletion is protected"'
 
 - name: test update Floating IP delete protection
-  hcloud_floating_ip:
+  hetzner.hcloud.hcloud_floating_ip:
     name: "{{ hcloud_floating_ip_name }}"
     type: ipv4
     delete_protection: false
@@ -386,7 +386,7 @@
       - floatingIP.hcloud_floating_ip.delete_protection is sameas false
 
 - name: test delete floating ip
-  hcloud_floating_ip:
+  hetzner.hcloud.hcloud_floating_ip:
     name: "{{ hcloud_floating_ip_name }}"
     state: "absent"
   register: result
@@ -396,7 +396,7 @@
       - result is changed
 
 - name: test create ipv6 floating ip
-  hcloud_floating_ip:
+  hetzner.hcloud.hcloud_floating_ip:
     name: "{{ hcloud_floating_ip_name }}"
     type: ipv6
     home_location: "fsn1"
@@ -408,7 +408,7 @@
       - result is changed
 
 - name: test delete ipv6 floating ip
-  hcloud_floating_ip:
+  hetzner.hcloud.hcloud_floating_ip:
     name: "{{ hcloud_floating_ip_name }}"
     state: "absent"
   register: result
@@ -418,7 +418,7 @@
       - result is changed
 
 - name: cleanup
-  hcloud_server:
+  hetzner.hcloud.hcloud_server:
     name: "{{ hcloud_server_name }}"
     state: absent
   register: result
@@ -427,7 +427,7 @@
     that:
       - result is changed
 - name: cleanup another server
-  hcloud_server:
+  hetzner.hcloud.hcloud_server:
     name: "{{ main_server2.hcloud_server.name }}"
     state: absent
   register: result
@@ -437,7 +437,7 @@
       - result is changed
 
 - name: test create Floating IP with delete protection
-  hcloud_floating_ip:
+  hetzner.hcloud.hcloud_floating_ip:
     name: "{{ hcloud_floating_ip_name }}"
     type: ipv4
     home_location: fsn1
@@ -450,7 +450,7 @@
       - floatingIP.hcloud_floating_ip.delete_protection is sameas true
 
 - name: test delete Floating IP fails if it is protected
-  hcloud_floating_ip:
+  hetzner.hcloud.hcloud_floating_ip:
     name: "{{ hcloud_floating_ip_name }}"
     state: "absent"
   register: result
@@ -462,7 +462,7 @@
       - 'result.msg == "Floating IP deletion is protected"'
 
 - name: test update Floating IP delete protection
-  hcloud_floating_ip:
+  hetzner.hcloud.hcloud_floating_ip:
     name: "{{ hcloud_floating_ip_name }}"
     type: ipv4
     delete_protection: false
@@ -474,7 +474,7 @@
       - floatingIP.hcloud_floating_ip.delete_protection is sameas false
 
 - name: test delete floating ip
-  hcloud_floating_ip:
+  hetzner.hcloud.hcloud_floating_ip:
     name: "{{ hcloud_floating_ip_name }}"
     state: "absent"
   register: result

--- a/tests/integration/targets/hcloud_floating_ip_info/tasks/main.yml
+++ b/tests/integration/targets/hcloud_floating_ip_info/tasks/main.yml
@@ -2,12 +2,12 @@
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 ---
 - name: setup ensure floating ip is absent
-  hcloud_floating_ip:
+  hetzner.hcloud.hcloud_floating_ip:
     name: "{{ hcloud_floating_ip_name }}"
     state: absent
 
 - name: setup floating ip
-  hcloud_floating_ip:
+  hetzner.hcloud.hcloud_floating_ip:
     name: "{{ hcloud_floating_ip_name }}"
     home_location: "fsn1"
     type: ipv4
@@ -21,7 +21,7 @@
       - test_floating_ip is changed
 
 - name: test gather hcloud floating ip infos
-  hcloud_floating_ip_info:
+  hetzner.hcloud.hcloud_floating_ip_info:
   register: hcloud_floating_ips
 - name: verify test gather hcloud floating ip infos
   assert:
@@ -29,7 +29,7 @@
       - hcloud_floating_ips.hcloud_floating_ip_info| list | count >= 1
 
 - name: test gather hcloud floating ip infos in check mode
-  hcloud_floating_ip_info:
+  hetzner.hcloud.hcloud_floating_ip_info:
   check_mode: true
   register: hcloud_floating_ips
 
@@ -39,7 +39,7 @@
       - hcloud_floating_ips.hcloud_floating_ip_info| list | count >= 1
 
 - name: test gather hcloud floating ip infos with correct label selector
-  hcloud_floating_ip_info:
+  hetzner.hcloud.hcloud_floating_ip_info:
     label_selector: "key=value"
   register: hcloud_floating_ips
 - name: verify test gather hcloud floating ip with correct label selector
@@ -48,7 +48,7 @@
       - hcloud_floating_ips.hcloud_floating_ip_info|selectattr('name','equalto','{{ test_floating_ip.hcloud_floating_ip.name }}') | list | count == 1
 
 - name: test gather hcloud floating ip infos with wrong label selector
-  hcloud_floating_ip_info:
+  hetzner.hcloud.hcloud_floating_ip_info:
     label_selector: "key!=value"
   register: hcloud_floating_ips
 - name: verify test gather hcloud floating ip with wrong label selector
@@ -57,7 +57,7 @@
       - hcloud_floating_ips.hcloud_floating_ip_info | list | count == 0
 
 - name: test gather hcloud floating ip infos with correct id
-  hcloud_floating_ip_info:
+  hetzner.hcloud.hcloud_floating_ip_info:
     id: "{{test_floating_ip.hcloud_floating_ip.id}}"
   register: hcloud_floating_ips
 - name: verify test gather hcloud floating ip with correct id
@@ -66,7 +66,7 @@
       - hcloud_floating_ips.hcloud_floating_ip_info|selectattr('name','equalto','{{ test_floating_ip.hcloud_floating_ip.name }}') | list | count == 1
 
 - name: test gather hcloud floating ip infos with wrong id
-  hcloud_floating_ip_info:
+  hetzner.hcloud.hcloud_floating_ip_info:
     id: "{{test_floating_ip.hcloud_floating_ip.id}}1"
   register: result
   ignore_errors: true
@@ -76,7 +76,7 @@
       - result is failed
 
 - name: cleanup
-  hcloud_floating_ip:
+  hetzner.hcloud.hcloud_floating_ip:
     id: "{{ test_floating_ip.hcloud_floating_ip.id }}"
     state: absent
   register: result

--- a/tests/integration/targets/hcloud_image_info/tasks/main.yml
+++ b/tests/integration/targets/hcloud_image_info/tasks/main.yml
@@ -2,7 +2,7 @@
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 ---
 - name: test gather hcloud image infos with type system
-  hcloud_image_info:
+  hetzner.hcloud.hcloud_image_info:
   register: hcloud_images
 - name: verify test gather hcloud image infos in check mode
   assert:
@@ -10,7 +10,7 @@
       - hcloud_images.hcloud_image_info| list | count > 2
 
 - name: test gather hcloud image infos in check mode
-  hcloud_image_info:
+  hetzner.hcloud.hcloud_image_info:
   check_mode: true
   register: hcloud_images
 
@@ -20,7 +20,7 @@
       - hcloud_images.hcloud_image_info| list | count > 2
 
 - name: test gather hcloud image infos with correct label selector
-  hcloud_image_info:
+  hetzner.hcloud.hcloud_image_info:
     label_selector: "key=value"
     type: snapshot
   register: hcloud_images
@@ -30,7 +30,7 @@
       - hcloud_images.hcloud_image_info|selectattr('description','equalto','{{ hcloud_test_image_name }}') | list | count == 1
 
 - name: test gather hcloud image infos with wrong label selector
-  hcloud_image_info:
+  hetzner.hcloud.hcloud_image_info:
     label_selector: "key!=value"
     type: snapshot
   register: hcloud_images
@@ -40,7 +40,7 @@
       - hcloud_images.hcloud_image_info | list | count == 0
 
 - name: test gather hcloud image infos with correct id
-  hcloud_image_info:
+  hetzner.hcloud.hcloud_image_info:
     id: "{{hcloud_test_image_id}}"
     type: snapshot
   register: hcloud_images
@@ -50,7 +50,7 @@
       - hcloud_images.hcloud_image_info|selectattr('description','equalto','{{ hcloud_test_image_name }}') | list | count == 1
 
 - name: test gather hcloud image infos with wrong id
-  hcloud_image_info:
+  hetzner.hcloud.hcloud_image_info:
     id: "{{hcloud_test_image_id}}1"
     type: snapshot
   ignore_errors: true
@@ -61,7 +61,7 @@
       - result is failed
 
 - name: test gather hcloud image infos with name
-  hcloud_image_info:
+  hetzner.hcloud.hcloud_image_info:
     name: "{{ hcloud_test_image_name_os }}"
   register: hcloud_images
 - name: verify test gather hcloud image infos with name
@@ -71,7 +71,7 @@
       - hcloud_images.hcloud_image_info[0].architecture == "x86"
 
 - name: test gather hcloud image infos with name and architecture
-  hcloud_image_info:
+  hetzner.hcloud.hcloud_image_info:
     name: "{{ hcloud_test_image_name_os }}"
     architecture: arm
   register: hcloud_images
@@ -82,7 +82,7 @@
       - hcloud_images.hcloud_image_info[0].architecture == "arm"
 
 - name: test gather hcloud image infos with architecture
-  hcloud_image_info:
+  hetzner.hcloud.hcloud_image_info:
     architecture: arm
   register: hcloud_images
 - name: verify test gather hcloud image infos with name

--- a/tests/integration/targets/hcloud_iso_info/tasks/main.yml
+++ b/tests/integration/targets/hcloud_iso_info/tasks/main.yml
@@ -2,7 +2,7 @@
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 ---
 - name: test gather hcloud iso infos with correct id
-  hcloud_iso_info:
+  hetzner.hcloud.hcloud_iso_info:
     id: "{{ hcloud_iso_id }}"
   register: hcloud_iso
 - name: verify test gather hcloud image with correct id
@@ -15,7 +15,7 @@
       - hcloud_iso.hcloud_iso_info[0].type == "{{ hcloud_iso_type }}"
 
 - name: test gather hcloud iso infos with wrong id
-  hcloud_iso_info:
+  hetzner.hcloud.hcloud_iso_info:
     id: "{{ hcloud_iso_id }}1"
   ignore_errors: true
   register: result
@@ -25,7 +25,7 @@
       - result is failed
 
 - name: test gather hcloud iso infos with name
-  hcloud_iso_info:
+  hetzner.hcloud.hcloud_iso_info:
     name: "{{ hcloud_iso_name }}"
   register: hcloud_iso
 - name: verify test gather hcloud iso infos with name
@@ -34,7 +34,7 @@
       - hcloud_iso.hcloud_iso_info | list | count == 1
 
 - name: test list hcloud iso infos with architecture
-  hcloud_iso_info:
+  hetzner.hcloud.hcloud_iso_info:
     architecture: arm
   register: hcloud_iso
 - name: verify test list hcloud iso infos with architecture
@@ -45,7 +45,7 @@
       - hcloud_iso.hcloud_iso_info | selectattr('architecture','equalto','arm') | list | count  > 2
 
 - name: test list hcloud iso infos in check mode
-  hcloud_iso_info:
+  hetzner.hcloud.hcloud_iso_info:
   check_mode: true
   register: hcloud_iso
 - name: verify test list hcloud iso infos in check mode

--- a/tests/integration/targets/hcloud_load_balancer/tasks/main.yml
+++ b/tests/integration/targets/hcloud_load_balancer/tasks/main.yml
@@ -2,7 +2,7 @@
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 ---
 - name: setup
-  hcloud_load_balancer:
+  hetzner.hcloud.hcloud_load_balancer:
     name: "{{ hcloud_load_balancer_name }}"
     state: absent
   register: result
@@ -11,7 +11,7 @@
     that:
       - result is success
 - name: test missing required parameters on create Load Balancer
-  hcloud_load_balancer:
+  hetzner.hcloud.hcloud_load_balancer:
     name: "{{ hcloud_load_balancer_name }}"
   register: result
   ignore_errors: true
@@ -22,7 +22,7 @@
       - 'result.msg == "missing required arguments: load_balancer_type"'
 
 - name: test create Load Balancer with check mode
-  hcloud_load_balancer:
+  hetzner.hcloud.hcloud_load_balancer:
     name: "{{ hcloud_load_balancer_name }}"
     load_balancer_type: lb11
     network_zone: eu-central
@@ -35,7 +35,7 @@
       - result is changed
 
 - name: test create Load Balancer
-  hcloud_load_balancer:
+  hetzner.hcloud.hcloud_load_balancer:
     name: "{{ hcloud_load_balancer_name}}"
     load_balancer_type: lb11
     network_zone: eu-central
@@ -49,7 +49,7 @@
       - main_load_balancer.hcloud_load_balancer.load_balancer_type == "lb11"
 
 - name: test create Load Balancer idempotence
-  hcloud_load_balancer:
+  hetzner.hcloud.hcloud_load_balancer:
     name: "{{ hcloud_load_balancer_name }}"
     load_balancer_type: lb11
     network_zone: eu-central
@@ -61,7 +61,7 @@
       - result is not changed
 
 - name: test change Load Balancer type
-  hcloud_load_balancer:
+  hetzner.hcloud.hcloud_load_balancer:
     name: "{{ hcloud_load_balancer_name }}"
     load_balancer_type: lb21
     state: present
@@ -74,7 +74,7 @@
       - result_after_test.hcloud_load_balancer.load_balancer_type == "lb21"
 
 - name: test Load Balancer without type set to be idempotent
-  hcloud_load_balancer:
+  hetzner.hcloud.hcloud_load_balancer:
     name: "{{hcloud_load_balancer_name}}"
   register: result_after_test
 - name: verify test Load Balancer without type set to be idempotent
@@ -84,7 +84,7 @@
       - result_after_test.hcloud_load_balancer.load_balancer_type == "lb21"
 
 - name: test update Load Balancer protection
-  hcloud_load_balancer:
+  hetzner.hcloud.hcloud_load_balancer:
     name: "{{ hcloud_load_balancer_name }}"
     delete_protection: true
     state: present
@@ -97,7 +97,7 @@
       - result_after_test.hcloud_load_balancer.delete_protection is sameas true
 
 - name: test Load Balancer without protection set to be idempotent
-  hcloud_load_balancer:
+  hetzner.hcloud.hcloud_load_balancer:
     name: "{{hcloud_load_balancer_name}}"
   register: result_after_test
 - name: verify test Load Balancer without protection set to be idempotent
@@ -107,7 +107,7 @@
       - result_after_test.hcloud_load_balancer.delete_protection is sameas true
 
 - name: test delete Load Balancer fails if it is protected
-  hcloud_load_balancer:
+  hetzner.hcloud.hcloud_load_balancer:
     name: "{{hcloud_load_balancer_name}}"
     state: absent
   ignore_errors: true
@@ -119,7 +119,7 @@
       - 'result.msg == "load balancer deletion is protected"'
 
 - name: test remove Load Balancer protection
-  hcloud_load_balancer:
+  hetzner.hcloud.hcloud_load_balancer:
     name: "{{ hcloud_load_balancer_name }}"
     delete_protection: false
     state: present
@@ -132,7 +132,7 @@
       - result_after_test.hcloud_load_balancer.delete_protection is sameas false
 
 - name: absent Load Balancer
-  hcloud_load_balancer:
+  hetzner.hcloud.hcloud_load_balancer:
     name: "{{ hcloud_load_balancer_name }}"
     state: absent
   register: result
@@ -142,7 +142,7 @@
       - result is success
 
 - name: test create Load Balancer with labels
-  hcloud_load_balancer:
+  hetzner.hcloud.hcloud_load_balancer:
     name: "{{ hcloud_load_balancer_name}}"
     load_balancer_type: lb11
     network_zone: eu-central
@@ -159,7 +159,7 @@
       - main_load_balancer.hcloud_load_balancer.labels.mylabel == "val123"
 
 - name: test update Load Balancer with labels
-  hcloud_load_balancer:
+  hetzner.hcloud.hcloud_load_balancer:
     name: "{{ hcloud_load_balancer_name}}"
     load_balancer_type: lb11
     network_zone: eu-central
@@ -176,7 +176,7 @@
       - main_load_balancer.hcloud_load_balancer.labels.mylabel == "val123"
 
 - name: test update Load Balancer with labels in other order
-  hcloud_load_balancer:
+  hetzner.hcloud.hcloud_load_balancer:
     name: "{{ hcloud_load_balancer_name}}"
     load_balancer_type: lb11
     network_zone: eu-central
@@ -191,7 +191,7 @@
       - main_load_balancer is not changed
 
 - name: cleanup with labels
-  hcloud_load_balancer:
+  hetzner.hcloud.hcloud_load_balancer:
     name: "{{ hcloud_load_balancer_name }}"
     state: absent
   register: result
@@ -201,7 +201,7 @@
       - result is success
 
 - name: test create Load Balancer with delete protection
-  hcloud_load_balancer:
+  hetzner.hcloud.hcloud_load_balancer:
     name: "{{ hcloud_load_balancer_name }}"
     load_balancer_type: lb11
     network_zone: eu-central
@@ -214,7 +214,7 @@
       - main_load_balancer.hcloud_load_balancer.delete_protection is sameas true
 
 - name: test delete Load Balancer fails if it is protected
-  hcloud_load_balancer:
+  hetzner.hcloud.hcloud_load_balancer:
     name: "{{ hcloud_load_balancer_name }}"
     state: "absent"
   register: result
@@ -226,7 +226,7 @@
       - 'result.msg == "load balancer deletion is protected"'
 
 - name: test update Load Balancer delete protection
-  hcloud_load_balancer:
+  hetzner.hcloud.hcloud_load_balancer:
     name: "{{ hcloud_load_balancer_name }}"
     delete_protection: false
   register: main_load_balancer
@@ -237,7 +237,7 @@
       - main_load_balancer.hcloud_load_balancer.delete_protection is sameas false
 
 - name: test delete Load Balancer
-  hcloud_load_balancer:
+  hetzner.hcloud.hcloud_load_balancer:
     name: "{{ hcloud_load_balancer_name }}"
     state: "absent"
   register: result

--- a/tests/integration/targets/hcloud_load_balancer_info/tasks/main.yml
+++ b/tests/integration/targets/hcloud_load_balancer_info/tasks/main.yml
@@ -2,11 +2,11 @@
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 ---
 - name: setup ensure Load Balancer is absent
-  hcloud_load_balancer:
+  hetzner.hcloud.hcloud_load_balancer:
     name: "{{ hcloud_load_balancer_name }}"
     state: absent
 - name: setup server
-  hcloud_server:
+  hetzner.hcloud.hcloud_server:
     name: "{{hcloud_server_name}}"
     server_type: cx11
     image: ubuntu-22.04
@@ -17,7 +17,7 @@
     that:
       - server is success
 - name: setup Load Balancer
-  hcloud_load_balancer:
+  hetzner.hcloud.hcloud_load_balancer:
     name: "{{ hcloud_load_balancer_name }}"
     load_balancer_type: lb11
     network_zone: eu-central
@@ -31,7 +31,7 @@
       - test_load_balancer is changed
 
 - name: test create load_balancer target
-  hcloud_load_balancer_target:
+  hetzner.hcloud.hcloud_load_balancer_target:
     type: "server"
     load_balancer: "{{hcloud_load_balancer_name}}"
     server: "{{hcloud_server_name}}"
@@ -42,7 +42,7 @@
     that:
       - load_balancer_target is success
 - name: test create load_balancer service
-  hcloud_load_balancer_service:
+  hetzner.hcloud.hcloud_load_balancer_service:
     load_balancer: "{{hcloud_load_balancer_name}}"
     protocol: "http"
     listen_port: 80
@@ -54,7 +54,7 @@
       - load_balancer_service is success
 
 - name: test gather hcloud Load Balancer infos
-  hcloud_load_balancer_info:
+  hetzner.hcloud.hcloud_load_balancer_info:
     id: "{{test_load_balancer.hcloud_load_balancer.id}}"
   register: hcloud_load_balancers
 - name: verify test gather hcloud Load Balancer infos
@@ -70,7 +70,7 @@
       - hcloud_load_balancers.hcloud_load_balancer_info[0].services | selectattr('destination_port','equalto',80) | list | count == 1
 
 - name: test gather hcloud Load Balancer infos in check mode
-  hcloud_load_balancer_info:
+  hetzner.hcloud.hcloud_load_balancer_info:
   check_mode: true
   register: hcloud_load_balancers
 
@@ -80,7 +80,7 @@
       - hcloud_load_balancers.hcloud_load_balancer_info| list | count >= 1
 
 - name: test gather hcloud Load Balancer infos with correct label selector
-  hcloud_load_balancer_info:
+  hetzner.hcloud.hcloud_load_balancer_info:
     label_selector: "key=value"
   register: hcloud_load_balancers
 - name: verify test gather hcloud Load Balancer with correct label selector
@@ -89,7 +89,7 @@
       - hcloud_load_balancers.hcloud_load_balancer_info|selectattr('name','equalto','{{ test_load_balancer.hcloud_load_balancer.name }}') | list | count == 1
 
 - name: test gather hcloud Load Balancer infos with wrong label selector
-  hcloud_load_balancer_info:
+  hetzner.hcloud.hcloud_load_balancer_info:
     label_selector: "key!=value"
   register: hcloud_load_balancers
 - name: verify test gather hcloud Load Balancer with wrong label selector
@@ -98,7 +98,7 @@
       - hcloud_load_balancers.hcloud_load_balancer_info | list | count == 0
 
 - name: test gather hcloud Load Balancer infos with correct id
-  hcloud_load_balancer_info:
+  hetzner.hcloud.hcloud_load_balancer_info:
     id: "{{test_load_balancer.hcloud_load_balancer.id}}"
   register: hcloud_load_balancers
 - name: verify test gather hcloud Load Balancer with correct id
@@ -107,7 +107,7 @@
       - hcloud_load_balancers.hcloud_load_balancer_info|selectattr('name','equalto','{{ test_load_balancer.hcloud_load_balancer.name }}') | list | count == 1
 
 - name: test gather hcloud Load Balancer infos with wrong id
-  hcloud_load_balancer_info:
+  hetzner.hcloud.hcloud_load_balancer_info:
     id: "{{test_load_balancer.hcloud_load_balancer.id}}1"
   register: result
   ignore_errors: true
@@ -117,7 +117,7 @@
       - result is failed
 
 - name: cleanup
-  hcloud_load_balancer:
+  hetzner.hcloud.hcloud_load_balancer:
     id: "{{ test_load_balancer.hcloud_load_balancer.id }}"
     state: absent
   register: result

--- a/tests/integration/targets/hcloud_load_balancer_network/tasks/main.yml
+++ b/tests/integration/targets/hcloud_load_balancer_network/tasks/main.yml
@@ -2,7 +2,7 @@
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 ---
 - name: setup network
-  hcloud_network:
+  hetzner.hcloud.hcloud_network:
     name: "{{ hcloud_network_name }}"
     ip_range: "10.0.0.0/8"
     state: present
@@ -13,7 +13,7 @@
       - network is success
 
 - name: setup subnetwork
-  hcloud_subnetwork:
+  hetzner.hcloud.hcloud_subnetwork:
     network: "{{ hcloud_network_name }}"
     ip_range: "10.0.0.0/16"
     type: "cloud"
@@ -26,7 +26,7 @@
       - subnetwork is success
 
 - name: setup load_balancer
-  hcloud_load_balancer:
+  hetzner.hcloud.hcloud_load_balancer:
     name: "{{hcloud_load_balancer_name}}"
     load_balancer_type: lb11
     state: present
@@ -38,7 +38,7 @@
       - load_balancer is success
 
 - name: test missing required parameters on create load_balancer network
-  hcloud_load_balancer_network:
+  hetzner.hcloud.hcloud_load_balancer_network:
     state: present
   register: result
   ignore_errors: true
@@ -75,7 +75,7 @@
       - "result.msg == 'Network does not exist: does-not-exist'"
 
 - name: test create load_balancer network with checkmode
-  hcloud_load_balancer_network:
+  hetzner.hcloud.hcloud_load_balancer_network:
     network: "{{ hcloud_network_name }}"
     load_balancer: "{{hcloud_load_balancer_name}}"
     state: present
@@ -87,7 +87,7 @@
       - result is changed
 
 - name: test create load_balancer network
-  hcloud_load_balancer_network:
+  hetzner.hcloud.hcloud_load_balancer_network:
     network: "{{ hcloud_network_name }}"
     load_balancer: "{{hcloud_load_balancer_name}}"
     state: present
@@ -100,7 +100,7 @@
       - load_balancerNetwork.hcloud_load_balancer_network.load_balancer == hcloud_load_balancer_name
 
 - name: test create load_balancer network idempotency
-  hcloud_load_balancer_network:
+  hetzner.hcloud.hcloud_load_balancer_network:
     network: "{{ hcloud_network_name }}"
     load_balancer: "{{hcloud_load_balancer_name}}"
     state: present
@@ -111,7 +111,7 @@
       - load_balancerNetwork is not changed
 
 - name: test absent load_balancer network
-  hcloud_load_balancer_network:
+  hetzner.hcloud.hcloud_load_balancer_network:
     network: "{{ hcloud_network_name }}"
     load_balancer: "{{hcloud_load_balancer_name}}"
     state: absent
@@ -122,7 +122,7 @@
       - result is changed
 
 - name: test create load_balancer network with specified ip
-  hcloud_load_balancer_network:
+  hetzner.hcloud.hcloud_load_balancer_network:
     network: "{{ hcloud_network_name }}"
     load_balancer: "{{hcloud_load_balancer_name}}"
     ip: "10.0.0.2"
@@ -137,7 +137,7 @@
       - load_balancerNetwork.hcloud_load_balancer_network.ip == "10.0.0.2"
 
 - name: cleanup create load_balancer network with specified ip
-  hcloud_load_balancer_network:
+  hetzner.hcloud.hcloud_load_balancer_network:
     network: "{{ hcloud_network_name }}"
     load_balancer: "{{hcloud_load_balancer_name}}"
     state: absent
@@ -148,7 +148,7 @@
       - result is changed
 
 - name: cleanup load_balancer
-  hcloud_load_balancer:
+  hetzner.hcloud.hcloud_load_balancer:
     name: "{{ hcloud_load_balancer_name }}"
     state: absent
   register: result
@@ -158,7 +158,7 @@
       - result is success
 
 - name: cleanup subnetwork
-  hcloud_subnetwork:
+  hetzner.hcloud.hcloud_subnetwork:
     network: "{{ hcloud_network_name }}"
     ip_range: "10.0.0.0/16"
     type: "cloud"
@@ -171,7 +171,7 @@
       - result is changed
 
 - name: cleanup
-  hcloud_network:
+  hetzner.hcloud.hcloud_network:
     name: "{{hcloud_network_name}}"
     state: absent
   register: result

--- a/tests/integration/targets/hcloud_load_balancer_service/tasks/main.yml
+++ b/tests/integration/targets/hcloud_load_balancer_service/tasks/main.yml
@@ -2,7 +2,7 @@
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 ---
 - name: setup load_balancer
-  hcloud_load_balancer:
+  hetzner.hcloud.hcloud_load_balancer:
     name: "{{hcloud_load_balancer_name}}"
     load_balancer_type: lb11
     state: present
@@ -28,7 +28,7 @@
       - "result.msg == 'Load balancer does not exist: does-not-exist'"
 
 - name: test create load_balancer service with checkmode
-  hcloud_load_balancer_service:
+  hetzner.hcloud.hcloud_load_balancer_service:
     load_balancer: "{{hcloud_load_balancer_name}}"
     protocol: "http"
     listen_port: 80
@@ -41,7 +41,7 @@
       - result is changed
 
 - name: test create load_balancer service
-  hcloud_load_balancer_service:
+  hetzner.hcloud.hcloud_load_balancer_service:
     load_balancer: "{{hcloud_load_balancer_name}}"
     protocol: "http"
     listen_port: 80
@@ -57,7 +57,7 @@
       - load_balancer_service.hcloud_load_balancer_service.proxyprotocol is sameas false
 
 - name: test create load_balancer service idempotency
-  hcloud_load_balancer_service:
+  hetzner.hcloud.hcloud_load_balancer_service:
     load_balancer: "{{hcloud_load_balancer_name}}"
     protocol: "http"
     listen_port: 80
@@ -69,7 +69,7 @@
       - load_balancer_service is not changed
 
 - name: test update load_balancer service
-  hcloud_load_balancer_service:
+  hetzner.hcloud.hcloud_load_balancer_service:
     load_balancer: "{{hcloud_load_balancer_name}}"
     protocol: "tcp"
     listen_port: 80
@@ -85,7 +85,7 @@
       - load_balancer_service.hcloud_load_balancer_service.proxyprotocol is sameas false
 
 - name: test absent load_balancer service
-  hcloud_load_balancer_service:
+  hetzner.hcloud.hcloud_load_balancer_service:
     load_balancer: "{{hcloud_load_balancer_name}}"
     protocol: "http"
     listen_port: 80
@@ -97,7 +97,7 @@
       - result is changed
 
 - name: test create load_balancer service with http
-  hcloud_load_balancer_service:
+  hetzner.hcloud.hcloud_load_balancer_service:
     load_balancer: "{{hcloud_load_balancer_name}}"
     protocol: "http"
     listen_port: 80
@@ -116,7 +116,7 @@
       - load_balancer_service.hcloud_load_balancer_service.proxyprotocol is sameas false
 
 - name: cleanup load_balancer
-  hcloud_load_balancer:
+  hetzner.hcloud.hcloud_load_balancer:
     name: "{{ hcloud_load_balancer_name }}"
     state: absent
   register: result

--- a/tests/integration/targets/hcloud_load_balancer_target/tasks/main.yml
+++ b/tests/integration/targets/hcloud_load_balancer_target/tasks/main.yml
@@ -2,7 +2,7 @@
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 ---
 - name: setup server
-  hcloud_server:
+  hetzner.hcloud.hcloud_server:
     name: "{{hcloud_server_name}}"
     server_type: cx11
     image: ubuntu-22.04
@@ -15,7 +15,7 @@
       - server is success
 
 - name: setup load_balancer
-  hcloud_load_balancer:
+  hetzner.hcloud.hcloud_load_balancer:
     name: "{{hcloud_load_balancer_name}}"
     load_balancer_type: lb11
     state: present
@@ -53,7 +53,7 @@
       - "result.msg == 'Server not found: does-not-exist'"
 
 - name: test create load_balancer target with checkmode
-  hcloud_load_balancer_target:
+  hetzner.hcloud.hcloud_load_balancer_target:
     type: "server"
     load_balancer: "{{hcloud_load_balancer_name}}"
     server: "{{hcloud_server_name}}"
@@ -66,7 +66,7 @@
       - result is changed
 
 - name: test create load_balancer target
-  hcloud_load_balancer_target:
+  hetzner.hcloud.hcloud_load_balancer_target:
     type: "server"
     load_balancer: "{{hcloud_load_balancer_name}}"
     server: "{{hcloud_server_name}}"
@@ -81,7 +81,7 @@
       - load_balancer_target.hcloud_load_balancer_target.load_balancer == hcloud_load_balancer_name
 
 - name: test create load_balancer target idempotency
-  hcloud_load_balancer_target:
+  hetzner.hcloud.hcloud_load_balancer_target:
     type: "server"
     load_balancer: "{{hcloud_load_balancer_name}}"
     server: "{{hcloud_server_name}}"
@@ -93,7 +93,7 @@
       - load_balancer_target is not changed
 
 - name: test absent load_balancer target
-  hcloud_load_balancer_target:
+  hetzner.hcloud.hcloud_load_balancer_target:
     type: "server"
     load_balancer: "{{hcloud_load_balancer_name}}"
     server: "{{hcloud_server_name}}"
@@ -105,7 +105,7 @@
       - result is changed
 
 - name: test create label_selector target
-  hcloud_load_balancer_target:
+  hetzner.hcloud.hcloud_load_balancer_target:
     type: "label_selector"
     load_balancer: "{{hcloud_load_balancer_name}}"
     label_selector: "application=backend"
@@ -120,7 +120,7 @@
       - load_balancer_target.hcloud_load_balancer_target.load_balancer == hcloud_load_balancer_name
 
 - name: test create ip target
-  hcloud_load_balancer_target:
+  hetzner.hcloud.hcloud_load_balancer_target:
     type: "ip"
     load_balancer: "{{hcloud_load_balancer_name}}"
     ip: "{{hcloud_testing_ip}}"
@@ -135,7 +135,7 @@
       - load_balancer_target.hcloud_load_balancer_target.load_balancer == hcloud_load_balancer_name
 
 - name: cleanup load_balancer
-  hcloud_load_balancer:
+  hetzner.hcloud.hcloud_load_balancer:
     name: "{{ hcloud_load_balancer_name }}"
     state: absent
   register: result
@@ -144,7 +144,7 @@
   delay: 2
 
 - name: cleanup
-  hcloud_server:
+  hetzner.hcloud.hcloud_server:
     name: "{{hcloud_server_name}}"
     state: absent
   register: result

--- a/tests/integration/targets/hcloud_load_balancer_type_info/tasks/main.yml
+++ b/tests/integration/targets/hcloud_load_balancer_type_info/tasks/main.yml
@@ -2,7 +2,7 @@
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 ---
 - name: test gather hcloud Load Balancer type infos
-  hcloud_load_balancer_type_info:
+  hetzner.hcloud.hcloud_load_balancer_type_info:
   register: hcloud_load_balancer_types
 - name: verify test gather hcloud Load Balancer type infos
   assert:
@@ -10,7 +10,7 @@
       - hcloud_load_balancer_types.hcloud_load_balancer_type_info| list | count >= 1
 
 - name: test gather hcloud Load Balancer type infos in check mode
-  hcloud_load_balancer_type_info:
+  hetzner.hcloud.hcloud_load_balancer_type_info:
   check_mode: true
   register: hcloud_load_balancer_types
 
@@ -20,7 +20,7 @@
       - hcloud_load_balancer_types.hcloud_load_balancer_type_info| list | count >= 1
 
 - name: test gather hcloud Load Balancer type infos with name
-  hcloud_load_balancer_type_info:
+  hetzner.hcloud.hcloud_load_balancer_type_info:
     name: "{{hcloud_load_balancer_type_name}}"
   register: hcloud_load_balancer_types
 - name: verify test gather hcloud Load Balancer type with name
@@ -29,7 +29,7 @@
       - hcloud_load_balancer_types.hcloud_load_balancer_type_info|selectattr('name','equalto','{{ hcloud_load_balancer_type_name }}') | list | count == 1
 
 - name: test gather hcloud Load Balancer type infos with correct id
-  hcloud_load_balancer_type_info:
+  hetzner.hcloud.hcloud_load_balancer_type_info:
     id: "{{hcloud_load_balancer_type_id}}"
   register: hcloud_load_balancer_types
 - name: verify test gather hcloud Load Balancer type with correct id

--- a/tests/integration/targets/hcloud_location_info/tasks/main.yml
+++ b/tests/integration/targets/hcloud_location_info/tasks/main.yml
@@ -2,7 +2,7 @@
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 ---
 - name: test gather hcloud location infos
-  hcloud_location_info:
+  hetzner.hcloud.hcloud_location_info:
   register: hcloud_location
 
 - name: verify test gather hcloud location infos
@@ -11,7 +11,7 @@
       - hcloud_location.hcloud_location_info | list | count >= 5
 
 - name: test gather hcloud location infos in check mode
-  hcloud_location_info:
+  hetzner.hcloud.hcloud_location_info:
   check_mode: true
   register: hcloud_location
 
@@ -21,7 +21,7 @@
       - hcloud_location.hcloud_location_info | list | count >= 5
 
 - name: test gather hcloud location infos with correct name
-  hcloud_location_info:
+  hetzner.hcloud.hcloud_location_info:
     name: "{{hcloud_location_name}}"
   register: hcloud_location
 - name: verify test gather hcloud location with correct name
@@ -30,7 +30,7 @@
       - hcloud_location.hcloud_location_info|selectattr('name','equalto','{{ hcloud_location_name }}') | list | count == 1
 
 - name: test gather hcloud location infos with wrong name
-  hcloud_location_info:
+  hetzner.hcloud.hcloud_location_info:
     name: "{{hcloud_location_name}}1"
   register: hcloud_location
 - name: verify test gather hcloud location with wrong name
@@ -39,7 +39,7 @@
       - hcloud_location.hcloud_location_info | list | count == 0
 
 - name: test gather hcloud location infos with correct id
-  hcloud_location_info:
+  hetzner.hcloud.hcloud_location_info:
     id: "{{hcloud_location_id}}"
   register: hcloud_location
 - name: verify test gather hcloud location with correct id
@@ -48,7 +48,7 @@
       - hcloud_location.hcloud_location_info|selectattr('name','equalto','{{ hcloud_location_name }}') | list | count == 1
 
 - name: test gather hcloud location infos with wrong id
-  hcloud_location_info:
+  hetzner.hcloud.hcloud_location_info:
     name: "4711"
   register: hcloud_location
 - name: verify test gather hcloud location with wrong id

--- a/tests/integration/targets/hcloud_network/tasks/main.yml
+++ b/tests/integration/targets/hcloud_network/tasks/main.yml
@@ -2,7 +2,7 @@
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 ---
 - name: setup ensure network is absent
-  hcloud_network:
+  hetzner.hcloud.hcloud_network:
     name: "{{ item }}"
     state: absent
   with_items:
@@ -10,7 +10,7 @@
     - "{{ hcloud_network_name_with_vswitch }}"
 
 - name: test missing ip_range parameter on create Network
-  hcloud_network:
+  hetzner.hcloud.hcloud_network:
     name: "{{hcloud_network_name}}"
   register: result
   ignore_errors: true
@@ -21,7 +21,7 @@
       - 'result.msg == "missing required arguments: ip_range"'
 
 - name: test create Network with check mode
-  hcloud_network:
+  hetzner.hcloud.hcloud_network:
     name: "{{hcloud_network_name}}"
     ip_range: "10.0.0.0/16"
   register: result
@@ -32,7 +32,7 @@
       - result is changed
 
 - name: test create Network
-  hcloud_network:
+  hetzner.hcloud.hcloud_network:
     name: "{{hcloud_network_name}}"
     ip_range: "10.0.0.0/16"
   register: network
@@ -44,7 +44,7 @@
       - network.hcloud_network.ip_range == "10.0.0.0/16"
 
 - name: test create Network idempotence
-  hcloud_network:
+  hetzner.hcloud.hcloud_network:
     name: "{{hcloud_network_name}}"
     ip_range: "10.0.0.0/16"
   register: network
@@ -54,7 +54,7 @@
       - network is not changed
 
 - name: test create Network with expose_routes_to_vswitch
-  hcloud_network:
+  hetzner.hcloud.hcloud_network:
     name: "{{hcloud_network_name_with_vswitch}}"
     ip_range: "10.0.0.0/16"
     expose_routes_to_vswitch: true
@@ -68,7 +68,7 @@
       - network.hcloud_network.expose_routes_to_vswitch is true
 
 - name: test create Network with expose_routes_to_vswitch idempotence
-  hcloud_network:
+  hetzner.hcloud.hcloud_network:
     name: "{{hcloud_network_name_with_vswitch}}"
     ip_range: "10.0.0.0/16"
     expose_routes_to_vswitch: true
@@ -79,7 +79,7 @@
       - network is not changed
 
 - name: test update Network label
-  hcloud_network:
+  hetzner.hcloud.hcloud_network:
     name: "{{hcloud_network_name}}"
     labels:
       key: value
@@ -91,7 +91,7 @@
       - network.hcloud_network.labels.key == "value"
 
 - name: test update Network label idempotency
-  hcloud_network:
+  hetzner.hcloud.hcloud_network:
     name: "{{hcloud_network_name}}"
     labels:
       key: value
@@ -102,7 +102,7 @@
       - network is not changed
 
 - name: test update Network ip range
-  hcloud_network:
+  hetzner.hcloud.hcloud_network:
     name: "{{hcloud_network_name}}"
     ip_range: "10.0.0.0/8"
   register: network
@@ -113,7 +113,7 @@
       - network.hcloud_network.ip_range == "10.0.0.0/8"
 
 - name: test update Network ip range idempotency
-  hcloud_network:
+  hetzner.hcloud.hcloud_network:
     name: "{{hcloud_network_name}}"
     ip_range: "10.0.0.0/8"
   register: network
@@ -123,7 +123,7 @@
       - network is not changed
 
 - name: test update Network expose_routes_to_vswitch
-  hcloud_network:
+  hetzner.hcloud.hcloud_network:
     name: "{{hcloud_network_name_with_vswitch}}"
     expose_routes_to_vswitch: false
   register: network
@@ -134,7 +134,7 @@
       - network.hcloud_network.expose_routes_to_vswitch is false
 
 - name: test update Network expose_routes_to_vswitch idempotency
-  hcloud_network:
+  hetzner.hcloud.hcloud_network:
     name: "{{hcloud_network_name_with_vswitch}}"
     expose_routes_to_vswitch: false
   register: network
@@ -144,7 +144,7 @@
       - network is not changed
 
 - name: test update Network delete protection
-  hcloud_network:
+  hetzner.hcloud.hcloud_network:
     name: "{{hcloud_network_name}}"
     ip_range: "10.0.0.0/8"
     delete_protection: true
@@ -156,7 +156,7 @@
       - network.hcloud_network.delete_protection is sameas true
 
 - name: test update Network delete protection idempotency
-  hcloud_network:
+  hetzner.hcloud.hcloud_network:
     name: "{{hcloud_network_name}}"
     ip_range: "10.0.0.0/8"
     delete_protection: true
@@ -168,7 +168,7 @@
       - network.hcloud_network.delete_protection is sameas true
 
 - name: test Network without delete protection set to be idempotent
-  hcloud_network:
+  hetzner.hcloud.hcloud_network:
     name: "{{hcloud_network_name}}"
     ip_range: "10.0.0.0/8"
   register: network
@@ -179,7 +179,7 @@
       - network.hcloud_network.delete_protection is sameas true
 
 - name: test delete Network fails if it is protected
-  hcloud_network:
+  hetzner.hcloud.hcloud_network:
     name: "{{hcloud_network_name}}"
     state: absent
   ignore_errors: true
@@ -191,7 +191,7 @@
       - 'result.msg == "network deletion is protected"'
 
 - name: test update Network delete protection
-  hcloud_network:
+  hetzner.hcloud.hcloud_network:
     name: "{{hcloud_network_name}}"
     ip_range: "10.0.0.0/8"
     delete_protection: false
@@ -203,7 +203,7 @@
       - network.hcloud_network.delete_protection is sameas false
 
 - name: test delete Network
-  hcloud_network:
+  hetzner.hcloud.hcloud_network:
     name: "{{hcloud_network_name}}"
     state: absent
   register: result
@@ -213,7 +213,7 @@
       - result is success
 
 - name: test create Network with delete protection
-  hcloud_network:
+  hetzner.hcloud.hcloud_network:
     name: "{{hcloud_network_name}}"
     ip_range: "10.0.0.0/8"
     delete_protection: true
@@ -225,7 +225,7 @@
       - network.hcloud_network.delete_protection is sameas true
 
 - name: test delete Network fails if it is protected
-  hcloud_network:
+  hetzner.hcloud.hcloud_network:
     name: "{{hcloud_network_name}}"
     state: absent
   ignore_errors: true
@@ -237,7 +237,7 @@
       - 'result.msg == "network deletion is protected"'
 
 - name: test update Network delete protection
-  hcloud_network:
+  hetzner.hcloud.hcloud_network:
     name: "{{hcloud_network_name}}"
     delete_protection: false
   register: network
@@ -248,7 +248,7 @@
       - network.hcloud_network.delete_protection is sameas false
 
 - name: test delete Network
-  hcloud_network:
+  hetzner.hcloud.hcloud_network:
     name: "{{hcloud_network_name}}"
     state: absent
   register: result
@@ -258,7 +258,7 @@
       - result is success
 
 - name: test delete Network with expose_routes_to_vswitch
-  hcloud_network:
+  hetzner.hcloud.hcloud_network:
     name: "{{hcloud_network_name_with_vswitch}}"
     state: absent
   register: result

--- a/tests/integration/targets/hcloud_network_info/tasks/main.yml
+++ b/tests/integration/targets/hcloud_network_info/tasks/main.yml
@@ -2,13 +2,13 @@
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 ---
 - name: setup ensure network is absent
-  hcloud_network:
+  hetzner.hcloud.hcloud_network:
     name: "{{ hcloud_network_name }}"
     state: absent
   register: result
 
 - name: create network
-  hcloud_network:
+  hetzner.hcloud.hcloud_network:
     name: "{{ hcloud_network_name }}"
     ip_range: "10.0.0.0/16"
     labels:
@@ -22,7 +22,7 @@
       - main_network.hcloud_network.ip_range == "10.0.0.0/16"
       - main_network.hcloud_network.expose_routes_to_vswitch is false
 - name: create subnetwork
-  hcloud_subnetwork:
+  hetzner.hcloud.hcloud_subnetwork:
     network: "{{ hcloud_network_name }}"
     type: server
     network_zone: eu-central
@@ -34,7 +34,7 @@
       - main_subnetwork is changed
       - main_subnetwork.hcloud_subnetwork.network == "{{ hcloud_network_name }}"
 - name: create route
-  hcloud_route:
+  hetzner.hcloud.hcloud_route:
     network: "{{ hcloud_network_name }}"
     destination: "10.0.3.0/24"
     gateway: "10.0.2.1"
@@ -46,7 +46,7 @@
       - main_route.hcloud_route.network == "{{ hcloud_network_name }}"
 
 - name: test gather hcloud network info in check mode
-  hcloud_network_info:
+  hetzner.hcloud.hcloud_network_info:
   check_mode: true
   register: hcloud_network
 - name: verify test gather hcloud network info in check mode
@@ -55,7 +55,7 @@
       - hcloud_network.hcloud_network_info | selectattr('name','equalto','{{ hcloud_network_name }}') | list | count >= 1
 
 - name: test gather hcloud network info with correct label selector
-  hcloud_network_info:
+  hetzner.hcloud.hcloud_network_info:
     label_selector: "key=value"
   register: hcloud_network
 - name: verify test gather hcloud network with correct label selector
@@ -64,7 +64,7 @@
       - hcloud_network.hcloud_network_info | selectattr('name','equalto','{{ hcloud_network_name }}') | list | count >= 1
 
 - name: test gather hcloud network info with wrong label selector
-  hcloud_network_info:
+  hetzner.hcloud.hcloud_network_info:
     label_selector: "key!=value"
   register: hcloud_network
 - name: verify test gather hcloud network with wrong label selector
@@ -73,7 +73,7 @@
       - hcloud_network.hcloud_network_info | list | count == 0
 
 - name: test gather hcloud network info with correct name
-  hcloud_network_info:
+  hetzner.hcloud.hcloud_network_info:
     name: "{{hcloud_network_name}}"
   register: hcloud_network
 - name: verify test gather hcloud network with correct name
@@ -84,7 +84,7 @@
       - hcloud_network.hcloud_network_info[0].routes | list | count >= 1
 
 - name: test gather hcloud network info with wrong name
-  hcloud_network_info:
+  hetzner.hcloud.hcloud_network_info:
     name: "{{hcloud_network_name}}1"
   register: hcloud_network
 - name: verify test gather hcloud network with wrong name
@@ -93,7 +93,7 @@
       - hcloud_network.hcloud_network_info | list | count == 0
 
 - name: test gather hcloud network info with correct id
-  hcloud_network_info:
+  hetzner.hcloud.hcloud_network_info:
     id: "{{main_network.hcloud_network.id}}"
   register: hcloud_network
 - name: verify test gather hcloud network with correct id
@@ -102,7 +102,7 @@
       - hcloud_network.hcloud_network_info | selectattr('name','equalto','{{ hcloud_network_name }}') | list | count == 1
 
 - name: test gather hcloud network info with wrong id
-  hcloud_network_info:
+  hetzner.hcloud.hcloud_network_info:
     name: "4711"
   register: hcloud_network
 - name: verify test gather hcloud network with wrong id
@@ -111,6 +111,6 @@
       - hcloud_network.hcloud_network_info | list | count == 0
 
 - name: cleanup
-  hcloud_network:
+  hetzner.hcloud.hcloud_network:
     name: "{{ hcloud_network_name }}"
     state: absent

--- a/tests/integration/targets/hcloud_placement_group/tasks/main.yml
+++ b/tests/integration/targets/hcloud_placement_group/tasks/main.yml
@@ -2,17 +2,17 @@
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 ---
 - name: setup placement group to be absent
-  hcloud_placement_group:
+  hetzner.hcloud.hcloud_placement_group:
     name: "{{ hcloud_placement_group_name }}"
     state: absent
 
 - name: setup server to be absent
-  hcloud_server:
+  hetzner.hcloud.hcloud_server:
     name: "{{ hcloud_server_name }}"
     state: absent
 
 - name: test missing required parameters on create placement group
-  hcloud_placement_group:
+  hetzner.hcloud.hcloud_placement_group:
   register: result
   ignore_errors: true
 - name: verify fail test missing required parameters on create placement group
@@ -22,7 +22,7 @@
       - 'result.msg == "one of the following is required: id, name"'
 
 - name: test create placement group with check mode
-  hcloud_placement_group:
+  hetzner.hcloud.hcloud_placement_group:
     name: "{{ hcloud_placement_group_name }}"
     type: spread
   register: result
@@ -33,7 +33,7 @@
       - result is changed
 
 - name: test create placement group
-  hcloud_placement_group:
+  hetzner.hcloud.hcloud_placement_group:
     name: "{{ hcloud_placement_group_name }}"
     type: spread
     labels:
@@ -49,7 +49,7 @@
       - placement_group.hcloud_placement_group.servers | list | count == 0
 
 - name: test create placement group idempotence
-  hcloud_placement_group:
+  hetzner.hcloud.hcloud_placement_group:
     name: "{{ hcloud_placement_group_name }}"
     type: spread
     labels:
@@ -62,7 +62,7 @@
       - result is not changed
 
 - name: test create server with placement group
-  hcloud_server:
+  hetzner.hcloud.hcloud_server:
     name: "{{ hcloud_server_name }}"
     server_type: cpx11
     placement_group: "{{ hcloud_placement_group_name }}"
@@ -78,7 +78,7 @@
       - server.hcloud_server.placement_group == "{{ hcloud_placement_group_name }}"
 
 - name: test remove server from placement group
-  hcloud_server:
+  hetzner.hcloud.hcloud_server:
     name: "{{ hcloud_server_name }}"
     placement_group: null
     state: present
@@ -90,7 +90,7 @@
       - result.hcloud_server.placement_group == None
 
 - name: test add server to placement group
-  hcloud_server:
+  hetzner.hcloud.hcloud_server:
     name: "{{ hcloud_server_name }}"
     placement_group: "{{ hcloud_placement_group_name }}"
     force: True
@@ -104,7 +104,7 @@
       - result.hcloud_server.status == "running"
 
 - name: test add server to placement group idempotence
-  hcloud_server:
+  hetzner.hcloud.hcloud_server:
     name: "{{ hcloud_server_name }}"
     placement_group: "{{ hcloud_placement_group_name }}"
     force: True
@@ -118,7 +118,7 @@
       - result.hcloud_server.status == "running"
 
 - name: test update placement group with check mode
-  hcloud_placement_group:
+  hetzner.hcloud.hcloud_placement_group:
     id: "{{ placement_group.hcloud_placement_group.id }}"
     name: "changed-{{ hcloud_placement_group_name }}"
   register: result
@@ -129,7 +129,7 @@
       - result is changed
 
 - name: test update placement group
-  hcloud_placement_group:
+  hetzner.hcloud.hcloud_placement_group:
     id: "{{ placement_group.hcloud_placement_group.id }}"
     name: "changed-{{ hcloud_placement_group_name }}"
     labels:
@@ -142,7 +142,7 @@
       - result.hcloud_placement_group.name == "changed-{{ hcloud_placement_group_name }}"
 
 - name: test update placement group idempotence
-  hcloud_placement_group:
+  hetzner.hcloud.hcloud_placement_group:
     id: "{{ placement_group.hcloud_placement_group.id }}"
     name: "changed-{{ hcloud_placement_group_name }}"
     labels:
@@ -154,12 +154,12 @@
       - result is not changed
 
 - name: absent server
-  hcloud_server:
+  hetzner.hcloud.hcloud_server:
     id: "{{ server.hcloud_server.id }}"
     state: absent
 
 - name: absent placement group
-  hcloud_placement_group:
+  hetzner.hcloud.hcloud_placement_group:
     id: "{{ placement_group.hcloud_placement_group.id }}"
     state: absent
   register: result

--- a/tests/integration/targets/hcloud_primary_ip/tasks/main.yml
+++ b/tests/integration/targets/hcloud_primary_ip/tasks/main.yml
@@ -2,12 +2,12 @@
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 ---
 - name: setup ensure primary ip is absent
-  hcloud_primary_ip:
+  hetzner.hcloud.hcloud_primary_ip:
     name: "{{ hcloud_primary_ip_name }}"
     state: absent
 
 - name: test create Primary IP with check mode
-  hcloud_primary_ip:
+  hetzner.hcloud.hcloud_primary_ip:
     name: "{{ hcloud_primary_ip_name }}"
     type: ipv4
     datacenter: "fsn1-dc14"
@@ -19,7 +19,7 @@
       - primaryIP is changed
 
 - name: test create Primary IP
-  hcloud_primary_ip:
+  hetzner.hcloud.hcloud_primary_ip:
     name: "{{ hcloud_primary_ip_name }}"
     type: ipv4
     datacenter: "fsn1-dc14"
@@ -32,7 +32,7 @@
       - primaryIP.hcloud_primary_ip.datacenter == "fsn1-dc14"
 
 - name: test create Primary IP idempotency
-  hcloud_primary_ip:
+  hetzner.hcloud.hcloud_primary_ip:
     name: "{{ hcloud_primary_ip_name }}"
     type: ipv4
     datacenter: "fsn1-dc14"
@@ -43,7 +43,7 @@
       - primaryIP is not changed
 
 - name: test update Primary IP
-  hcloud_primary_ip:
+  hetzner.hcloud.hcloud_primary_ip:
     name: "{{ hcloud_primary_ip_name }}"
     type: ipv4
     datacenter: "fsn1-dc14"
@@ -56,7 +56,7 @@
       - primaryIP is changed
 
 - name: test update Primary IP idempotency
-  hcloud_primary_ip:
+  hetzner.hcloud.hcloud_primary_ip:
     name: "{{ hcloud_primary_ip_name }}"
     type: ipv4
     datacenter: "fsn1-dc14"
@@ -69,7 +69,7 @@
       - primaryIP is not changed
 
 - name: test update Primary IP with same labels
-  hcloud_primary_ip:
+  hetzner.hcloud.hcloud_primary_ip:
     name: "{{ hcloud_primary_ip_name }}"
     type: ipv4
     datacenter: "fsn1-dc14"
@@ -82,7 +82,7 @@
       - primaryIP is not changed
 
 - name: test update Primary IP with other labels
-  hcloud_primary_ip:
+  hetzner.hcloud.hcloud_primary_ip:
     name: "{{ hcloud_primary_ip_name }}"
     type: ipv4
     datacenter: "fsn1-dc14"
@@ -96,7 +96,7 @@
       - primaryIP is changed
 
 - name: test update Primary IP with other labels in different order
-  hcloud_primary_ip:
+  hetzner.hcloud.hcloud_primary_ip:
     name: "{{ hcloud_primary_ip_name }}"
     type: ipv4
     datacenter: "fsn1-dc14"
@@ -110,7 +110,7 @@
       - primaryIP is not changed
 
 - name: test update Primary IP delete protection
-  hcloud_primary_ip:
+  hetzner.hcloud.hcloud_primary_ip:
     name: "{{ hcloud_primary_ip_name }}"
     type: ipv4
     delete_protection: true
@@ -122,7 +122,7 @@
       - primaryIP.hcloud_primary_ip.delete_protection is sameas true
 
 - name: test update Primary IP delete protection idempotency
-  hcloud_primary_ip:
+  hetzner.hcloud.hcloud_primary_ip:
     name: "{{ hcloud_primary_ip_name }}"
     type: ipv4
     delete_protection: true
@@ -134,7 +134,7 @@
       - primaryIP.hcloud_primary_ip.delete_protection is sameas true
 
 - name: test Primary IP without delete protection set to be idempotent
-  hcloud_primary_ip:
+  hetzner.hcloud.hcloud_primary_ip:
     name: "{{ hcloud_primary_ip_name }}"
     type: ipv4
   register: primaryIP
@@ -145,7 +145,7 @@
       - primaryIP.hcloud_primary_ip.delete_protection is sameas true
 
 - name: test delete Primary IP fails if it is protected
-  hcloud_primary_ip:
+  hetzner.hcloud.hcloud_primary_ip:
     name: "{{ hcloud_primary_ip_name }}"
     state: "absent"
   register: result
@@ -157,7 +157,7 @@
       - 'result.msg == "Primary IP deletion is protected"'
 
 - name: test update Primary IP delete protection
-  hcloud_primary_ip:
+  hetzner.hcloud.hcloud_primary_ip:
     name: "{{ hcloud_primary_ip_name }}"
     type: ipv4
     delete_protection: false
@@ -169,7 +169,7 @@
       - primaryIP.hcloud_primary_ip.delete_protection is sameas false
 
 - name: test delete primary ip
-  hcloud_primary_ip:
+  hetzner.hcloud.hcloud_primary_ip:
     name: "{{ hcloud_primary_ip_name }}"
     state: "absent"
   register: result
@@ -179,7 +179,7 @@
       - result is changed
 
 - name: test create ipv6 primary ip
-  hcloud_primary_ip:
+  hetzner.hcloud.hcloud_primary_ip:
     name: "{{ hcloud_primary_ip_name }}"
     type: ipv6
     datacenter: "fsn1-dc14"
@@ -191,7 +191,7 @@
       - result is changed
 
 - name: test delete ipv6 primary ip
-  hcloud_primary_ip:
+  hetzner.hcloud.hcloud_primary_ip:
     name: "{{ hcloud_primary_ip_name }}"
     state: "absent"
   register: result
@@ -201,7 +201,7 @@
       - result is changed
 
 - name: test create Primary IP with delete protection
-  hcloud_primary_ip:
+  hetzner.hcloud.hcloud_primary_ip:
     name: "{{ hcloud_primary_ip_name }}"
     type: ipv4
     datacenter: fsn1-dc14
@@ -214,7 +214,7 @@
       - primaryIP.hcloud_primary_ip.delete_protection is sameas true
 
 - name: test delete Primary IP fails if it is protected
-  hcloud_primary_ip:
+  hetzner.hcloud.hcloud_primary_ip:
     name: "{{ hcloud_primary_ip_name }}"
     state: "absent"
   register: result
@@ -226,7 +226,7 @@
       - 'result.msg == "Primary IP deletion is protected"'
 
 - name: test update Primary IP delete protection
-  hcloud_primary_ip:
+  hetzner.hcloud.hcloud_primary_ip:
     name: "{{ hcloud_primary_ip_name }}"
     type: ipv4
     delete_protection: false
@@ -238,7 +238,7 @@
       - primaryIP.hcloud_primary_ip.delete_protection is sameas false
 
 - name: test delete primary ip
-  hcloud_primary_ip:
+  hetzner.hcloud.hcloud_primary_ip:
     name: "{{ hcloud_primary_ip_name }}"
     state: "absent"
   register: result

--- a/tests/integration/targets/hcloud_primary_ip_info/tasks/main.yml
+++ b/tests/integration/targets/hcloud_primary_ip_info/tasks/main.yml
@@ -2,12 +2,12 @@
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 ---
 - name: setup ensure primary ip is absent
-  hcloud_primary_ip:
+  hetzner.hcloud.hcloud_primary_ip:
     name: "{{ hcloud_primary_ip_name }}"
     state: absent
 
 - name: setup primary ip
-  hcloud_primary_ip:
+  hetzner.hcloud.hcloud_primary_ip:
     name: "{{ hcloud_primary_ip_name }}"
     datacenter: "fsn1-dc14"
     type: ipv4
@@ -21,7 +21,7 @@
       - test_primary_ip is changed
 
 - name: test gather hcloud primary ip infos
-  hcloud_primary_ip_info:
+  hetzner.hcloud.hcloud_primary_ip_info:
   register: hcloud_primary_ips
 - name: verify test gather hcloud primary ip infos
   assert:
@@ -29,7 +29,7 @@
       - hcloud_primary_ips.hcloud_primary_ip_info| list | count >= 1
 
 - name: test gather hcloud primary ip infos in check mode
-  hcloud_primary_ip_info:
+  hetzner.hcloud.hcloud_primary_ip_info:
   check_mode: yes
   register: hcloud_primary_ips
 
@@ -39,7 +39,7 @@
       - hcloud_primary_ips.hcloud_primary_ip_info| list | count >= 1
 
 - name: test gather hcloud primary ip infos with correct label selector
-  hcloud_primary_ip_info:
+  hetzner.hcloud.hcloud_primary_ip_info:
     label_selector: "key=value"
   register: hcloud_primary_ips
 - name: verify test gather hcloud primary ip with correct label selector
@@ -48,7 +48,7 @@
       - hcloud_primary_ips.hcloud_primary_ip_info|selectattr('name','equalto','{{ test_primary_ip.hcloud_primary_ip.name }}') | list | count == 1
 
 - name: test gather hcloud primary ip infos with wrong label selector
-  hcloud_primary_ip_info:
+  hetzner.hcloud.hcloud_primary_ip_info:
     label_selector: "key!=value"
   register: hcloud_primary_ips
 - name: verify test gather hcloud primary ip with wrong label selector
@@ -57,7 +57,7 @@
       - hcloud_primary_ips.hcloud_primary_ip_info | list | count == 0
 
 - name: test gather hcloud primary ip infos with correct name
-  hcloud_primary_ip_info:
+  hetzner.hcloud.hcloud_primary_ip_info:
     name: "{{ hcloud_primary_ip_name }}"
   register: hcloud_primary_ips
 - name: verify test gather hcloud primary ip with correct name
@@ -66,7 +66,7 @@
       - hcloud_primary_ips.hcloud_primary_ip_info|selectattr('name','equalto','{{ test_primary_ip.hcloud_primary_ip.name }}') | list | count == 1
 
 - name: test gather hcloud primary ip infos with wrong name
-  hcloud_primary_ip_info:
+  hetzner.hcloud.hcloud_primary_ip_info:
     name: "wrong-name"
   register: hcloud_primary_ips
 - name: verify test gather hcloud primary ip with wrong name
@@ -75,7 +75,7 @@
       - hcloud_primary_ips.hcloud_primary_ip_info | list | count == 0
 
 - name: test gather hcloud primary ip infos with correct id
-  hcloud_primary_ip_info:
+  hetzner.hcloud.hcloud_primary_ip_info:
     id: "{{test_primary_ip.hcloud_primary_ip.id}}"
   register: hcloud_primary_ips
 - name: verify test gather hcloud primary ip with correct id
@@ -84,7 +84,7 @@
       - hcloud_primary_ips.hcloud_primary_ip_info|selectattr('name','equalto','{{ test_primary_ip.hcloud_primary_ip.name }}') | list | count == 1
 
 - name: test gather hcloud primary ip infos with wrong id
-  hcloud_primary_ip_info:
+  hetzner.hcloud.hcloud_primary_ip_info:
     id: "{{test_primary_ip.hcloud_primary_ip.id}}1"
   register: result
   ignore_errors: true
@@ -94,7 +94,7 @@
       - result is failed
 
 - name: cleanup
-  hcloud_primary_ip:
+  hetzner.hcloud.hcloud_primary_ip:
     id: "{{ test_primary_ip.hcloud_primary_ip.id }}"
     state: absent
   register: result

--- a/tests/integration/targets/hcloud_rdns/tasks/main.yml
+++ b/tests/integration/targets/hcloud_rdns/tasks/main.yml
@@ -2,7 +2,7 @@
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 ---
 - name: setup
-  hcloud_server:
+  hetzner.hcloud.hcloud_server:
     name: "{{ hcloud_server_name }}"
     server_type: cx11
     image: "ubuntu-22.04"
@@ -16,7 +16,7 @@
       - setup is success
 
 - name: setup Floating IP
-  hcloud_floating_ip:
+  hetzner.hcloud.hcloud_floating_ip:
     name: "{{ hcloud_floating_ip_name }}"
     type: ipv4
     home_location: "fsn1"
@@ -27,7 +27,7 @@
       - floatingIP is success
 
 - name: setup Load Balancer
-  hcloud_load_balancer:
+  hetzner.hcloud.hcloud_load_balancer:
     name: "{{ hcloud_load_balancer_name}}"
     load_balancer_type: lb11
     network_zone: eu-central
@@ -39,7 +39,7 @@
       - load_balancer is success
 
 - name: setup Primary IP
-  hcloud_primary_ip:
+  hetzner.hcloud.hcloud_primary_ip:
     name: "{{ hcloud_primary_ip_name }}"
     type: ipv4
     datacenter: "fsn1-dc14"
@@ -50,7 +50,7 @@
       - primaryIP is success
 
 - name: test missing required parameter
-  hcloud_rdns:
+  hetzner.hcloud.hcloud_rdns:
     state: present
   register: result
   ignore_errors: true
@@ -60,7 +60,7 @@
       - result is failed
       - 'result.msg == "missing required arguments: ip_address"'
 - name: test fail on not existing resource
-  hcloud_rdns:
+  hetzner.hcloud.hcloud_rdns:
     server: "not-existing"
     ip_address: "127.0.0.1"
     state: present
@@ -72,7 +72,7 @@
       - result is failed
       - 'result.msg == "The selected server does not exist"'
 - name: test create rdns
-  hcloud_rdns:
+  hetzner.hcloud.hcloud_rdns:
     server: "{{ hcloud_server_name }}"
     ip_address: "{{ setup.hcloud_server.ipv6 | ansible.netcommon.ipaddr('next_usable') }}"
     dns_ptr: "example.com"
@@ -87,7 +87,7 @@
       - rdns.hcloud_rdns.dns_ptr == "example.com"
 
 - name: test create rdns idempotency
-  hcloud_rdns:
+  hetzner.hcloud.hcloud_rdns:
     server: "{{ hcloud_server_name }}"
     ip_address: "{{ setup.hcloud_server.ipv6 | ansible.netcommon.ipaddr('next_usable') }}"
     dns_ptr: "example.com"
@@ -99,7 +99,7 @@
       - result is not changed
 
 - name: test absent rdns
-  hcloud_rdns:
+  hetzner.hcloud.hcloud_rdns:
     server: "{{ hcloud_server_name }}"
     ip_address: "{{ setup.hcloud_server.ipv6 | ansible.netcommon.ipaddr('next_usable') }}"
     state: absent
@@ -110,7 +110,7 @@
       - result is changed
 
 - name: test update rdns
-  hcloud_rdns:
+  hetzner.hcloud.hcloud_rdns:
     server: "{{ hcloud_server_name }}"
     ip_address: "{{ setup.hcloud_server.ipv4_address }}"
     dns_ptr: "example.com"
@@ -125,7 +125,7 @@
       - rdns.hcloud_rdns.dns_ptr == "example.com"
 
 - name: test reset rdns
-  hcloud_rdns:
+  hetzner.hcloud.hcloud_rdns:
     server: "{{ hcloud_server_name }}"
     ip_address: "{{ setup.hcloud_server.ipv4_address }}"
     state: present
@@ -139,7 +139,7 @@
       - rdns.hcloud_rdns.dns_ptr != "example.com"
 
 - name: test create rdns with floating IP
-  hcloud_rdns:
+  hetzner.hcloud.hcloud_rdns:
     floating_ip: "{{ hcloud_floating_ip_name }}"
     ip_address: "{{ floatingIP.hcloud_floating_ip.ip}}"
     dns_ptr: "example.com"
@@ -154,7 +154,7 @@
       - rdns.hcloud_rdns.dns_ptr == "example.com"
 
 - name: test create rdns with primary IP
-  hcloud_rdns:
+  hetzner.hcloud.hcloud_rdns:
     primary_ip: "{{ hcloud_primary_ip_name }}"
     ip_address: "{{ primaryIP.hcloud_primary_ip.ip}}"
     dns_ptr: "example.com"
@@ -169,7 +169,7 @@
       - rdns.hcloud_rdns.dns_ptr == "example.com"
 
 - name: test create rdns with load balancer
-  hcloud_rdns:
+  hetzner.hcloud.hcloud_rdns:
     load_balancer: "{{ hcloud_load_balancer_name }}"
     ip_address: "{{ load_balancer.hcloud_load_balancer.ipv4_address }}"
     dns_ptr: "example.com"
@@ -184,7 +184,7 @@
       - rdns.hcloud_rdns.dns_ptr == "example.com"
 
 - name: cleanup
-  hcloud_server:
+  hetzner.hcloud.hcloud_server:
     name: "{{ hcloud_server_name }}"
     state: absent
   register: result
@@ -194,7 +194,7 @@
       - result is success
 
 - name: cleanup
-  hcloud_floating_ip:
+  hetzner.hcloud.hcloud_floating_ip:
     name: "{{ hcloud_floating_ip_name }}"
     state: absent
   register: result
@@ -204,7 +204,7 @@
       - result is success
 
 - name: cleanup
-  hcloud_primary_ip:
+  hetzner.hcloud.hcloud_primary_ip:
     name: "{{ hcloud_primary_ip_name }}"
     state: absent
   register: result
@@ -214,7 +214,7 @@
       - result is success
 
 - name: cleanup
-  hcloud_load_balancer:
+  hetzner.hcloud.hcloud_load_balancer:
     name: "{{ hcloud_load_balancer_name }}"
     state: absent
   register: result

--- a/tests/integration/targets/hcloud_route/tasks/main.yml
+++ b/tests/integration/targets/hcloud_route/tasks/main.yml
@@ -2,7 +2,7 @@
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 ---
 - name: setup
-  hcloud_network:
+  hetzner.hcloud.hcloud_network:
     name: "{{ hcloud_network_name }}"
     ip_range: "10.0.0.0/8"
     state: present
@@ -13,7 +13,7 @@
       - network is success
 
 - name: test missing required parameters on create route
-  hcloud_route:
+  hetzner.hcloud.hcloud_route:
     state: present
   register: result
   ignore_errors: true
@@ -24,7 +24,7 @@
       - 'result.msg == "missing required arguments: destination, gateway, network"'
 
 - name: test create route with checkmode
-  hcloud_route:
+  hetzner.hcloud.hcloud_route:
     network: "{{ hcloud_network_name }}"
     destination: "10.100.1.0/24"
     gateway: "10.0.1.1"
@@ -37,7 +37,7 @@
       - result is changed
 
 - name: test create route
-  hcloud_route:
+  hetzner.hcloud.hcloud_route:
     network: "{{ hcloud_network_name }}"
     destination: "10.100.1.0/24"
     gateway: "10.0.1.1"
@@ -52,7 +52,7 @@
       - route.hcloud_route.gateway == "10.0.1.1"
 
 - name: test create route idempotency
-  hcloud_route:
+  hetzner.hcloud.hcloud_route:
     network: "{{ hcloud_network_name }}"
     destination: "10.100.1.0/24"
     gateway: "10.0.1.1"
@@ -64,7 +64,7 @@
       - result is not changed
 
 - name: test fail create route with wrong gateway
-  hcloud_route:
+  hetzner.hcloud.hcloud_route:
     network: "{{ hcloud_network_name }}"
     destination: "10.100.1.0/24"
     gateway: "10.0.1.2"
@@ -77,7 +77,7 @@
       - route is failed
 
 - name: test absent route
-  hcloud_route:
+  hetzner.hcloud.hcloud_route:
     network: "{{ hcloud_network_name }}"
     destination: "10.100.1.0/24"
     gateway: "10.0.1.1"
@@ -89,7 +89,7 @@
       - result is changed
 
 - name: cleanup
-  hcloud_network:
+  hetzner.hcloud.hcloud_network:
     name: "{{hcloud_network_name}}"
     state: absent
   register: result

--- a/tests/integration/targets/hcloud_server/tasks/basic.yml
+++ b/tests/integration/targets/hcloud_server/tasks/basic.yml
@@ -1,5 +1,5 @@
 - name: test create server with check mode
-  hcloud_server:
+  hetzner.hcloud.hcloud_server:
     name: "{{ hcloud_server_name }}"
     server_type: cx11
     image: ubuntu-22.04
@@ -12,7 +12,7 @@
       - result is changed
 
 - name: test create server
-  hcloud_server:
+  hetzner.hcloud.hcloud_server:
     name: "{{ hcloud_server_name}}"
     server_type: cx11
     image: ubuntu-22.04
@@ -29,7 +29,7 @@
       - main_server.root_password != ""
 
 - name: test create server idempotence
-  hcloud_server:
+  hetzner.hcloud.hcloud_server:
     name: "{{ hcloud_server_name }}"
     state: started
   register: result
@@ -39,7 +39,7 @@
       - result is not changed
 
 - name: test stop server with check mode
-  hcloud_server:
+  hetzner.hcloud.hcloud_server:
     name: "{{ hcloud_server_name }}"
     state: stopped
   register: result
@@ -51,7 +51,7 @@
       - result.hcloud_server.status == "running"
 
 - name: test stop server
-  hcloud_server:
+  hetzner.hcloud.hcloud_server:
     name: "{{ hcloud_server_name }}"
     state: stopped
   register: result
@@ -62,7 +62,7 @@
       - result.hcloud_server.status == "off"
 
 - name: test start server with check mode
-  hcloud_server:
+  hetzner.hcloud.hcloud_server:
     name: "{{ hcloud_server_name }}"
     state: started
   register: result
@@ -73,7 +73,7 @@
       - result is changed
 
 - name: test start server
-  hcloud_server:
+  hetzner.hcloud.hcloud_server:
     name: "{{ hcloud_server_name }}"
     state: started
   register: result
@@ -84,7 +84,7 @@
       - result.hcloud_server.status == "running"
 
 - name: test start server idempotence
-  hcloud_server:
+  hetzner.hcloud.hcloud_server:
     name: "{{ hcloud_server_name }}"
     state: started
   register: result
@@ -95,7 +95,7 @@
       - result.hcloud_server.status == "running"
 
 - name: test stop server by its id
-  hcloud_server:
+  hetzner.hcloud.hcloud_server:
     id: "{{ main_server.hcloud_server.id }}"
     state: stopped
   register: result
@@ -106,7 +106,7 @@
       - result.hcloud_server.status == "off"
 
 - name: test resize server running without force
-  hcloud_server:
+  hetzner.hcloud.hcloud_server:
     name: "{{ hcloud_server_name }}"
     server_type: "cx21"
     state: present
@@ -119,7 +119,7 @@
       - result.hcloud_server.server_type == "cx11"
 
 - name: test resize server with check mode
-  hcloud_server:
+  hetzner.hcloud.hcloud_server:
     name: "{{ hcloud_server_name }}"
     server_type: "cx21"
     state: stopped
@@ -131,7 +131,7 @@
       - result is changed
 
 - name: test resize server without disk
-  hcloud_server:
+  hetzner.hcloud.hcloud_server:
     name: "{{ hcloud_server_name }}"
     server_type: "cx21"
     state: stopped
@@ -143,7 +143,7 @@
       - result.hcloud_server.server_type == "cx21"
 
 - name: test resize server idempotence
-  hcloud_server:
+  hetzner.hcloud.hcloud_server:
     name: "{{ hcloud_server_name }}"
     server_type: "cx21"
     state: stopped
@@ -154,7 +154,7 @@
       - result is not changed
 
 - name: test resize server to smaller plan
-  hcloud_server:
+  hetzner.hcloud.hcloud_server:
     name: "{{ hcloud_server_name }}"
     server_type: "cx11"
     state: stopped
@@ -166,7 +166,7 @@
       - result.hcloud_server.server_type == "cx11"
 
 - name: test resize server with disk
-  hcloud_server:
+  hetzner.hcloud.hcloud_server:
     name: "{{ hcloud_server_name }}"
     server_type: "cx21"
     upgrade_disk: true
@@ -179,7 +179,7 @@
       - result.hcloud_server.server_type == "cx21"
 
 - name: test enable backups with check mode
-  hcloud_server:
+  hetzner.hcloud.hcloud_server:
     name: "{{ hcloud_server_name }}"
     backups: true
     state: stopped
@@ -191,7 +191,7 @@
       - result is changed
 
 - name: test enable backups
-  hcloud_server:
+  hetzner.hcloud.hcloud_server:
     name: "{{ hcloud_server_name }}"
     backups: true
     state: stopped
@@ -203,7 +203,7 @@
       - result.hcloud_server.backup_window != ""
 
 - name: test enable backups idempotence
-  hcloud_server:
+  hetzner.hcloud.hcloud_server:
     name: "{{ hcloud_server_name }}"
     backups: true
     state: stopped
@@ -215,7 +215,7 @@
       - result.hcloud_server.backup_window != ""
 
 - name: test backups are not accidentally disabled
-  hcloud_server:
+  hetzner.hcloud.hcloud_server:
     name: "{{ hcloud_server_name }}"
     # Make sure that backups are not disabled because a partial server object without "backups" was supplied somewhere
     # to update some unrelated properties.
@@ -230,7 +230,7 @@
       - result.hcloud_server.backup_window != ""
 
 - name: test rebuild server
-  hcloud_server:
+  hetzner.hcloud.hcloud_server:
     name: "{{ hcloud_server_name }}"
     image: ubuntu-22.04
     state: rebuild
@@ -242,7 +242,7 @@
       - result.hcloud_server.id == result_after_test.hcloud_server.id
 
 - name: test rebuild server with check mode
-  hcloud_server:
+  hetzner.hcloud.hcloud_server:
     name: "{{ hcloud_server_name }}"
     image: ubuntu-22.04
     state: rebuild
@@ -254,7 +254,7 @@
       - result_after_test is changed
 
 - name: test update server protection booth protection arguments are required
-  hcloud_server:
+  hetzner.hcloud.hcloud_server:
     name: "{{ hcloud_server_name }}"
     delete_protection: true
     state: present
@@ -267,7 +267,7 @@
       - 'result_after_test.msg == "parameters are required together: delete_protection, rebuild_protection"'
 
 - name: test update server protection fails if they are not the same
-  hcloud_server:
+  hetzner.hcloud.hcloud_server:
     name: "{{ hcloud_server_name }}"
     delete_protection: true
     rebuild_protection: false
@@ -280,7 +280,7 @@
       - result_after_test is failed
 
 - name: test update server protection
-  hcloud_server:
+  hetzner.hcloud.hcloud_server:
     name: "{{ hcloud_server_name }}"
     delete_protection: true
     rebuild_protection: true
@@ -295,7 +295,7 @@
       - result_after_test.hcloud_server.rebuild_protection is sameas true
 
 - name: test server without protection set to be idempotent
-  hcloud_server:
+  hetzner.hcloud.hcloud_server:
     name: "{{hcloud_server_name}}"
   register: result_after_test
 - name: verify test server without protection set to be idempotent
@@ -306,7 +306,7 @@
       - result_after_test.hcloud_server.rebuild_protection is sameas true
 
 - name: test delete server fails if it is protected
-  hcloud_server:
+  hetzner.hcloud.hcloud_server:
     name: "{{hcloud_server_name}}"
     state: absent
   ignore_errors: true
@@ -318,7 +318,7 @@
       - 'result.msg == "server deletion is protected"'
 
 - name: test rebuild server fails if it is protected
-  hcloud_server:
+  hetzner.hcloud.hcloud_server:
     name: "{{hcloud_server_name}}"
     image: ubuntu-22.04
     state: rebuild
@@ -331,7 +331,7 @@
       - 'result.msg == "server rebuild is protected"'
 
 - name: test remove server protection
-  hcloud_server:
+  hetzner.hcloud.hcloud_server:
     name: "{{ hcloud_server_name }}"
     delete_protection: false
     rebuild_protection: false
@@ -346,7 +346,7 @@
       - result_after_test.hcloud_server.rebuild_protection is sameas false
 
 - name: absent server
-  hcloud_server:
+  hetzner.hcloud.hcloud_server:
     name: "{{ hcloud_server_name }}"
     state: absent
   register: result
@@ -356,7 +356,7 @@
       - result is success
 
 - name: test create server with ssh key
-  hcloud_server:
+  hetzner.hcloud.hcloud_server:
     name: "{{ hcloud_server_name}}"
     server_type: cx11
     image: "ubuntu-22.04"
@@ -374,7 +374,7 @@
       - main_server.root_password != ""
 
 - name: test activate rescue mode with check_mode
-  hcloud_server:
+  hetzner.hcloud.hcloud_server:
     name: "{{ hcloud_server_name }}"
     rescue_mode: "linux64"
     ssh_keys:
@@ -388,7 +388,7 @@
       - main_server is changed
 
 - name: test activate rescue mode
-  hcloud_server:
+  hetzner.hcloud.hcloud_server:
     name: "{{ hcloud_server_name }}"
     rescue_mode: "linux64"
     ssh_keys:
@@ -402,7 +402,7 @@
       - main_server.hcloud_server.rescue_enabled is sameas true
 
 - name: test disable rescue mode
-  hcloud_server:
+  hetzner.hcloud.hcloud_server:
     name: "{{ hcloud_server_name }}"
     ssh_keys:
       - ci@ansible.hetzner.cloud
@@ -415,7 +415,7 @@
       - main_server.hcloud_server.rescue_enabled is sameas false
 
 - name: test activate rescue mode without ssh keys
-  hcloud_server:
+  hetzner.hcloud.hcloud_server:
     name: "{{ hcloud_server_name }}"
     rescue_mode: "linux64"
     state: present
@@ -427,7 +427,7 @@
       - main_server.hcloud_server.rescue_enabled is sameas true
 
 - name: absent server
-  hcloud_server:
+  hetzner.hcloud.hcloud_server:
     name: "{{ hcloud_server_name }}"
     state: absent
   register: result
@@ -437,7 +437,7 @@
       - result is success
 
 - name: test create server with rescue_mode
-  hcloud_server:
+  hetzner.hcloud.hcloud_server:
     name: "{{ hcloud_server_name}}"
     server_type: cx11
     image: "ubuntu-22.04"
@@ -457,7 +457,7 @@
       - main_server.hcloud_server.rescue_enabled is sameas true
 
 - name: absent server
-  hcloud_server:
+  hetzner.hcloud.hcloud_server:
     name: "{{ hcloud_server_name }}"
     state: absent
   register: result
@@ -466,7 +466,7 @@
     that:
       - result is success
 - name: test create server with labels
-  hcloud_server:
+  hetzner.hcloud.hcloud_server:
     name: "{{ hcloud_server_name}}"
     server_type: cx11
     image: "ubuntu-22.04"
@@ -485,7 +485,7 @@
       - main_server.hcloud_server.labels.mylabel == "val123"
 
 - name: test update server with labels
-  hcloud_server:
+  hetzner.hcloud.hcloud_server:
     name: "{{ hcloud_server_name}}"
     server_type: cx11
     image: "ubuntu-22.04"
@@ -504,7 +504,7 @@
       - main_server.hcloud_server.labels.mylabel == "val123"
 
 - name: test update server with labels in other order
-  hcloud_server:
+  hetzner.hcloud.hcloud_server:
     name: "{{ hcloud_server_name}}"
     server_type: cx11
     image: "ubuntu-22.04"
@@ -521,7 +521,7 @@
       - main_server is not changed
 
 - name: cleanup with labels
-  hcloud_server:
+  hetzner.hcloud.hcloud_server:
     name: "{{ hcloud_server_name }}"
     state: absent
   register: result
@@ -531,7 +531,7 @@
       - result is success
 
 - name: test create server with enabled backups
-  hcloud_server:
+  hetzner.hcloud.hcloud_server:
     name: "{{ hcloud_server_name }}"
     server_type: cpx11
     backups: true
@@ -547,7 +547,7 @@
       - result.hcloud_server.backup_window != ""
 
 - name: cleanup test create server with enabled backups
-  hcloud_server:
+  hetzner.hcloud.hcloud_server:
     name: "{{ hcloud_server_name }}"
     state: absent
   register: result
@@ -557,7 +557,7 @@
       - result is success
 
 - name: test create server with protection
-  hcloud_server:
+  hetzner.hcloud.hcloud_server:
     name: "{{ hcloud_server_name }}"
     delete_protection: true
     rebuild_protection: true
@@ -576,7 +576,7 @@
       - result_after_test.hcloud_server.rebuild_protection is sameas true
 
 - name: test delete server fails if it is protected
-  hcloud_server:
+  hetzner.hcloud.hcloud_server:
     name: "{{hcloud_server_name}}"
     state: absent
   ignore_errors: true
@@ -588,7 +588,7 @@
       - 'result.msg == "server deletion is protected"'
 
 - name: remove protection from server
-  hcloud_server:
+  hetzner.hcloud.hcloud_server:
     name: "{{ hcloud_server_name }}"
     delete_protection: false
     rebuild_protection: false
@@ -603,7 +603,7 @@
       - result_after_test.hcloud_server.rebuild_protection is sameas false
 
 - name: cleanup
-  hcloud_server:
+  hetzner.hcloud.hcloud_server:
     name: "{{ hcloud_server_name }}"
     state: absent
   register: result

--- a/tests/integration/targets/hcloud_server/tasks/firewalls.yml
+++ b/tests/integration/targets/hcloud_server/tasks/firewalls.yml
@@ -2,7 +2,7 @@
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 ---
 - name: test add not existing firewall should fail
-  hcloud_server:
+  hetzner.hcloud.hcloud_server:
     name: "{{ hcloud_server_name }}"
     firewalls:
       - not-existing
@@ -15,7 +15,7 @@
       - result is failed
       - 'result.msg == "firewall not-existing was not found"'
 - name: setup create firewalls
-  hcloud_firewall:
+  hetzner.hcloud.hcloud_firewall:
     name: "{{ item }}"
     rules:
       - direction: in
@@ -28,7 +28,7 @@
     - "{{ hcloud_firewall_name }}2"
 
 - name: test create server with firewalls
-  hcloud_server:
+  hetzner.hcloud.hcloud_server:
     name: "{{ hcloud_server_name }}"
     server_type: cpx11
     firewalls:
@@ -44,7 +44,7 @@
       - result is changed
 
 - name: test create server with firewalls idempotence
-  hcloud_server:
+  hetzner.hcloud.hcloud_server:
     name: "{{ hcloud_server_name }}"
     server_type: cpx11
     firewalls:
@@ -60,7 +60,7 @@
       - result is not changed
 
 - name: test update server with firewalls
-  hcloud_server:
+  hetzner.hcloud.hcloud_server:
     name: "{{ hcloud_server_name }}"
     server_type: cpx11
     firewalls:
@@ -76,7 +76,7 @@
       - result is changed
 
 - name: test update server with firewalls idempotence
-  hcloud_server:
+  hetzner.hcloud.hcloud_server:
     name: "{{ hcloud_server_name }}"
     server_type: cpx11
     firewalls:
@@ -92,12 +92,12 @@
       - result is not changed
 
 - name: cleanup server with firewalls
-  hcloud_server:
+  hetzner.hcloud.hcloud_server:
     name: "{{ hcloud_server_name }}"
     state: absent
 
 - name: cleanup test create firewall
-  hcloud_firewall:
+  hetzner.hcloud.hcloud_firewall:
     name: "{{ item }}"
     state: absent
   with_items:

--- a/tests/integration/targets/hcloud_server/tasks/primary_ips.yml
+++ b/tests/integration/targets/hcloud_server/tasks/primary_ips.yml
@@ -2,28 +2,28 @@
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 ---
 - name: setup create primary ipv4
-  hcloud_primary_ip:
+  hetzner.hcloud.hcloud_primary_ip:
     name: "{{ hcloud_primary_ip_name }}v4"
     type: ipv4
     datacenter: "fsn1-dc14"
   register: primaryIPv4
 
 - name: setup create second primary ipv4
-  hcloud_primary_ip:
+  hetzner.hcloud.hcloud_primary_ip:
     name: "{{ hcloud_primary_ip_name }}v42"
     type: ipv4
     datacenter: "fsn1-dc14"
   register: secondPrimaryIPv4
 
 - name: setup create primary ipv6
-  hcloud_primary_ip:
+  hetzner.hcloud.hcloud_primary_ip:
     name: "{{ hcloud_primary_ip_name }}v6"
     type: ipv6
     datacenter: "fsn1-dc14"
   register: primaryIPv6
 
 - name: test create server with primary ips
-  hcloud_server:
+  hetzner.hcloud.hcloud_server:
     name: "{{ hcloud_server_name }}"
     server_type: cpx11
     datacenter: "fsn1-dc14"
@@ -40,7 +40,7 @@
       - result is changed
 
 - name: test update server with primary ips
-  hcloud_server:
+  hetzner.hcloud.hcloud_server:
     name: "{{ hcloud_server_name }}"
     server_type: cpx11
     datacenter: "fsn1-dc14"
@@ -58,23 +58,23 @@
       - result is changed
 
 - name: cleanup server with primary ips
-  hcloud_server:
+  hetzner.hcloud.hcloud_server:
     name: "{{ hcloud_server_name }}"
     state: absent
 
 - name: cleanup test create primary ips
-  hcloud_primary_ip:
+  hetzner.hcloud.hcloud_primary_ip:
     name: "{{ hcloud_server_name }}v4"
     state: absent
 - name: cleanup test create primary ips
-  hcloud_primary_ip:
+  hetzner.hcloud.hcloud_primary_ip:
     name: "{{ hcloud_server_name }}v42"
     state: absent
   until: result is not failed
   retries: 5
   delay: 2
 - name: cleanup test create primary ips
-  hcloud_primary_ip:
+  hetzner.hcloud.hcloud_primary_ip:
     name: "{{ hcloud_server_name }}v6"
     state: absent
   until: result is not failed

--- a/tests/integration/targets/hcloud_server/tasks/private_network_only.yml
+++ b/tests/integration/targets/hcloud_server/tasks/private_network_only.yml
@@ -2,28 +2,28 @@
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 ---
 - name: setup network 1 to be absent
-  hcloud_network:
+  hetzner.hcloud.hcloud_network:
     name: "{{ hcloud_network_name }}-1"
     state: absent
 
 - name: setup network 2 to be absent
-  hcloud_network:
+  hetzner.hcloud.hcloud_network:
     name: "{{ hcloud_network_name }}-2"
     state: absent
 
 - name: setup server to be absent
-  hcloud_server:
+  hetzner.hcloud.hcloud_server:
     name: "{{ hcloud_server_name }}"
     state: absent
 
 - name: setup create network
-  hcloud_network:
+  hetzner.hcloud.hcloud_network:
     name: "{{ hcloud_network_name }}-1"
     ip_range: 192.168.0.0/23
   register: primaryNetwork
 
 - name: setup create network subnet 1
-  hcloud_subnetwork:
+  hetzner.hcloud.hcloud_subnetwork:
     network: "{{ hcloud_network_name }}-1"
     ip_range: 192.168.0.0/24
     network_zone: eu-central
@@ -31,7 +31,7 @@
     state: present
 
 - name: setup create network subnet 2
-  hcloud_subnetwork:
+  hetzner.hcloud.hcloud_subnetwork:
     network: "{{ hcloud_network_name }}-1"
     ip_range: 192.168.1.0/24
     network_zone: eu-central
@@ -39,13 +39,13 @@
     state: present
 
 - name: setup create secondary network
-  hcloud_network:
+  hetzner.hcloud.hcloud_network:
     name: "{{ hcloud_network_name }}-2"
     ip_range: 192.168.2.0/23
   register: secondaryNetwork
 
 - name: setup create secondary network subnet 1
-  hcloud_subnetwork:
+  hetzner.hcloud.hcloud_subnetwork:
     network: "{{ hcloud_network_name }}-2"
     ip_range: 192.168.2.0/24
     network_zone: eu-central
@@ -53,7 +53,7 @@
     state: present
 
 - name: setup create secondary network subnet 2
-  hcloud_subnetwork:
+  hetzner.hcloud.hcloud_subnetwork:
     network: "{{ hcloud_network_name }}-2"
     ip_range: 192.168.3.0/24
     network_zone: eu-central
@@ -61,7 +61,7 @@
     state: present
 
 - name: test create server with primary network and no internet
-  hcloud_server:
+  hetzner.hcloud.hcloud_server:
     name: "{{ hcloud_server_name }}"
     server_type: cpx11
     datacenter: "fsn1-dc14"
@@ -80,7 +80,7 @@
       - result is changed
 
 - name: test update server by adding secondary network
-  hcloud_server:
+  hetzner.hcloud.hcloud_server:
     name: "{{ hcloud_server_name }}"
     server_type: cpx11
     datacenter: "fsn1-dc14"
@@ -100,7 +100,7 @@
       - result is changed
 
 - name: test update server idem
-  hcloud_server:
+  hetzner.hcloud.hcloud_server:
     name: "{{ hcloud_server_name }}"
     server_type: cpx11
     datacenter: "fsn1-dc14"
@@ -120,11 +120,11 @@
       - result is not changed
 
 - name: cleanup server
-  hcloud_server:
+  hetzner.hcloud.hcloud_server:
     name: "{{ hcloud_server_name }}"
     state: absent
 - name: cleanup networks
-  hcloud_network:
+  hetzner.hcloud.hcloud_network:
     name: "{{ item }}"
     state: absent
   with_items:

--- a/tests/integration/targets/hcloud_server/tasks/validation.yml
+++ b/tests/integration/targets/hcloud_server/tasks/validation.yml
@@ -2,7 +2,7 @@
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 ---
 - name: setup
-  hcloud_server:
+  hetzner.hcloud.hcloud_server:
     name: "{{ hcloud_server_name }}"
     state: absent
   register: result
@@ -12,7 +12,7 @@
       - result is success
 
 - name: test missing required parameters on create server
-  hcloud_server:
+  hetzner.hcloud.hcloud_server:
     name: "{{ hcloud_server_name }}"
   register: result
   ignore_errors: true
@@ -23,7 +23,7 @@
       - 'result.msg == "missing required arguments: server_type, image"'
 
 - name: test create server with not existing server type
-  hcloud_server:
+  hetzner.hcloud.hcloud_server:
     name: "{{ hcloud_server_name }}"
     server_type: not-existing-server-type
     image: ubuntu-22.04
@@ -37,7 +37,7 @@
       - 'result.msg == "server_type not-existing-server-type was not found"'
 
 - name: test create server with not existing image
-  hcloud_server:
+  hetzner.hcloud.hcloud_server:
     name: "{{ hcloud_server_name }}"
     server_type: cx11
     image: my-not-existing-image-20.04

--- a/tests/integration/targets/hcloud_server_info/tasks/main.yml
+++ b/tests/integration/targets/hcloud_server_info/tasks/main.yml
@@ -2,13 +2,13 @@
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 ---
 - name: setup ensure server is absent
-  hcloud_server:
+  hetzner.hcloud.hcloud_server:
     name: "{{ hcloud_server_name }}"
     state: absent
   register: result
 
 - name: create server
-  hcloud_server:
+  hetzner.hcloud.hcloud_server:
     name: "{{ hcloud_server_name }}"
     server_type: cx11
     image: ubuntu-22.04
@@ -26,7 +26,7 @@
       - main_server.root_password != ""
 
 - name: test gather hcloud server infos in check mode
-  hcloud_server_info:
+  hetzner.hcloud.hcloud_server_info:
   register: server
   check_mode: true
 
@@ -36,7 +36,7 @@
       - server.hcloud_server_info|selectattr('name','equalto','{{ hcloud_server_name }}') | list | count == 1
 
 - name: test gather hcloud server infos with correct label selector
-  hcloud_server_info:
+  hetzner.hcloud.hcloud_server_info:
     label_selector: "key=value"
   register: server
 - name: verify test gather hcloud server infos with correct label selector
@@ -45,7 +45,7 @@
       - server.hcloud_server_info|selectattr('name','equalto','{{ hcloud_server_name }}') | list | count == 1
 
 - name: test gather hcloud server infos with wrong label selector
-  hcloud_server_info:
+  hetzner.hcloud.hcloud_server_info:
     label_selector: "key!=value"
   register: server
 - name: verify test gather hcloud server infos with wrong label selector
@@ -54,7 +54,7 @@
       - server.hcloud_server_info | list | count == 0
 
 - name: test gather hcloud server infos with correct name
-  hcloud_server_info:
+  hetzner.hcloud.hcloud_server_info:
     name: "{{hcloud_server_name}}"
   register: server
 - name: verify test gather hcloud server infos with correct name
@@ -63,7 +63,7 @@
       - server.hcloud_server_info|selectattr('name','equalto','{{ hcloud_server_name }}') | list | count == 1
 
 - name: test gather hcloud server infos with wrong name
-  hcloud_server_info:
+  hetzner.hcloud.hcloud_server_info:
     name: "{{hcloud_server_name}}1"
   register: server
 - name: verify test gather hcloud server infos with wrong name
@@ -72,7 +72,7 @@
       - server.hcloud_server_info | list | count == 0
 
 - name: test gather hcloud server infos with correct id
-  hcloud_server_info:
+  hetzner.hcloud.hcloud_server_info:
     id: "{{main_server.hcloud_server.id}}"
   register: server
 - name: verify test gather hcloud server infos with correct id
@@ -81,7 +81,7 @@
       - server.hcloud_server_info|selectattr('name','equalto','{{ hcloud_server_name }}') | list | count == 1
 
 - name: test gather hcloud server infos with wrong id
-  hcloud_server_info:
+  hetzner.hcloud.hcloud_server_info:
     name: "4711"
   register: server
 - name: verify test gather hcloud server infos with wrong id
@@ -90,12 +90,12 @@
       - server.hcloud_server_info | list | count == 0
 
 - name: cleanup
-  hcloud_server:
+  hetzner.hcloud.hcloud_server:
     name: "{{ hcloud_server_name }}"
     state: absent
 
 - name: create server without ips
-  hcloud_server:
+  hetzner.hcloud.hcloud_server:
     name: "{{ hcloud_server_name }}"
     server_type: cx11
     image: ubuntu-22.04
@@ -113,7 +113,7 @@
       - main_server.hcloud_server.server_type == "cx11"
       - main_server.root_password != ""
 - name: test gather hcloud server infos with correct id
-  hcloud_server_info:
+  hetzner.hcloud.hcloud_server_info:
     id: "{{main_server.hcloud_server.id}}"
   register: server
 - name: verify test gather hcloud server infos with correct id
@@ -121,6 +121,6 @@
     that:
       - server.hcloud_server_info|selectattr('name','equalto','{{ hcloud_server_name }}') | list | count == 1
 - name: cleanup
-  hcloud_server:
+  hetzner.hcloud.hcloud_server:
     name: "{{ hcloud_server_name }}"
     state: absent

--- a/tests/integration/targets/hcloud_server_network/tasks/main.yml
+++ b/tests/integration/targets/hcloud_server_network/tasks/main.yml
@@ -2,7 +2,7 @@
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 ---
 - name: setup network
-  hcloud_network:
+  hetzner.hcloud.hcloud_network:
     name: "{{ hcloud_network_name }}"
     ip_range: "10.0.0.0/8"
     state: present
@@ -13,7 +13,7 @@
       - network is success
 
 - name: setup subnetwork
-  hcloud_subnetwork:
+  hetzner.hcloud.hcloud_subnetwork:
     network: "{{ hcloud_network_name }}"
     ip_range: "10.0.0.0/16"
     type: "server"
@@ -26,7 +26,7 @@
       - subnetwork is success
 
 - name: setup server
-  hcloud_server:
+  hetzner.hcloud.hcloud_server:
     name: "{{hcloud_server_name}}"
     server_type: cx11
     image: ubuntu-22.04
@@ -39,7 +39,7 @@
       - server is success
 
 - name: test missing required parameters on create server network
-  hcloud_server_network:
+  hetzner.hcloud.hcloud_server_network:
     state: present
   register: result
   ignore_errors: true
@@ -50,7 +50,7 @@
       - 'result.msg == "missing required arguments: network, server"'
 
 - name: test create server network with checkmode
-  hcloud_server_network:
+  hetzner.hcloud.hcloud_server_network:
     network: "{{ hcloud_network_name }}"
     server: "{{hcloud_server_name}}"
     state: present
@@ -62,7 +62,7 @@
       - result is changed
 
 - name: test create server network
-  hcloud_server_network:
+  hetzner.hcloud.hcloud_server_network:
     network: "{{ hcloud_network_name }}"
     server: "{{hcloud_server_name}}"
     state: present
@@ -75,7 +75,7 @@
       - serverNetwork.hcloud_server_network.server == hcloud_server_name
 
 - name: test create server network idempotency
-  hcloud_server_network:
+  hetzner.hcloud.hcloud_server_network:
     network: "{{ hcloud_network_name }}"
     server: "{{hcloud_server_name}}"
     state: present
@@ -86,7 +86,7 @@
       - serverNetwork is not changed
 
 - name: test absent server network
-  hcloud_server_network:
+  hetzner.hcloud.hcloud_server_network:
     network: "{{ hcloud_network_name }}"
     server: "{{hcloud_server_name}}"
     state: absent
@@ -97,7 +97,7 @@
       - result is changed
 
 - name: test create server network with specified ip
-  hcloud_server_network:
+  hetzner.hcloud.hcloud_server_network:
     network: "{{ hcloud_network_name }}"
     server: "{{hcloud_server_name}}"
     ip: "10.0.0.2"
@@ -112,7 +112,7 @@
       - serverNetwork.hcloud_server_network.ip == "10.0.0.2"
 
 - name: cleanup create server network with specified ip
-  hcloud_server_network:
+  hetzner.hcloud.hcloud_server_network:
     network: "{{ hcloud_network_name }}"
     server: "{{hcloud_server_name}}"
     state: absent
@@ -123,7 +123,7 @@
       - result is changed
 
 - name: test create server network with alias ips
-  hcloud_server_network:
+  hetzner.hcloud.hcloud_server_network:
     network: "{{ hcloud_network_name }}"
     server: "{{hcloud_server_name}}"
     ip: "10.0.0.2"
@@ -143,7 +143,7 @@
       - 'serverNetwork.hcloud_server_network.alias_ips[1] == "10.0.1.2"'
 
 - name: test update server network with alias ips
-  hcloud_server_network:
+  hetzner.hcloud.hcloud_server_network:
     network: "{{ hcloud_network_name }}"
     server: "{{hcloud_server_name}}"
     ip: "10.0.0.2"
@@ -163,7 +163,7 @@
       - 'serverNetwork.hcloud_server_network.alias_ips[1] == "10.0.3.1"'
 
 - name: test update server network with alias ips idempotency
-  hcloud_server_network:
+  hetzner.hcloud.hcloud_server_network:
     network: "{{ hcloud_network_name }}"
     server: "{{hcloud_server_name}}"
     ip: "10.0.0.2"
@@ -178,7 +178,7 @@
       - serverNetwork is not changed
 
 - name: cleanup create server network with alias ips
-  hcloud_server_network:
+  hetzner.hcloud.hcloud_server_network:
     network: "{{ hcloud_network_name }}"
     server: "{{hcloud_server_name}}"
     state: absent
@@ -189,7 +189,7 @@
       - result is changed
 
 - name: cleanup server
-  hcloud_server:
+  hetzner.hcloud.hcloud_server:
     name: "{{ hcloud_server_name }}"
     state: absent
   register: result
@@ -199,7 +199,7 @@
       - result is success
 
 - name: cleanup subnetwork
-  hcloud_subnetwork:
+  hetzner.hcloud.hcloud_subnetwork:
     network: "{{ hcloud_network_name }}"
     ip_range: "10.0.0.0/16"
     type: "server"
@@ -212,7 +212,7 @@
       - result is changed
 
 - name: cleanup
-  hcloud_network:
+  hetzner.hcloud.hcloud_network:
     name: "{{hcloud_network_name}}"
     state: absent
   register: result

--- a/tests/integration/targets/hcloud_server_type_info/tasks/main.yml
+++ b/tests/integration/targets/hcloud_server_type_info/tasks/main.yml
@@ -2,7 +2,7 @@
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 ---
 - name: test gather hcloud server type infos
-  hcloud_server_type_info:
+  hetzner.hcloud.hcloud_server_type_info:
   register: hcloud_server_types
 - name: verify test gather hcloud server type infos
   assert:
@@ -10,7 +10,7 @@
       - hcloud_server_types.hcloud_server_type_info| list | count > 2
 
 - name: test gather hcloud server type infos in check mode
-  hcloud_server_type_info:
+  hetzner.hcloud.hcloud_server_type_info:
   check_mode: true
   register: hcloud_server_types
 
@@ -20,7 +20,7 @@
       - hcloud_server_types.hcloud_server_type_info| list | count > 2
 
 - name: test gather hcloud server type infos with name
-  hcloud_server_type_info:
+  hetzner.hcloud.hcloud_server_type_info:
     name: "{{hcloud_server_type_name}}"
   register: hcloud_server_types
 - name: verify test gather hcloud server type with name
@@ -30,7 +30,7 @@
       - hcloud_server_types.hcloud_server_type_info[0].deprecation is none # fails if cx11 is ever deprecated
 
 - name: test gather hcloud server type infos with correct id
-  hcloud_server_type_info:
+  hetzner.hcloud.hcloud_server_type_info:
     id: "{{hcloud_server_type_id}}"
   register: hcloud_server_types
 - name: verify test gather hcloud server type with correct id
@@ -39,7 +39,7 @@
       - hcloud_server_types.hcloud_server_type_info|selectattr('name','equalto','{{ hcloud_server_type_name }}') | list | count == 1
 
 - name: test gather hcloud server type infos for deprecated server type
-  hcloud_server_type_info:
+  hetzner.hcloud.hcloud_server_type_info:
     id: "{{hcloud_server_type_id_deprecated}}"
   register: hcloud_server_types
 

--- a/tests/integration/targets/hcloud_ssh_key/tasks/main.yml
+++ b/tests/integration/targets/hcloud_ssh_key/tasks/main.yml
@@ -2,7 +2,7 @@
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 ---
 - name: test missing required parameters on create ssh_key
-  hcloud_ssh_key:
+  hetzner.hcloud.hcloud_ssh_key:
     name: "{{ hcloud_ssh_key_name }}"
   register: result
   ignore_errors: true
@@ -13,7 +13,7 @@
       - 'result.msg == "missing required arguments: public_key"'
 
 - name: test create ssh key with check mode
-  hcloud_ssh_key:
+  hetzner.hcloud.hcloud_ssh_key:
     name: "{{ hcloud_ssh_key_name }}"
     public_key: "{{ key_material }}"
   register: result
@@ -24,7 +24,7 @@
       - result is changed
 
 - name: test create ssh key
-  hcloud_ssh_key:
+  hetzner.hcloud.hcloud_ssh_key:
     name: "{{ hcloud_ssh_key_name }}"
     public_key: "{{ key_material }}"
     labels:
@@ -40,7 +40,7 @@
       - sshKey.hcloud_ssh_key.labels.key == "value"
 
 - name: test create ssh key idempotence
-  hcloud_ssh_key:
+  hetzner.hcloud.hcloud_ssh_key:
     name: "{{ hcloud_ssh_key_name }}"
     public_key: "{{ key_material }}"
   register: result
@@ -50,7 +50,7 @@
       - result is not changed
 
 - name: test update ssh key with check mode
-  hcloud_ssh_key:
+  hetzner.hcloud.hcloud_ssh_key:
     id: "{{ sshKey.hcloud_ssh_key.id }}"
     name: "changed-{{ hcloud_ssh_key_name }}"
   register: result
@@ -61,7 +61,7 @@
       - result is changed
 
 - name: test update ssh key
-  hcloud_ssh_key:
+  hetzner.hcloud.hcloud_ssh_key:
     id: "{{ sshKey.hcloud_ssh_key.id }}"
     name: "changed-{{ hcloud_ssh_key_name }}"
     labels:
@@ -74,7 +74,7 @@
       - result.hcloud_ssh_key.name == "changed-{{ hcloud_ssh_key_name }}"
 
 - name: test update ssh key with same labels
-  hcloud_ssh_key:
+  hetzner.hcloud.hcloud_ssh_key:
     id: "{{ sshKey.hcloud_ssh_key.id }}"
     name: "changed-{{ hcloud_ssh_key_name }}"
     labels:
@@ -86,7 +86,7 @@
       - result is not changed
 
 - name: test update ssh key with other labels
-  hcloud_ssh_key:
+  hetzner.hcloud.hcloud_ssh_key:
     id: "{{ sshKey.hcloud_ssh_key.id }}"
     name: "changed-{{ hcloud_ssh_key_name }}"
     labels:
@@ -99,7 +99,7 @@
       - result is changed
 
 - name: test rename ssh key
-  hcloud_ssh_key:
+  hetzner.hcloud.hcloud_ssh_key:
     id: "{{ sshKey.hcloud_ssh_key.id }}"
     name: "{{ hcloud_ssh_key_name }}"
   register: result
@@ -110,7 +110,7 @@
       - result.hcloud_ssh_key.name == "{{ hcloud_ssh_key_name }}"
 
 - name: test create server with ssh key
-  hcloud_server:
+  hetzner.hcloud.hcloud_server:
     name: "{{ hcloud_server_name }}"
     server_type: cx11
     image: "ubuntu-22.04"
@@ -124,7 +124,7 @@
       - main_server is changed
 
 - name: absent ssh key
-  hcloud_ssh_key:
+  hetzner.hcloud.hcloud_ssh_key:
     id: "{{ sshKey.hcloud_ssh_key.id }}"
     state: absent
   register: result
@@ -134,7 +134,7 @@
       - result is success
 
 - name: test fail cleanly on double created ssh key
-  hcloud_ssh_key:
+  hetzner.hcloud.hcloud_ssh_key:
     name: "{{ hcloud_ssh_key_name }}othername"
     public_key: "{{ hcloud_doubled_ssh_key_public_key }}"
   register: result
@@ -146,7 +146,7 @@
       - 'result.msg == "SSH key with the same fingerprint already exists"'
 
 - name: cleanup
-  hcloud_server:
+  hetzner.hcloud.hcloud_server:
     name: "{{ hcloud_server_name }}"
     state: absent
   register: result

--- a/tests/integration/targets/hcloud_ssh_key_info/tasks/main.yml
+++ b/tests/integration/targets/hcloud_ssh_key_info/tasks/main.yml
@@ -2,13 +2,13 @@
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 ---
 - name: setup ensure ssh key is absent
-  hcloud_ssh_key:
+  hetzner.hcloud.hcloud_ssh_key:
     name: "{{ hcloud_ssh_key_name }}"
     state: absent
   register: result
 
 - name: setup test ssh_key
-  hcloud_ssh_key:
+  hetzner.hcloud.hcloud_ssh_key:
     name: "{{hcloud_ssh_key_name}}"
     public_key: "{{ key_material }}"
     labels:
@@ -21,7 +21,7 @@
       - result.hcloud_ssh_key.public_key == "{{ key_material }}"
 
 - name: test gather hcloud ssh key infos in check mode
-  hcloud_ssh_key_info:
+  hetzner.hcloud.hcloud_ssh_key_info:
   register: hcloud_ssh_key
   check_mode: true
 - name: verify test gather hcloud ssh key infos in check mode
@@ -30,7 +30,7 @@
       - hcloud_ssh_key.hcloud_ssh_key_info| list | count >= 1
 
 - name: test gather hcloud ssh key infos
-  hcloud_ssh_key_info:
+  hetzner.hcloud.hcloud_ssh_key_info:
   register: hcloud_ssh_key
   check_mode: true
 - name: verify test gather hcloud ssh key infos
@@ -39,7 +39,7 @@
       - hcloud_ssh_key.hcloud_ssh_key_info| list | count >= 1
 
 - name: test gather hcloud ssh key infos with correct label selector
-  hcloud_ssh_key_info:
+  hetzner.hcloud.hcloud_ssh_key_info:
     label_selector: "key=value"
   register: hcloud_ssh_key
 - name: verify test gather hcloud ssh key infos with correct label selector
@@ -48,7 +48,7 @@
       - hcloud_ssh_key.hcloud_ssh_key_info|selectattr('name','equalto','{{ hcloud_ssh_key_name }}') | list | count == 1
 
 - name: test gather hcloud ssh key infos with wrong label selector
-  hcloud_ssh_key_info:
+  hetzner.hcloud.hcloud_ssh_key_info:
     label_selector: "key!=value"
   register: hcloud_ssh_key
 - name: verify test gather hcloud ssh key infos with wrong label selector
@@ -57,7 +57,7 @@
       - hcloud_ssh_key.hcloud_ssh_key_info | list | count == 0
 
 - name: cleanup
-  hcloud_ssh_key:
+  hetzner.hcloud.hcloud_ssh_key:
     name: "{{hcloud_ssh_key_name}}"
     state: absent
   register: result

--- a/tests/integration/targets/hcloud_subnetwork/tasks/main.yml
+++ b/tests/integration/targets/hcloud_subnetwork/tasks/main.yml
@@ -2,7 +2,7 @@
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 ---
 - name: setup
-  hcloud_network:
+  hetzner.hcloud.hcloud_network:
     name: "{{ hcloud_network_name }}"
     ip_range: "10.0.0.0/8"
     state: present
@@ -13,7 +13,7 @@
       - network is success
 
 - name: test missing required parameters on create route
-  hcloud_subnetwork:
+  hetzner.hcloud.hcloud_subnetwork:
     network: "{{ hcloud_network_name }}"
     state: present
   register: result
@@ -25,7 +25,7 @@
       - 'result.msg == "missing required arguments: ip_range, network_zone, type"'
 
 - name: test create subnetwork with checkmode
-  hcloud_subnetwork:
+  hetzner.hcloud.hcloud_subnetwork:
     network: "{{ hcloud_network_name }}"
     ip_range: "10.0.0.0/16"
     type: "server"
@@ -39,7 +39,7 @@
       - result is changed
 
 - name: test create subnetwork
-  hcloud_subnetwork:
+  hetzner.hcloud.hcloud_subnetwork:
     network: "{{ hcloud_network_name }}"
     ip_range: "10.0.0.0/16"
     type: "cloud"
@@ -56,7 +56,7 @@
       - subnet.hcloud_subnetwork.network_zone == "eu-central"
 
 - name: test create subnetwork idempotency
-  hcloud_subnetwork:
+  hetzner.hcloud.hcloud_subnetwork:
     network: "{{ hcloud_network_name }}"
     ip_range: "10.0.0.0/16"
     type: "cloud"
@@ -69,7 +69,7 @@
       - result is not changed
 
 - name: test absent subnetwork
-  hcloud_subnetwork:
+  hetzner.hcloud.hcloud_subnetwork:
     network: "{{ hcloud_network_name }}"
     ip_range: "10.0.0.0/16"
     type: "cloud"
@@ -82,7 +82,7 @@
       - result is changed
 
 - name: test vswitch subnetwork
-  hcloud_subnetwork:
+  hetzner.hcloud.hcloud_subnetwork:
     network: "{{ hcloud_network_name }}"
     ip_range: "10.0.0.0/16"
     type: "vswitch"
@@ -101,7 +101,7 @@
       - subnet.hcloud_subnetwork.vswitch_id == hetzner_vswitch_id
 
 - name: test absent subnetwork
-  hcloud_subnetwork:
+  hetzner.hcloud.hcloud_subnetwork:
     network: "{{ hcloud_network_name }}"
     ip_range: "10.0.0.0/16"
     type: "vswitch"
@@ -115,7 +115,7 @@
       - result is changed
 
 - name: cleanup
-  hcloud_network:
+  hetzner.hcloud.hcloud_network:
     name: "{{hcloud_network_name}}"
     state: absent
   register: result

--- a/tests/integration/targets/hcloud_volume/tasks/main.yml
+++ b/tests/integration/targets/hcloud_volume/tasks/main.yml
@@ -2,7 +2,7 @@
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 ---
 - name: setup server
-  hcloud_server:
+  hetzner.hcloud.hcloud_server:
     name: "{{hcloud_server_name}}"
     server_type: cx11
     image: ubuntu-22.04
@@ -15,7 +15,7 @@
       - vol_server is changed
 
 - name: test missing size parameter on create Volume
-  hcloud_volume:
+  hetzner.hcloud.hcloud_volume:
     name: "{{hcloud_volume_name}}"
     server: "{{hcloud_server_name}}"
   register: result
@@ -27,7 +27,7 @@
       - 'result.msg == "missing required arguments: size"'
 
 - name: test create Volume with check mode
-  hcloud_volume:
+  hetzner.hcloud.hcloud_volume:
     name: "{{hcloud_volume_name}}"
     size: 10
     location: "fsn1"
@@ -39,7 +39,7 @@
       - result is changed
 
 - name: test create Volume
-  hcloud_volume:
+  hetzner.hcloud.hcloud_volume:
     name: "{{hcloud_volume_name}}"
     size: 10
     location: "fsn1"
@@ -55,7 +55,7 @@
       - volume.hcloud_volume.linux_device is defined
 
 - name: test create Volume idempotence
-  hcloud_volume:
+  hetzner.hcloud.hcloud_volume:
     name: "{{hcloud_volume_name}}"
     size: 10
     location: "fsn1"
@@ -66,7 +66,7 @@
       - volume is not changed
 
 - name: test attach Volume with checkmode
-  hcloud_volume:
+  hetzner.hcloud.hcloud_volume:
     name: "{{hcloud_volume_name}}"
     server: "{{hcloud_server_name}}"
   check_mode: true
@@ -78,7 +78,7 @@
       - volume.hcloud_volume.server != "{{hcloud_server_name}}"
 
 - name: test attach Volume
-  hcloud_volume:
+  hetzner.hcloud.hcloud_volume:
     name: "{{hcloud_volume_name}}"
     server: "{{hcloud_server_name}}"
   register: volume
@@ -89,7 +89,7 @@
       - volume.hcloud_volume.server == "{{hcloud_server_name}}"
 
 - name: test attach Volume idempotence
-  hcloud_volume:
+  hetzner.hcloud.hcloud_volume:
     name: "{{hcloud_volume_name}}"
     server: "{{hcloud_server_name}}"
   register: volume
@@ -100,7 +100,7 @@
       - volume.hcloud_volume.server == "{{hcloud_server_name}}"
 
 - name: test detach Volume with checkmode
-  hcloud_volume:
+  hetzner.hcloud.hcloud_volume:
     name: "{{hcloud_volume_name}}"
   check_mode: true
   register: volume
@@ -111,7 +111,7 @@
       - volume.hcloud_volume.server == "{{hcloud_server_name}}"
 
 - name: test detach Volume
-  hcloud_volume:
+  hetzner.hcloud.hcloud_volume:
     name: "{{hcloud_volume_name}}"
   register: volume
 - name: verify detach volume
@@ -122,7 +122,7 @@
       - volume.hcloud_volume.server != "{{hcloud_server_name}}"
 
 - name: test update Volume label
-  hcloud_volume:
+  hetzner.hcloud.hcloud_volume:
     name: "{{hcloud_volume_name}}"
     labels:
       key: value
@@ -134,7 +134,7 @@
       - volume.hcloud_volume.labels.key == "value"
 
 - name: test update Volume label with the same label
-  hcloud_volume:
+  hetzner.hcloud.hcloud_volume:
     name: "{{hcloud_volume_name}}"
     labels:
       key: value
@@ -145,7 +145,7 @@
       - volume is not changed
 
 - name: test increase Volume size
-  hcloud_volume:
+  hetzner.hcloud.hcloud_volume:
     name: "{{hcloud_volume_name}}"
     size: 11
   register: volume
@@ -156,7 +156,7 @@
       - volume.hcloud_volume.size == 11
 
 - name: test decreace Volume size
-  hcloud_volume:
+  hetzner.hcloud.hcloud_volume:
     name: "{{hcloud_volume_name}}"
     size: 10
   register: volume
@@ -167,7 +167,7 @@
       - volume.hcloud_volume.size == 11
 
 - name: test update Volume delete protection
-  hcloud_volume:
+  hetzner.hcloud.hcloud_volume:
     name: "{{hcloud_volume_name}}"
     delete_protection: true
   register: volume
@@ -178,7 +178,7 @@
       - volume.hcloud_volume.delete_protection is sameas true
 
 - name: test update Volume delete protection idempotency
-  hcloud_volume:
+  hetzner.hcloud.hcloud_volume:
     name: "{{hcloud_volume_name}}"
     delete_protection: true
   register: volume
@@ -189,7 +189,7 @@
       - volume.hcloud_volume.delete_protection is sameas true
 
 - name: test Volume without delete protection set to be idempotent
-  hcloud_volume:
+  hetzner.hcloud.hcloud_volume:
     name: "{{hcloud_volume_name}}"
   register: volume
 - name: verify test Volume without delete protection set to be idempotent
@@ -199,7 +199,7 @@
       - volume.hcloud_volume.delete_protection is sameas true
 
 - name: test delete Volume fails if it is protected
-  hcloud_volume:
+  hetzner.hcloud.hcloud_volume:
     name: "{{hcloud_volume_name}}"
     state: absent
   ignore_errors: true
@@ -211,7 +211,7 @@
       - 'result.msg == "volume deletion is protected"'
 
 - name: test update Volume delete protection
-  hcloud_volume:
+  hetzner.hcloud.hcloud_volume:
     name: "{{hcloud_volume_name}}"
     delete_protection: false
   register: volume
@@ -222,7 +222,7 @@
       - volume.hcloud_volume.delete_protection is sameas false
 
 - name: test delete Volume
-  hcloud_volume:
+  hetzner.hcloud.hcloud_volume:
     name: "{{hcloud_volume_name}}"
     state: absent
   register: result
@@ -232,7 +232,7 @@
       - result is success
 
 - name: test create Volume with delete protection
-  hcloud_volume:
+  hetzner.hcloud.hcloud_volume:
     name: "{{hcloud_volume_name}}"
     size: 10
     location: "fsn1"
@@ -245,7 +245,7 @@
       - volume.hcloud_volume.delete_protection is sameas true
 
 - name: test delete Volume fails if it is protected
-  hcloud_volume:
+  hetzner.hcloud.hcloud_volume:
     name: "{{hcloud_volume_name}}"
     state: absent
   ignore_errors: true
@@ -257,7 +257,7 @@
       - 'result.msg == "volume deletion is protected"'
 
 - name: test update Volume delete protection
-  hcloud_volume:
+  hetzner.hcloud.hcloud_volume:
     name: "{{hcloud_volume_name}}"
     delete_protection: false
   register: volume
@@ -268,7 +268,7 @@
       - volume.hcloud_volume.delete_protection is sameas false
 
 - name: test delete Volume
-  hcloud_volume:
+  hetzner.hcloud.hcloud_volume:
     name: "{{hcloud_volume_name}}"
     state: absent
   register: result
@@ -278,7 +278,7 @@
       - result is success
 
 - name: cleanup
-  hcloud_server:
+  hetzner.hcloud.hcloud_server:
     name: "{{ hcloud_server_name }}"
     state: absent
   register: result

--- a/tests/integration/targets/hcloud_volume_info/tasks/main.yml
+++ b/tests/integration/targets/hcloud_volume_info/tasks/main.yml
@@ -2,13 +2,13 @@
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 ---
 - name: setup ensure volume is absent
-  hcloud_volume:
+  hetzner.hcloud.hcloud_volume:
     name: "{{ hcloud_volume_name }}"
     state: absent
   register: result
 
 - name: setup volume
-  hcloud_volume:
+  hetzner.hcloud.hcloud_volume:
     name: "{{hcloud_volume_name}}"
     size: 10
     location: "fsn1"
@@ -21,7 +21,7 @@
       - main_volume is changed
 
 - name: test gather hcloud volume infos in check mode
-  hcloud_volume_info:
+  hetzner.hcloud.hcloud_volume_info:
   register: hcloud_volume
   check_mode: true
 
@@ -37,7 +37,7 @@
       - volume.linux_device is defined
 
 - name: test gather hcloud volume infos with correct label selector
-  hcloud_volume_info:
+  hetzner.hcloud.hcloud_volume_info:
     label_selector: "key=value"
   register: hcloud_volume
 - name: verify test gather hcloud volume infos with correct label selector
@@ -46,7 +46,7 @@
       - hcloud_volume.hcloud_volume_info|selectattr('name','equalto','{{ hcloud_volume_name }}') | list | count == 1
 
 - name: test gather hcloud volume infos with wrong label selector
-  hcloud_volume_info:
+  hetzner.hcloud.hcloud_volume_info:
     label_selector: "key!=value"
   register: hcloud_volume
 - name: verify test gather hcloud volume infos with wrong label selector
@@ -55,7 +55,7 @@
       - hcloud_volume.hcloud_volume_info | list | count == 0
 
 - name: test gather hcloud volume infos with correct name
-  hcloud_volume_info:
+  hetzner.hcloud.hcloud_volume_info:
     name: "{{hcloud_volume_name}}"
   register: hcloud_volume
 - name: verify test gather hcloud volume infos with correct name
@@ -64,7 +64,7 @@
       - hcloud_volume.hcloud_volume_info|selectattr('name','equalto','{{ hcloud_volume_name }}') | list | count == 1
 
 - name: test gather hcloud volume infos with wrong name
-  hcloud_volume_info:
+  hetzner.hcloud.hcloud_volume_info:
     name: "{{hcloud_volume_name}}1"
   register: hcloud_volume
 - name: verify test gather hcloud volume infos with wrong name
@@ -73,7 +73,7 @@
       - hcloud_volume.hcloud_volume_info | list | count == 0
 
 - name: test gather hcloud volume facts with correct id
-  hcloud_volume_info:
+  hetzner.hcloud.hcloud_volume_info:
     id: "{{main_volume.hcloud_volume.id}}"
   register: hcloud_volume
 - name: verify test gather hcloud volume with correct id
@@ -82,7 +82,7 @@
       - hcloud_volume.hcloud_volume_info|selectattr('name','equalto','{{ hcloud_volume_name }}') | list | count == 1
 
 - name: test gather hcloud volume infos with wrong id
-  hcloud_volume_info:
+  hetzner.hcloud.hcloud_volume_info:
     name: "4711"
   register: hcloud_volume
 - name: verify test gather hcloud volume infos with wrong id
@@ -91,7 +91,7 @@
       - hcloud_volume.hcloud_volume_info | list | count == 0
 
 - name: cleanup
-  hcloud_volume:
+  hetzner.hcloud.hcloud_volume:
     name: "{{ hcloud_volume_name }}"
     state: absent
   register: result


### PR DESCRIPTION
##### SUMMARY

Using fqcn for when using modules is a recommended practice. Updated the references to our own modules in both the docs and any roles/playbooks.

