### PR TITLE
chore: fix pre-commit config

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -46,6 +46,11 @@ repos:
   - repo: https://github.com/ansible-community/antsibull-changelog
     rev: 0.22.0
     hooks:
+      - id: antsibull-changelog-lint
+      - id: antsibull-changelog-lint-changelog-yaml
+
+  - repo: local
+    hooks:
       - id: shfmt
         name: shfmt
         description: Format shell scripts with shfmt
@@ -58,11 +63,6 @@ repos:
     rev: v0.9.0.5
     hooks:
       - id: shellcheck
-
-  - repo: local
-    hooks:
-      - id: antsibull-changelog-lint
-      - id: antsibull-changelog-lint-changelog-yaml
 
   - repo: local
     hooks:


### PR DESCRIPTION
The previous PR #277 merge somehow destroyed the config while rebasing and squashing.

https://github.com/ansible-collections/hetzner.hcloud/commit/1b83de57ef5f3f90ed615bf6fa200d333d9a4dd1