### PR TITLE
refactor: use relative imports for local modules

### DIFF
--- a/plugins/inventory/hcloud.py
+++ b/plugins/inventory/hcloud.py
@@ -121,11 +121,9 @@ from ansible.errors import AnsibleError
 from ansible.module_utils.common.text.converters import to_native
 from ansible.plugins.inventory import BaseInventoryPlugin, Constructable
 from ansible.release import __version__
-from ansible_collections.hetzner.hcloud.plugins.module_utils.hcloud import (
-    HAS_DATEUTIL,
-    HAS_REQUESTS,
-)
-from ansible_collections.hetzner.hcloud.plugins.module_utils.vendor import hcloud
+
+from ..module_utils.hcloud import HAS_DATEUTIL, HAS_REQUESTS
+from ..module_utils.vendor import hcloud
 
 
 class InventoryModule(BaseInventoryPlugin, Constructable):

--- a/plugins/module_utils/hcloud.py
+++ b/plugins/module_utils/hcloud.py
@@ -8,7 +8,8 @@ import traceback
 from ansible.module_utils.ansible_release import __version__
 from ansible.module_utils.basic import env_fallback, missing_required_lib
 from ansible.module_utils.common.text.converters import to_native
-from ansible_collections.hetzner.hcloud.plugins.module_utils.vendor import hcloud
+
+from ..module_utils.vendor import hcloud
 
 HAS_REQUESTS = True
 HAS_DATEUTIL = True

--- a/plugins/modules/hcloud_certificate.py
+++ b/plugins/modules/hcloud_certificate.py
@@ -136,10 +136,9 @@ hcloud_certificate:
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.common.text.converters import to_native
-from ansible_collections.hetzner.hcloud.plugins.module_utils.hcloud import Hcloud
-from ansible_collections.hetzner.hcloud.plugins.module_utils.vendor.hcloud import (
-    HCloudException,
-)
+
+from ..module_utils.hcloud import Hcloud
+from ..module_utils.vendor.hcloud import HCloudException
 
 
 class AnsibleHcloudCertificate(Hcloud):

--- a/plugins/modules/hcloud_certificate_info.py
+++ b/plugins/modules/hcloud_certificate_info.py
@@ -84,10 +84,9 @@ hcloud_certificate_info:
 """
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.common.text.converters import to_native
-from ansible_collections.hetzner.hcloud.plugins.module_utils.hcloud import Hcloud
-from ansible_collections.hetzner.hcloud.plugins.module_utils.vendor.hcloud import (
-    HCloudException,
-)
+
+from ..module_utils.hcloud import Hcloud
+from ..module_utils.vendor.hcloud import HCloudException
 
 
 class AnsibleHcloudCertificateInfo(Hcloud):

--- a/plugins/modules/hcloud_datacenter_info.py
+++ b/plugins/modules/hcloud_datacenter_info.py
@@ -75,10 +75,9 @@ hcloud_datacenter_info:
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.common.text.converters import to_native
-from ansible_collections.hetzner.hcloud.plugins.module_utils.hcloud import Hcloud
-from ansible_collections.hetzner.hcloud.plugins.module_utils.vendor.hcloud import (
-    HCloudException,
-)
+
+from ..module_utils.hcloud import Hcloud
+from ..module_utils.vendor.hcloud import HCloudException
 
 
 class AnsibleHcloudDatacenterInfo(Hcloud):

--- a/plugins/modules/hcloud_firewall.py
+++ b/plugins/modules/hcloud_firewall.py
@@ -170,14 +170,10 @@ import time
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.common.text.converters import to_native
-from ansible_collections.hetzner.hcloud.plugins.module_utils.hcloud import Hcloud
-from ansible_collections.hetzner.hcloud.plugins.module_utils.vendor.hcloud import (
-    APIException,
-    HCloudException,
-)
-from ansible_collections.hetzner.hcloud.plugins.module_utils.vendor.hcloud.firewalls.domain import (
-    FirewallRule,
-)
+
+from ..module_utils.hcloud import Hcloud
+from ..module_utils.vendor.hcloud import APIException, HCloudException
+from ..module_utils.vendor.hcloud.firewalls.domain import FirewallRule
 
 
 class AnsibleHcloudFirewall(Hcloud):

--- a/plugins/modules/hcloud_floating_ip.py
+++ b/plugins/modules/hcloud_floating_ip.py
@@ -163,10 +163,9 @@ hcloud_floating_ip:
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.common.text.converters import to_native
-from ansible_collections.hetzner.hcloud.plugins.module_utils.hcloud import Hcloud
-from ansible_collections.hetzner.hcloud.plugins.module_utils.vendor.hcloud import (
-    HCloudException,
-)
+
+from ..module_utils.hcloud import Hcloud
+from ..module_utils.vendor.hcloud import HCloudException
 
 
 class AnsibleHcloudFloatingIP(Hcloud):

--- a/plugins/modules/hcloud_floating_ip_info.py
+++ b/plugins/modules/hcloud_floating_ip_info.py
@@ -94,10 +94,9 @@ hcloud_floating_ip_info:
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.common.text.converters import to_native
-from ansible_collections.hetzner.hcloud.plugins.module_utils.hcloud import Hcloud
-from ansible_collections.hetzner.hcloud.plugins.module_utils.vendor.hcloud import (
-    HCloudException,
-)
+
+from ..module_utils.hcloud import Hcloud
+from ..module_utils.vendor.hcloud import HCloudException
 
 
 class AnsibleHcloudFloatingIPInfo(Hcloud):

--- a/plugins/modules/hcloud_image_info.py
+++ b/plugins/modules/hcloud_image_info.py
@@ -110,10 +110,9 @@ hcloud_image_info:
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.common.text.converters import to_native
-from ansible_collections.hetzner.hcloud.plugins.module_utils.hcloud import Hcloud
-from ansible_collections.hetzner.hcloud.plugins.module_utils.vendor.hcloud import (
-    HCloudException,
-)
+
+from ..module_utils.hcloud import Hcloud
+from ..module_utils.vendor.hcloud import HCloudException
 
 
 class AnsibleHcloudImageInfo(Hcloud):

--- a/plugins/modules/hcloud_iso_info.py
+++ b/plugins/modules/hcloud_iso_info.py
@@ -97,7 +97,8 @@ hcloud_iso_info:
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.common.text.converters import to_native
-from ansible_collections.hetzner.hcloud.plugins.module_utils.hcloud import Hcloud
+
+from ..module_utils.hcloud import Hcloud
 
 
 class AnsibleHcloudIsoInfo(Hcloud):

--- a/plugins/modules/hcloud_load_balancer.py
+++ b/plugins/modules/hcloud_load_balancer.py
@@ -143,10 +143,9 @@ hcloud_load_balancer:
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.common.text.converters import to_native
-from ansible_collections.hetzner.hcloud.plugins.module_utils.hcloud import Hcloud
-from ansible_collections.hetzner.hcloud.plugins.module_utils.vendor.hcloud import (
-    HCloudException,
-)
+
+from ..module_utils.hcloud import Hcloud
+from ..module_utils.vendor.hcloud import HCloudException
 
 
 class AnsibleHcloudLoadBalancer(Hcloud):

--- a/plugins/modules/hcloud_load_balancer_info.py
+++ b/plugins/modules/hcloud_load_balancer_info.py
@@ -258,10 +258,9 @@ hcloud_load_balancer_info:
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.common.text.converters import to_native
-from ansible_collections.hetzner.hcloud.plugins.module_utils.hcloud import Hcloud
-from ansible_collections.hetzner.hcloud.plugins.module_utils.vendor.hcloud import (
-    HCloudException,
-)
+
+from ..module_utils.hcloud import Hcloud
+from ..module_utils.vendor.hcloud import HCloudException
 
 
 class AnsibleHcloudLoadBalancerInfo(Hcloud):

--- a/plugins/modules/hcloud_load_balancer_network.py
+++ b/plugins/modules/hcloud_load_balancer_network.py
@@ -93,10 +93,9 @@ hcloud_load_balancer_network:
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.common.text.converters import to_native
-from ansible_collections.hetzner.hcloud.plugins.module_utils.hcloud import Hcloud
-from ansible_collections.hetzner.hcloud.plugins.module_utils.vendor.hcloud import (
-    HCloudException,
-)
+
+from ..module_utils.hcloud import Hcloud
+from ..module_utils.vendor.hcloud import HCloudException
 
 
 class AnsibleHcloudLoadBalancerNetwork(Hcloud):

--- a/plugins/modules/hcloud_load_balancer_service.py
+++ b/plugins/modules/hcloud_load_balancer_service.py
@@ -281,12 +281,10 @@ hcloud_load_balancer_service:
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.common.text.converters import to_native
-from ansible_collections.hetzner.hcloud.plugins.module_utils.hcloud import Hcloud
-from ansible_collections.hetzner.hcloud.plugins.module_utils.vendor.hcloud import (
-    APIException,
-    HCloudException,
-)
-from ansible_collections.hetzner.hcloud.plugins.module_utils.vendor.hcloud.load_balancers.domain import (
+
+from ..module_utils.hcloud import Hcloud
+from ..module_utils.vendor.hcloud import APIException, HCloudException
+from ..module_utils.vendor.hcloud.load_balancers.domain import (
     LoadBalancerHealtCheckHttp,
     LoadBalancerHealthCheck,
     LoadBalancerService,

--- a/plugins/modules/hcloud_load_balancer_target.py
+++ b/plugins/modules/hcloud_load_balancer_target.py
@@ -137,12 +137,10 @@ hcloud_load_balancer_target:
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.common.text.converters import to_native
-from ansible_collections.hetzner.hcloud.plugins.module_utils.hcloud import Hcloud
-from ansible_collections.hetzner.hcloud.plugins.module_utils.vendor.hcloud import (
-    APIException,
-    HCloudException,
-)
-from ansible_collections.hetzner.hcloud.plugins.module_utils.vendor.hcloud.load_balancers.domain import (
+
+from ..module_utils.hcloud import Hcloud
+from ..module_utils.vendor.hcloud import APIException, HCloudException
+from ..module_utils.vendor.hcloud.load_balancers.domain import (
     LoadBalancerTarget,
     LoadBalancerTargetIP,
     LoadBalancerTargetLabelSelector,

--- a/plugins/modules/hcloud_load_balancer_type_info.py
+++ b/plugins/modules/hcloud_load_balancer_type_info.py
@@ -86,10 +86,9 @@ hcloud_load_balancer_type_info:
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.common.text.converters import to_native
-from ansible_collections.hetzner.hcloud.plugins.module_utils.hcloud import Hcloud
-from ansible_collections.hetzner.hcloud.plugins.module_utils.vendor.hcloud import (
-    HCloudException,
-)
+
+from ..module_utils.hcloud import Hcloud
+from ..module_utils.vendor.hcloud import HCloudException
 
 
 class AnsibleHcloudLoadBalancerTypeInfo(Hcloud):

--- a/plugins/modules/hcloud_location_info.py
+++ b/plugins/modules/hcloud_location_info.py
@@ -76,10 +76,9 @@ hcloud_location_info:
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.common.text.converters import to_native
-from ansible_collections.hetzner.hcloud.plugins.module_utils.hcloud import Hcloud
-from ansible_collections.hetzner.hcloud.plugins.module_utils.vendor.hcloud import (
-    HCloudException,
-)
+
+from ..module_utils.hcloud import Hcloud
+from ..module_utils.vendor.hcloud import HCloudException
 
 
 class AnsibleHcloudLocationInfo(Hcloud):

--- a/plugins/modules/hcloud_network.py
+++ b/plugins/modules/hcloud_network.py
@@ -118,10 +118,9 @@ hcloud_network:
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.common.text.converters import to_native
-from ansible_collections.hetzner.hcloud.plugins.module_utils.hcloud import Hcloud
-from ansible_collections.hetzner.hcloud.plugins.module_utils.vendor.hcloud import (
-    HCloudException,
-)
+
+from ..module_utils.hcloud import Hcloud
+from ..module_utils.vendor.hcloud import HCloudException
 
 
 class AnsibleHcloudNetwork(Hcloud):

--- a/plugins/modules/hcloud_network_info.py
+++ b/plugins/modules/hcloud_network_info.py
@@ -183,10 +183,9 @@ hcloud_network_info:
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.common.text.converters import to_native
-from ansible_collections.hetzner.hcloud.plugins.module_utils.hcloud import Hcloud
-from ansible_collections.hetzner.hcloud.plugins.module_utils.vendor.hcloud import (
-    HCloudException,
-)
+
+from ..module_utils.hcloud import Hcloud
+from ..module_utils.vendor.hcloud import HCloudException
 
 
 class AnsibleHcloudNetworkInfo(Hcloud):

--- a/plugins/modules/hcloud_placement_group.py
+++ b/plugins/modules/hcloud_placement_group.py
@@ -109,10 +109,9 @@ hcloud_placement_group:
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.common.text.converters import to_native
-from ansible_collections.hetzner.hcloud.plugins.module_utils.hcloud import Hcloud
-from ansible_collections.hetzner.hcloud.plugins.module_utils.vendor.hcloud import (
-    HCloudException,
-)
+
+from ..module_utils.hcloud import Hcloud
+from ..module_utils.vendor.hcloud import HCloudException
 
 
 class AnsibleHcloudPlacementGroup(Hcloud):

--- a/plugins/modules/hcloud_primary_ip.py
+++ b/plugins/modules/hcloud_primary_ip.py
@@ -133,10 +133,9 @@ hcloud_primary_ip:
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.common.text.converters import to_native
-from ansible_collections.hetzner.hcloud.plugins.module_utils.hcloud import Hcloud
-from ansible_collections.hetzner.hcloud.plugins.module_utils.vendor.hcloud import (
-    HCloudException,
-)
+
+from ..module_utils.hcloud import Hcloud
+from ..module_utils.vendor.hcloud import HCloudException
 
 
 class AnsibleHcloudPrimaryIP(Hcloud):

--- a/plugins/modules/hcloud_primary_ip_info.py
+++ b/plugins/modules/hcloud_primary_ip_info.py
@@ -119,10 +119,9 @@ hcloud_primary_ip_info:
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.common.text.converters import to_native
-from ansible_collections.hetzner.hcloud.plugins.module_utils.hcloud import Hcloud
-from ansible_collections.hetzner.hcloud.plugins.module_utils.vendor.hcloud import (
-    HCloudException,
-)
+
+from ..module_utils.hcloud import Hcloud
+from ..module_utils.vendor.hcloud import HCloudException
 
 
 class AnsibleHcloudPrimaryIPInfo(Hcloud):

--- a/plugins/modules/hcloud_rdns.py
+++ b/plugins/modules/hcloud_rdns.py
@@ -139,10 +139,9 @@ from ansible.module_utils.common.text.converters import to_native
 from ansible_collections.ansible.netcommon.plugins.module_utils.network.common import (
     utils,
 )
-from ansible_collections.hetzner.hcloud.plugins.module_utils.hcloud import Hcloud
-from ansible_collections.hetzner.hcloud.plugins.module_utils.vendor.hcloud import (
-    HCloudException,
-)
+
+from ..module_utils.hcloud import Hcloud
+from ..module_utils.vendor.hcloud import HCloudException
 
 
 class AnsibleHcloudReverseDNS(Hcloud):

--- a/plugins/modules/hcloud_route.py
+++ b/plugins/modules/hcloud_route.py
@@ -89,13 +89,10 @@ hcloud_route:
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.common.text.converters import to_native
-from ansible_collections.hetzner.hcloud.plugins.module_utils.hcloud import Hcloud
-from ansible_collections.hetzner.hcloud.plugins.module_utils.vendor.hcloud import (
-    HCloudException,
-)
-from ansible_collections.hetzner.hcloud.plugins.module_utils.vendor.hcloud.networks.domain import (
-    NetworkRoute,
-)
+
+from ..module_utils.hcloud import Hcloud
+from ..module_utils.vendor.hcloud import HCloudException
+from ..module_utils.vendor.hcloud.networks.domain import NetworkRoute
 
 
 class AnsibleHcloudRoute(Hcloud):

--- a/plugins/modules/hcloud_server.py
+++ b/plugins/modules/hcloud_server.py
@@ -332,23 +332,16 @@ from datetime import datetime, timedelta, timezone
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.common.text.converters import to_native
-from ansible_collections.hetzner.hcloud.plugins.module_utils.hcloud import Hcloud
-from ansible_collections.hetzner.hcloud.plugins.module_utils.vendor.hcloud import (
-    HCloudException,
-)
-from ansible_collections.hetzner.hcloud.plugins.module_utils.vendor.hcloud.firewalls.domain import (
-    FirewallResource,
-)
-from ansible_collections.hetzner.hcloud.plugins.module_utils.vendor.hcloud.servers.domain import (
+
+from ..module_utils.hcloud import Hcloud
+from ..module_utils.vendor.hcloud import HCloudException
+from ..module_utils.vendor.hcloud.firewalls.domain import FirewallResource
+from ..module_utils.vendor.hcloud.servers.domain import (
     Server,
     ServerCreatePublicNetwork,
 )
-from ansible_collections.hetzner.hcloud.plugins.module_utils.vendor.hcloud.ssh_keys.domain import (
-    SSHKey,
-)
-from ansible_collections.hetzner.hcloud.plugins.module_utils.vendor.hcloud.volumes.domain import (
-    Volume,
-)
+from ..module_utils.vendor.hcloud.ssh_keys.domain import SSHKey
+from ..module_utils.vendor.hcloud.volumes.domain import Volume
 
 
 class AnsibleHcloudServer(Hcloud):

--- a/plugins/modules/hcloud_server_info.py
+++ b/plugins/modules/hcloud_server_info.py
@@ -139,10 +139,9 @@ hcloud_server_info:
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.common.text.converters import to_native
-from ansible_collections.hetzner.hcloud.plugins.module_utils.hcloud import Hcloud
-from ansible_collections.hetzner.hcloud.plugins.module_utils.vendor.hcloud import (
-    HCloudException,
-)
+
+from ..module_utils.hcloud import Hcloud
+from ..module_utils.vendor.hcloud import HCloudException
 
 
 class AnsibleHcloudServerInfo(Hcloud):

--- a/plugins/modules/hcloud_server_network.py
+++ b/plugins/modules/hcloud_server_network.py
@@ -114,11 +114,9 @@ hcloud_server_network:
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.common.text.converters import to_native
-from ansible_collections.hetzner.hcloud.plugins.module_utils.hcloud import Hcloud
-from ansible_collections.hetzner.hcloud.plugins.module_utils.vendor.hcloud import (
-    APIException,
-    HCloudException,
-)
+
+from ..module_utils.hcloud import Hcloud
+from ..module_utils.vendor.hcloud import APIException, HCloudException
 
 
 class AnsibleHcloudServerNetwork(Hcloud):

--- a/plugins/modules/hcloud_server_type_info.py
+++ b/plugins/modules/hcloud_server_type_info.py
@@ -122,10 +122,9 @@ hcloud_server_type_info:
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.common.text.converters import to_native
-from ansible_collections.hetzner.hcloud.plugins.module_utils.hcloud import Hcloud
-from ansible_collections.hetzner.hcloud.plugins.module_utils.vendor.hcloud import (
-    HCloudException,
-)
+
+from ..module_utils.hcloud import Hcloud
+from ..module_utils.vendor.hcloud import HCloudException
 
 
 class AnsibleHcloudServerTypeInfo(Hcloud):

--- a/plugins/modules/hcloud_ssh_key.py
+++ b/plugins/modules/hcloud_ssh_key.py
@@ -112,10 +112,9 @@ hcloud_ssh_key:
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.common.text.converters import to_native
-from ansible_collections.hetzner.hcloud.plugins.module_utils.hcloud import Hcloud
-from ansible_collections.hetzner.hcloud.plugins.module_utils.vendor.hcloud import (
-    HCloudException,
-)
+
+from ..module_utils.hcloud import Hcloud
+from ..module_utils.vendor.hcloud import HCloudException
 
 
 class AnsibleHcloudSSHKey(Hcloud):

--- a/plugins/modules/hcloud_ssh_key_info.py
+++ b/plugins/modules/hcloud_ssh_key_info.py
@@ -76,10 +76,9 @@ hcloud_ssh_key_info:
 """
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.common.text.converters import to_native
-from ansible_collections.hetzner.hcloud.plugins.module_utils.hcloud import Hcloud
-from ansible_collections.hetzner.hcloud.plugins.module_utils.vendor.hcloud import (
-    HCloudException,
-)
+
+from ..module_utils.hcloud import Hcloud
+from ..module_utils.vendor.hcloud import HCloudException
 
 
 class AnsibleHcloudSSHKeyInfo(Hcloud):

--- a/plugins/modules/hcloud_subnetwork.py
+++ b/plugins/modules/hcloud_subnetwork.py
@@ -126,13 +126,10 @@ hcloud_subnetwork:
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.common.text.converters import to_native
-from ansible_collections.hetzner.hcloud.plugins.module_utils.hcloud import Hcloud
-from ansible_collections.hetzner.hcloud.plugins.module_utils.vendor.hcloud import (
-    HCloudException,
-)
-from ansible_collections.hetzner.hcloud.plugins.module_utils.vendor.hcloud.networks.domain import (
-    NetworkSubnet,
-)
+
+from ..module_utils.hcloud import Hcloud
+from ..module_utils.vendor.hcloud import HCloudException
+from ..module_utils.vendor.hcloud.networks.domain import NetworkSubnet
 
 
 class AnsibleHcloudSubnetwork(Hcloud):

--- a/plugins/modules/hcloud_volume.py
+++ b/plugins/modules/hcloud_volume.py
@@ -159,10 +159,9 @@ hcloud_volume:
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.common.text.converters import to_native
-from ansible_collections.hetzner.hcloud.plugins.module_utils.hcloud import Hcloud
-from ansible_collections.hetzner.hcloud.plugins.module_utils.vendor.hcloud import (
-    HCloudException,
-)
+
+from ..module_utils.hcloud import Hcloud
+from ..module_utils.vendor.hcloud import HCloudException
 
 
 class AnsibleHcloudVolume(Hcloud):

--- a/plugins/modules/hcloud_volume_info.py
+++ b/plugins/modules/hcloud_volume_info.py
@@ -93,10 +93,9 @@ hcloud_volume_info:
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.common.text.converters import to_native
-from ansible_collections.hetzner.hcloud.plugins.module_utils.hcloud import Hcloud
-from ansible_collections.hetzner.hcloud.plugins.module_utils.vendor.hcloud import (
-    HCloudException,
-)
+
+from ..module_utils.hcloud import Hcloud
+from ..module_utils.vendor.hcloud import HCloudException
 
 
 class AnsibleHcloudVolumeInfo(Hcloud):


### PR DESCRIPTION
##### SUMMARY

Importing through the ansible_collection loader prevents use for accessing the code from the IDE/ while type checking. Using relative import for local code should be working. This enables the type definition for the IDE and will improve developers experience.

In a future step, we should have enough information about the code to be able to run `mypy` against it and catch bugs :partying_face:.

Preparation work to take full advantage of https://github.com/hetznercloud/hcloud-python/pull/255