### PR TITLE
test: reorganize groups to balance test duration

### DIFF
--- a/tests/integration/targets/hcloud_floating_ip/aliases
+++ b/tests/integration/targets/hcloud_floating_ip/aliases
@@ -1,2 +1,2 @@
 cloud/hcloud
-shippable/hcloud/group2
+shippable/hcloud/group3

--- a/tests/integration/targets/hcloud_floating_ip_info/aliases
+++ b/tests/integration/targets/hcloud_floating_ip_info/aliases
@@ -1,2 +1,2 @@
 cloud/hcloud
-shippable/hcloud/group2
+shippable/hcloud/group3

--- a/tests/integration/targets/hcloud_location_info/aliases
+++ b/tests/integration/targets/hcloud_location_info/aliases
@@ -1,2 +1,2 @@
 cloud/hcloud
-shippable/hcloud/group2
+shippable/hcloud/group3

--- a/tests/integration/targets/hcloud_primary_ip/aliases
+++ b/tests/integration/targets/hcloud_primary_ip/aliases
@@ -1,2 +1,2 @@
 cloud/hcloud
-shippable/hcloud/group2
+shippable/hcloud/group3

--- a/tests/integration/targets/hcloud_primary_ip_info/aliases
+++ b/tests/integration/targets/hcloud_primary_ip_info/aliases
@@ -1,2 +1,2 @@
 cloud/hcloud
-shippable/hcloud/group2
+shippable/hcloud/group3

--- a/tests/integration/targets/hcloud_server/aliases
+++ b/tests/integration/targets/hcloud_server/aliases
@@ -1,2 +1,2 @@
 cloud/hcloud
-shippable/hcloud/group1
+shippable/hcloud/group3


### PR DESCRIPTION
##### SUMMARY

Move some tests in the group3 to balance test duration.

One large test is the `hcloud_server` module, it was moved from the group1 to the group3.

Before:
```
     10 shippable/hcloud/group1
     19 shippable/hcloud/group2
      2 shippable/hcloud/group3
```

After:
```
      9 shippable/hcloud/group1
     14 shippable/hcloud/group2
      8 shippable/hcloud/group3
```


