### PR TITLE
fix!: don't set inventory image vars if server image is undefined

### DIFF
--- a/changelogs/fragments/do-not-set-inventory-server-image-variables-when-undefined.yml
+++ b/changelogs/fragments/do-not-set-inventory-server-image-variables-when-undefined.yml
@@ -1,0 +1,4 @@
+breaking_changes:
+  - >
+    inventory plugin - Don't set the server image variables (`image_id`,
+    `image_os_flavor` and `image_name`) when the server image is not defined.

--- a/plugins/inventory/hcloud.py
+++ b/plugins/inventory/hcloud.py
@@ -270,10 +270,6 @@ class InventoryModule(BaseInventoryPlugin, Constructable):
                 self.inventory.set_variable(server.name, "image_name", to_native(server.image.name))
             else:
                 self.inventory.set_variable(server.name, "image_name", to_native(server.image.description))
-        else:
-            self.inventory.set_variable(server.name, "image_id", to_native("No Image ID found"))
-            self.inventory.set_variable(server.name, "image_name", to_native("No Image Name found"))
-            self.inventory.set_variable(server.name, "image_os_flavor", to_native("No Image OS Flavor found"))
 
         # Labels
         self.inventory.set_variable(server.name, "labels", dict(server.labels))


### PR DESCRIPTION
##### SUMMARY

Related to #116

Don't set "No Image * found" string if the server image is not defined. This is not an intuitive behavior. 

This is a breaking change.

##### ISSUE TYPE

- Bugfix Pull Request


##### COMPONENT NAME
`inventory`
