### PR TITLE
refactor: rename ansible module classes

### DIFF
--- a/plugins/module_utils/hcloud.py
+++ b/plugins/module_utils/hcloud.py
@@ -4,6 +4,7 @@
 
 
 import traceback
+import warnings
 
 from ansible.module_utils.ansible_release import __version__
 from ansible.module_utils.basic import env_fallback, missing_required_lib
@@ -25,7 +26,7 @@ except ImportError:
     HAS_DATEUTIL = False
 
 
-class Hcloud:
+class AnsibleHCloud:
     def __init__(self, module, represent):
         self.module = module
         self.represent = represent
@@ -94,3 +95,13 @@ class Hcloud:
         if getattr(self, self.represent) is not None:
             self.result[self.represent] = self._prepare_result()
         return self.result
+
+
+class Hcloud(AnsibleHCloud):
+    def __init__(self, module, represent):
+        warnings.warn(
+            "The 'Hcloud' class is deprecated, it was renamed to 'AnsibleHCloud', please use it instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        super().__init__(module, represent)

--- a/plugins/module_utils/hcloud.py
+++ b/plugins/module_utils/hcloud.py
@@ -4,7 +4,6 @@
 
 
 import traceback
-import warnings
 
 from ansible.module_utils.ansible_release import __version__
 from ansible.module_utils.basic import env_fallback, missing_required_lib
@@ -95,13 +94,3 @@ class AnsibleHCloud:
         if getattr(self, self.represent) is not None:
             self.result[self.represent] = self._prepare_result()
         return self.result
-
-
-class Hcloud(AnsibleHCloud):
-    def __init__(self, module, represent):
-        warnings.warn(
-            "The 'Hcloud' class is deprecated, it was renamed to 'AnsibleHCloud', please use it instead.",
-            DeprecationWarning,
-            stacklevel=2,
-        )
-        super().__init__(module, represent)

--- a/plugins/modules/hcloud_certificate.py
+++ b/plugins/modules/hcloud_certificate.py
@@ -137,11 +137,11 @@ hcloud_certificate:
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.common.text.converters import to_native
 
-from ..module_utils.hcloud import Hcloud
+from ..module_utils.hcloud import AnsibleHCloud
 from ..module_utils.vendor.hcloud import HCloudException
 
 
-class AnsibleHcloudCertificate(Hcloud):
+class AnsibleHcloudCertificate(AnsibleHCloud):
     def __init__(self, module):
         super().__init__(module, "hcloud_certificate")
         self.hcloud_certificate = None

--- a/plugins/modules/hcloud_certificate.py
+++ b/plugins/modules/hcloud_certificate.py
@@ -141,7 +141,7 @@ from ..module_utils.hcloud import AnsibleHCloud
 from ..module_utils.vendor.hcloud import HCloudException
 
 
-class AnsibleHcloudCertificate(AnsibleHCloud):
+class AnsibleHCloudCertificate(AnsibleHCloud):
     def __init__(self, module):
         super().__init__(module, "hcloud_certificate")
         self.hcloud_certificate = None
@@ -261,9 +261,9 @@ class AnsibleHcloudCertificate(AnsibleHCloud):
 
 
 def main():
-    module = AnsibleHcloudCertificate.define_module()
+    module = AnsibleHCloudCertificate.define_module()
 
-    hcloud = AnsibleHcloudCertificate(module)
+    hcloud = AnsibleHCloudCertificate(module)
     state = module.params.get("state")
     if state == "absent":
         hcloud.delete_certificate()

--- a/plugins/modules/hcloud_certificate_info.py
+++ b/plugins/modules/hcloud_certificate_info.py
@@ -85,11 +85,11 @@ hcloud_certificate_info:
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.common.text.converters import to_native
 
-from ..module_utils.hcloud import Hcloud
+from ..module_utils.hcloud import AnsibleHCloud
 from ..module_utils.vendor.hcloud import HCloudException
 
 
-class AnsibleHcloudCertificateInfo(Hcloud):
+class AnsibleHcloudCertificateInfo(AnsibleHCloud):
     def __init__(self, module):
         super().__init__(module, "hcloud_certificate_info")
         self.hcloud_certificate_info = None

--- a/plugins/modules/hcloud_certificate_info.py
+++ b/plugins/modules/hcloud_certificate_info.py
@@ -89,7 +89,7 @@ from ..module_utils.hcloud import AnsibleHCloud
 from ..module_utils.vendor.hcloud import HCloudException
 
 
-class AnsibleHcloudCertificateInfo(AnsibleHCloud):
+class AnsibleHCloudCertificateInfo(AnsibleHCloud):
     def __init__(self, module):
         super().__init__(module, "hcloud_certificate_info")
         self.hcloud_certificate_info = None
@@ -143,8 +143,8 @@ class AnsibleHcloudCertificateInfo(AnsibleHCloud):
 
 
 def main():
-    module = AnsibleHcloudCertificateInfo.define_module()
-    hcloud = AnsibleHcloudCertificateInfo(module)
+    module = AnsibleHCloudCertificateInfo.define_module()
+    hcloud = AnsibleHCloudCertificateInfo(module)
 
     hcloud.get_certificates()
     result = hcloud.get_result()

--- a/plugins/modules/hcloud_datacenter_info.py
+++ b/plugins/modules/hcloud_datacenter_info.py
@@ -80,7 +80,7 @@ from ..module_utils.hcloud import AnsibleHCloud
 from ..module_utils.vendor.hcloud import HCloudException
 
 
-class AnsibleHcloudDatacenterInfo(AnsibleHCloud):
+class AnsibleHCloudDatacenterInfo(AnsibleHCloud):
     def __init__(self, module):
         super().__init__(module, "hcloud_datacenter_info")
         self.hcloud_datacenter_info = None
@@ -126,8 +126,8 @@ class AnsibleHcloudDatacenterInfo(AnsibleHCloud):
 
 
 def main():
-    module = AnsibleHcloudDatacenterInfo.define_module()
-    hcloud = AnsibleHcloudDatacenterInfo(module)
+    module = AnsibleHCloudDatacenterInfo.define_module()
+    hcloud = AnsibleHCloudDatacenterInfo(module)
 
     hcloud.get_datacenters()
     result = hcloud.get_result()

--- a/plugins/modules/hcloud_datacenter_info.py
+++ b/plugins/modules/hcloud_datacenter_info.py
@@ -76,11 +76,11 @@ hcloud_datacenter_info:
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.common.text.converters import to_native
 
-from ..module_utils.hcloud import Hcloud
+from ..module_utils.hcloud import AnsibleHCloud
 from ..module_utils.vendor.hcloud import HCloudException
 
 
-class AnsibleHcloudDatacenterInfo(Hcloud):
+class AnsibleHcloudDatacenterInfo(AnsibleHCloud):
     def __init__(self, module):
         super().__init__(module, "hcloud_datacenter_info")
         self.hcloud_datacenter_info = None

--- a/plugins/modules/hcloud_firewall.py
+++ b/plugins/modules/hcloud_firewall.py
@@ -171,12 +171,12 @@ import time
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.common.text.converters import to_native
 
-from ..module_utils.hcloud import Hcloud
+from ..module_utils.hcloud import AnsibleHCloud
 from ..module_utils.vendor.hcloud import APIException, HCloudException
 from ..module_utils.vendor.hcloud.firewalls.domain import FirewallRule
 
 
-class AnsibleHcloudFirewall(Hcloud):
+class AnsibleHcloudFirewall(AnsibleHCloud):
     def __init__(self, module):
         super().__init__(module, "hcloud_firewall")
         self.hcloud_firewall = None

--- a/plugins/modules/hcloud_firewall.py
+++ b/plugins/modules/hcloud_firewall.py
@@ -176,7 +176,7 @@ from ..module_utils.vendor.hcloud import APIException, HCloudException
 from ..module_utils.vendor.hcloud.firewalls.domain import FirewallRule
 
 
-class AnsibleHcloudFirewall(AnsibleHCloud):
+class AnsibleHCloudFirewall(AnsibleHCloud):
     def __init__(self, module):
         super().__init__(module, "hcloud_firewall")
         self.hcloud_firewall = None
@@ -328,9 +328,9 @@ class AnsibleHcloudFirewall(AnsibleHCloud):
 
 
 def main():
-    module = AnsibleHcloudFirewall.define_module()
+    module = AnsibleHCloudFirewall.define_module()
 
-    hcloud = AnsibleHcloudFirewall(module)
+    hcloud = AnsibleHCloudFirewall(module)
     state = module.params.get("state")
     if state == "absent":
         hcloud.delete_firewall()

--- a/plugins/modules/hcloud_floating_ip.py
+++ b/plugins/modules/hcloud_floating_ip.py
@@ -164,11 +164,11 @@ hcloud_floating_ip:
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.common.text.converters import to_native
 
-from ..module_utils.hcloud import Hcloud
+from ..module_utils.hcloud import AnsibleHCloud
 from ..module_utils.vendor.hcloud import HCloudException
 
 
-class AnsibleHcloudFloatingIP(Hcloud):
+class AnsibleHcloudFloatingIP(AnsibleHCloud):
     def __init__(self, module):
         super().__init__(module, "hcloud_floating_ip")
         self.hcloud_floating_ip = None

--- a/plugins/modules/hcloud_floating_ip.py
+++ b/plugins/modules/hcloud_floating_ip.py
@@ -168,7 +168,7 @@ from ..module_utils.hcloud import AnsibleHCloud
 from ..module_utils.vendor.hcloud import HCloudException
 
 
-class AnsibleHcloudFloatingIP(AnsibleHCloud):
+class AnsibleHCloudFloatingIP(AnsibleHCloud):
     def __init__(self, module):
         super().__init__(module, "hcloud_floating_ip")
         self.hcloud_floating_ip = None
@@ -323,9 +323,9 @@ class AnsibleHcloudFloatingIP(AnsibleHCloud):
 
 
 def main():
-    module = AnsibleHcloudFloatingIP.define_module()
+    module = AnsibleHCloudFloatingIP.define_module()
 
-    hcloud = AnsibleHcloudFloatingIP(module)
+    hcloud = AnsibleHCloudFloatingIP(module)
     state = module.params["state"]
     if state == "absent":
         hcloud.delete_floating_ip()

--- a/plugins/modules/hcloud_floating_ip_info.py
+++ b/plugins/modules/hcloud_floating_ip_info.py
@@ -95,11 +95,11 @@ hcloud_floating_ip_info:
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.common.text.converters import to_native
 
-from ..module_utils.hcloud import Hcloud
+from ..module_utils.hcloud import AnsibleHCloud
 from ..module_utils.vendor.hcloud import HCloudException
 
 
-class AnsibleHcloudFloatingIPInfo(Hcloud):
+class AnsibleHcloudFloatingIPInfo(AnsibleHCloud):
     def __init__(self, module):
         super().__init__(module, "hcloud_floating_ip_info")
         self.hcloud_floating_ip_info = None

--- a/plugins/modules/hcloud_floating_ip_info.py
+++ b/plugins/modules/hcloud_floating_ip_info.py
@@ -99,7 +99,7 @@ from ..module_utils.hcloud import AnsibleHCloud
 from ..module_utils.vendor.hcloud import HCloudException
 
 
-class AnsibleHcloudFloatingIPInfo(AnsibleHCloud):
+class AnsibleHCloudFloatingIPInfo(AnsibleHCloud):
     def __init__(self, module):
         super().__init__(module, "hcloud_floating_ip_info")
         self.hcloud_floating_ip_info = None
@@ -155,8 +155,8 @@ class AnsibleHcloudFloatingIPInfo(AnsibleHCloud):
 
 
 def main():
-    module = AnsibleHcloudFloatingIPInfo.define_module()
-    hcloud = AnsibleHcloudFloatingIPInfo(module)
+    module = AnsibleHCloudFloatingIPInfo.define_module()
+    hcloud = AnsibleHCloudFloatingIPInfo(module)
 
     hcloud.get_floating_ips()
     result = hcloud.get_result()

--- a/plugins/modules/hcloud_image_info.py
+++ b/plugins/modules/hcloud_image_info.py
@@ -111,11 +111,11 @@ hcloud_image_info:
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.common.text.converters import to_native
 
-from ..module_utils.hcloud import Hcloud
+from ..module_utils.hcloud import AnsibleHCloud
 from ..module_utils.vendor.hcloud import HCloudException
 
 
-class AnsibleHcloudImageInfo(Hcloud):
+class AnsibleHcloudImageInfo(AnsibleHCloud):
     def __init__(self, module):
         super().__init__(module, "hcloud_image_info")
         self.hcloud_image_info = None

--- a/plugins/modules/hcloud_image_info.py
+++ b/plugins/modules/hcloud_image_info.py
@@ -115,7 +115,7 @@ from ..module_utils.hcloud import AnsibleHCloud
 from ..module_utils.vendor.hcloud import HCloudException
 
 
-class AnsibleHcloudImageInfo(AnsibleHCloud):
+class AnsibleHCloudImageInfo(AnsibleHCloud):
     def __init__(self, module):
         super().__init__(module, "hcloud_image_info")
         self.hcloud_image_info = None
@@ -191,8 +191,8 @@ class AnsibleHcloudImageInfo(AnsibleHCloud):
 
 
 def main():
-    module = AnsibleHcloudImageInfo.define_module()
-    hcloud = AnsibleHcloudImageInfo(module)
+    module = AnsibleHCloudImageInfo.define_module()
+    hcloud = AnsibleHCloudImageInfo(module)
 
     hcloud.get_images()
     result = hcloud.get_result()

--- a/plugins/modules/hcloud_iso_info.py
+++ b/plugins/modules/hcloud_iso_info.py
@@ -98,10 +98,10 @@ hcloud_iso_info:
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.common.text.converters import to_native
 
-from ..module_utils.hcloud import Hcloud
+from ..module_utils.hcloud import AnsibleHCloud
 
 
-class AnsibleHcloudIsoInfo(Hcloud):
+class AnsibleHcloudIsoInfo(AnsibleHCloud):
     def __init__(self, module):
         super().__init__(module, "hcloud_iso_info")
         self.hcloud_iso_info = None

--- a/plugins/modules/hcloud_iso_info.py
+++ b/plugins/modules/hcloud_iso_info.py
@@ -101,7 +101,7 @@ from ansible.module_utils.common.text.converters import to_native
 from ..module_utils.hcloud import AnsibleHCloud
 
 
-class AnsibleHcloudIsoInfo(AnsibleHCloud):
+class AnsibleHCloudIsoInfo(AnsibleHCloud):
     def __init__(self, module):
         super().__init__(module, "hcloud_iso_info")
         self.hcloud_iso_info = None
@@ -156,8 +156,8 @@ class AnsibleHcloudIsoInfo(AnsibleHCloud):
 
 
 def main():
-    module = AnsibleHcloudIsoInfo.define_module()
-    hcloud = AnsibleHcloudIsoInfo(module)
+    module = AnsibleHCloudIsoInfo.define_module()
+    hcloud = AnsibleHCloudIsoInfo(module)
     hcloud.get_iso_infos()
     result = hcloud.get_result()
     ansible_info = {"hcloud_iso_info": result["hcloud_iso_info"]}

--- a/plugins/modules/hcloud_load_balancer.py
+++ b/plugins/modules/hcloud_load_balancer.py
@@ -144,11 +144,11 @@ hcloud_load_balancer:
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.common.text.converters import to_native
 
-from ..module_utils.hcloud import Hcloud
+from ..module_utils.hcloud import AnsibleHCloud
 from ..module_utils.vendor.hcloud import HCloudException
 
 
-class AnsibleHcloudLoadBalancer(Hcloud):
+class AnsibleHcloudLoadBalancer(AnsibleHCloud):
     def __init__(self, module):
         super().__init__(module, "hcloud_load_balancer")
         self.hcloud_load_balancer = None

--- a/plugins/modules/hcloud_load_balancer.py
+++ b/plugins/modules/hcloud_load_balancer.py
@@ -148,7 +148,7 @@ from ..module_utils.hcloud import AnsibleHCloud
 from ..module_utils.vendor.hcloud import HCloudException
 
 
-class AnsibleHcloudLoadBalancer(AnsibleHCloud):
+class AnsibleHCloudLoadBalancer(AnsibleHCloud):
     def __init__(self, module):
         super().__init__(module, "hcloud_load_balancer")
         self.hcloud_load_balancer = None
@@ -299,9 +299,9 @@ class AnsibleHcloudLoadBalancer(AnsibleHCloud):
 
 
 def main():
-    module = AnsibleHcloudLoadBalancer.define_module()
+    module = AnsibleHCloudLoadBalancer.define_module()
 
-    hcloud = AnsibleHcloudLoadBalancer(module)
+    hcloud = AnsibleHCloudLoadBalancer(module)
     state = module.params.get("state")
     if state == "absent":
         hcloud.delete_load_balancer()

--- a/plugins/modules/hcloud_load_balancer_info.py
+++ b/plugins/modules/hcloud_load_balancer_info.py
@@ -259,11 +259,11 @@ hcloud_load_balancer_info:
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.common.text.converters import to_native
 
-from ..module_utils.hcloud import Hcloud
+from ..module_utils.hcloud import AnsibleHCloud
 from ..module_utils.vendor.hcloud import HCloudException
 
 
-class AnsibleHcloudLoadBalancerInfo(Hcloud):
+class AnsibleHcloudLoadBalancerInfo(AnsibleHCloud):
     def __init__(self, module):
         super().__init__(module, "hcloud_load_balancer_info")
         self.hcloud_load_balancer_info = None

--- a/plugins/modules/hcloud_load_balancer_info.py
+++ b/plugins/modules/hcloud_load_balancer_info.py
@@ -263,7 +263,7 @@ from ..module_utils.hcloud import AnsibleHCloud
 from ..module_utils.vendor.hcloud import HCloudException
 
 
-class AnsibleHcloudLoadBalancerInfo(AnsibleHCloud):
+class AnsibleHCloudLoadBalancerInfo(AnsibleHCloud):
     def __init__(self, module):
         super().__init__(module, "hcloud_load_balancer_info")
         self.hcloud_load_balancer_info = None
@@ -379,8 +379,8 @@ class AnsibleHcloudLoadBalancerInfo(AnsibleHCloud):
 
 
 def main():
-    module = AnsibleHcloudLoadBalancerInfo.define_module()
-    hcloud = AnsibleHcloudLoadBalancerInfo(module)
+    module = AnsibleHCloudLoadBalancerInfo.define_module()
+    hcloud = AnsibleHCloudLoadBalancerInfo(module)
 
     hcloud.get_load_balancers()
     result = hcloud.get_result()

--- a/plugins/modules/hcloud_load_balancer_network.py
+++ b/plugins/modules/hcloud_load_balancer_network.py
@@ -98,7 +98,7 @@ from ..module_utils.hcloud import AnsibleHCloud
 from ..module_utils.vendor.hcloud import HCloudException
 
 
-class AnsibleHcloudLoadBalancerNetwork(AnsibleHCloud):
+class AnsibleHCloudLoadBalancerNetwork(AnsibleHCloud):
     def __init__(self, module):
         super().__init__(module, "hcloud_load_balancer_network")
         self.hcloud_network = None
@@ -188,9 +188,9 @@ class AnsibleHcloudLoadBalancerNetwork(AnsibleHCloud):
 
 
 def main():
-    module = AnsibleHcloudLoadBalancerNetwork.define_module()
+    module = AnsibleHCloudLoadBalancerNetwork.define_module()
 
-    hcloud = AnsibleHcloudLoadBalancerNetwork(module)
+    hcloud = AnsibleHCloudLoadBalancerNetwork(module)
     state = module.params["state"]
     if state == "absent":
         hcloud.delete_load_balancer_network()

--- a/plugins/modules/hcloud_load_balancer_network.py
+++ b/plugins/modules/hcloud_load_balancer_network.py
@@ -94,11 +94,11 @@ hcloud_load_balancer_network:
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.common.text.converters import to_native
 
-from ..module_utils.hcloud import Hcloud
+from ..module_utils.hcloud import AnsibleHCloud
 from ..module_utils.vendor.hcloud import HCloudException
 
 
-class AnsibleHcloudLoadBalancerNetwork(Hcloud):
+class AnsibleHcloudLoadBalancerNetwork(AnsibleHCloud):
     def __init__(self, module):
         super().__init__(module, "hcloud_load_balancer_network")
         self.hcloud_network = None

--- a/plugins/modules/hcloud_load_balancer_service.py
+++ b/plugins/modules/hcloud_load_balancer_service.py
@@ -292,7 +292,7 @@ from ..module_utils.vendor.hcloud.load_balancers.domain import (
 )
 
 
-class AnsibleHcloudLoadBalancerService(AnsibleHCloud):
+class AnsibleHCloudLoadBalancerService(AnsibleHCloud):
     def __init__(self, module):
         super().__init__(module, "hcloud_load_balancer_service")
         self.hcloud_load_balancer = None
@@ -563,9 +563,9 @@ class AnsibleHcloudLoadBalancerService(AnsibleHCloud):
 
 
 def main():
-    module = AnsibleHcloudLoadBalancerService.define_module()
+    module = AnsibleHCloudLoadBalancerService.define_module()
 
-    hcloud = AnsibleHcloudLoadBalancerService(module)
+    hcloud = AnsibleHCloudLoadBalancerService(module)
     state = module.params.get("state")
     if state == "absent":
         hcloud.delete_load_balancer_service()

--- a/plugins/modules/hcloud_load_balancer_service.py
+++ b/plugins/modules/hcloud_load_balancer_service.py
@@ -282,7 +282,7 @@ hcloud_load_balancer_service:
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.common.text.converters import to_native
 
-from ..module_utils.hcloud import Hcloud
+from ..module_utils.hcloud import AnsibleHCloud
 from ..module_utils.vendor.hcloud import APIException, HCloudException
 from ..module_utils.vendor.hcloud.load_balancers.domain import (
     LoadBalancerHealtCheckHttp,
@@ -292,7 +292,7 @@ from ..module_utils.vendor.hcloud.load_balancers.domain import (
 )
 
 
-class AnsibleHcloudLoadBalancerService(Hcloud):
+class AnsibleHcloudLoadBalancerService(AnsibleHCloud):
     def __init__(self, module):
         super().__init__(module, "hcloud_load_balancer_service")
         self.hcloud_load_balancer = None

--- a/plugins/modules/hcloud_load_balancer_target.py
+++ b/plugins/modules/hcloud_load_balancer_target.py
@@ -147,7 +147,7 @@ from ..module_utils.vendor.hcloud.load_balancers.domain import (
 )
 
 
-class AnsibleHcloudLoadBalancerTarget(AnsibleHCloud):
+class AnsibleHCloudLoadBalancerTarget(AnsibleHCloud):
     def __init__(self, module):
         super().__init__(module, "hcloud_load_balancer_target")
         self.hcloud_load_balancer = None
@@ -297,9 +297,9 @@ class AnsibleHcloudLoadBalancerTarget(AnsibleHCloud):
 
 
 def main():
-    module = AnsibleHcloudLoadBalancerTarget.define_module()
+    module = AnsibleHCloudLoadBalancerTarget.define_module()
 
-    hcloud = AnsibleHcloudLoadBalancerTarget(module)
+    hcloud = AnsibleHCloudLoadBalancerTarget(module)
     state = module.params["state"]
     if state == "absent":
         hcloud.delete_load_balancer_target()

--- a/plugins/modules/hcloud_load_balancer_target.py
+++ b/plugins/modules/hcloud_load_balancer_target.py
@@ -138,7 +138,7 @@ hcloud_load_balancer_target:
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.common.text.converters import to_native
 
-from ..module_utils.hcloud import Hcloud
+from ..module_utils.hcloud import AnsibleHCloud
 from ..module_utils.vendor.hcloud import APIException, HCloudException
 from ..module_utils.vendor.hcloud.load_balancers.domain import (
     LoadBalancerTarget,
@@ -147,7 +147,7 @@ from ..module_utils.vendor.hcloud.load_balancers.domain import (
 )
 
 
-class AnsibleHcloudLoadBalancerTarget(Hcloud):
+class AnsibleHcloudLoadBalancerTarget(AnsibleHCloud):
     def __init__(self, module):
         super().__init__(module, "hcloud_load_balancer_target")
         self.hcloud_load_balancer = None

--- a/plugins/modules/hcloud_load_balancer_type_info.py
+++ b/plugins/modules/hcloud_load_balancer_type_info.py
@@ -91,7 +91,7 @@ from ..module_utils.hcloud import AnsibleHCloud
 from ..module_utils.vendor.hcloud import HCloudException
 
 
-class AnsibleHcloudLoadBalancerTypeInfo(AnsibleHCloud):
+class AnsibleHCloudLoadBalancerTypeInfo(AnsibleHCloud):
     def __init__(self, module):
         super().__init__(module, "hcloud_load_balancer_type_info")
         self.hcloud_load_balancer_type_info = None
@@ -143,8 +143,8 @@ class AnsibleHcloudLoadBalancerTypeInfo(AnsibleHCloud):
 
 
 def main():
-    module = AnsibleHcloudLoadBalancerTypeInfo.define_module()
-    hcloud = AnsibleHcloudLoadBalancerTypeInfo(module)
+    module = AnsibleHCloudLoadBalancerTypeInfo.define_module()
+    hcloud = AnsibleHCloudLoadBalancerTypeInfo(module)
 
     hcloud.get_load_balancer_types()
     result = hcloud.get_result()

--- a/plugins/modules/hcloud_load_balancer_type_info.py
+++ b/plugins/modules/hcloud_load_balancer_type_info.py
@@ -87,11 +87,11 @@ hcloud_load_balancer_type_info:
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.common.text.converters import to_native
 
-from ..module_utils.hcloud import Hcloud
+from ..module_utils.hcloud import AnsibleHCloud
 from ..module_utils.vendor.hcloud import HCloudException
 
 
-class AnsibleHcloudLoadBalancerTypeInfo(Hcloud):
+class AnsibleHcloudLoadBalancerTypeInfo(AnsibleHCloud):
     def __init__(self, module):
         super().__init__(module, "hcloud_load_balancer_type_info")
         self.hcloud_load_balancer_type_info = None

--- a/plugins/modules/hcloud_location_info.py
+++ b/plugins/modules/hcloud_location_info.py
@@ -81,7 +81,7 @@ from ..module_utils.hcloud import AnsibleHCloud
 from ..module_utils.vendor.hcloud import HCloudException
 
 
-class AnsibleHcloudLocationInfo(AnsibleHCloud):
+class AnsibleHCloudLocationInfo(AnsibleHCloud):
     def __init__(self, module):
         super().__init__(module, "hcloud_location_info")
         self.hcloud_location_info = None
@@ -127,8 +127,8 @@ class AnsibleHcloudLocationInfo(AnsibleHCloud):
 
 
 def main():
-    module = AnsibleHcloudLocationInfo.define_module()
-    hcloud = AnsibleHcloudLocationInfo(module)
+    module = AnsibleHCloudLocationInfo.define_module()
+    hcloud = AnsibleHCloudLocationInfo(module)
 
     hcloud.get_locations()
     result = hcloud.get_result()

--- a/plugins/modules/hcloud_location_info.py
+++ b/plugins/modules/hcloud_location_info.py
@@ -77,11 +77,11 @@ hcloud_location_info:
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.common.text.converters import to_native
 
-from ..module_utils.hcloud import Hcloud
+from ..module_utils.hcloud import AnsibleHCloud
 from ..module_utils.vendor.hcloud import HCloudException
 
 
-class AnsibleHcloudLocationInfo(Hcloud):
+class AnsibleHcloudLocationInfo(AnsibleHCloud):
     def __init__(self, module):
         super().__init__(module, "hcloud_location_info")
         self.hcloud_location_info = None

--- a/plugins/modules/hcloud_network.py
+++ b/plugins/modules/hcloud_network.py
@@ -123,7 +123,7 @@ from ..module_utils.hcloud import AnsibleHCloud
 from ..module_utils.vendor.hcloud import HCloudException
 
 
-class AnsibleHcloudNetwork(AnsibleHCloud):
+class AnsibleHCloudNetwork(AnsibleHCloud):
     def __init__(self, module):
         super().__init__(module, "hcloud_network")
         self.hcloud_network = None
@@ -244,9 +244,9 @@ class AnsibleHcloudNetwork(AnsibleHCloud):
 
 
 def main():
-    module = AnsibleHcloudNetwork.define_module()
+    module = AnsibleHCloudNetwork.define_module()
 
-    hcloud = AnsibleHcloudNetwork(module)
+    hcloud = AnsibleHCloudNetwork(module)
     state = module.params["state"]
     if state == "absent":
         hcloud.delete_network()

--- a/plugins/modules/hcloud_network.py
+++ b/plugins/modules/hcloud_network.py
@@ -119,11 +119,11 @@ hcloud_network:
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.common.text.converters import to_native
 
-from ..module_utils.hcloud import Hcloud
+from ..module_utils.hcloud import AnsibleHCloud
 from ..module_utils.vendor.hcloud import HCloudException
 
 
-class AnsibleHcloudNetwork(Hcloud):
+class AnsibleHcloudNetwork(AnsibleHCloud):
     def __init__(self, module):
         super().__init__(module, "hcloud_network")
         self.hcloud_network = None

--- a/plugins/modules/hcloud_network_info.py
+++ b/plugins/modules/hcloud_network_info.py
@@ -188,7 +188,7 @@ from ..module_utils.hcloud import AnsibleHCloud
 from ..module_utils.vendor.hcloud import HCloudException
 
 
-class AnsibleHcloudNetworkInfo(AnsibleHCloud):
+class AnsibleHCloudNetworkInfo(AnsibleHCloud):
     def __init__(self, module):
         super().__init__(module, "hcloud_network_info")
         self.hcloud_network_info = None
@@ -278,8 +278,8 @@ class AnsibleHcloudNetworkInfo(AnsibleHCloud):
 
 
 def main():
-    module = AnsibleHcloudNetworkInfo.define_module()
-    hcloud = AnsibleHcloudNetworkInfo(module)
+    module = AnsibleHCloudNetworkInfo.define_module()
+    hcloud = AnsibleHCloudNetworkInfo(module)
 
     hcloud.get_networks()
     result = hcloud.get_result()

--- a/plugins/modules/hcloud_network_info.py
+++ b/plugins/modules/hcloud_network_info.py
@@ -184,11 +184,11 @@ hcloud_network_info:
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.common.text.converters import to_native
 
-from ..module_utils.hcloud import Hcloud
+from ..module_utils.hcloud import AnsibleHCloud
 from ..module_utils.vendor.hcloud import HCloudException
 
 
-class AnsibleHcloudNetworkInfo(Hcloud):
+class AnsibleHcloudNetworkInfo(AnsibleHCloud):
     def __init__(self, module):
         super().__init__(module, "hcloud_network_info")
         self.hcloud_network_info = None

--- a/plugins/modules/hcloud_placement_group.py
+++ b/plugins/modules/hcloud_placement_group.py
@@ -114,7 +114,7 @@ from ..module_utils.hcloud import AnsibleHCloud
 from ..module_utils.vendor.hcloud import HCloudException
 
 
-class AnsibleHcloudPlacementGroup(AnsibleHCloud):
+class AnsibleHCloudPlacementGroup(AnsibleHCloud):
     def __init__(self, module):
         super().__init__(module, "hcloud_placement_group")
         self.hcloud_placement_group = None
@@ -204,9 +204,9 @@ class AnsibleHcloudPlacementGroup(AnsibleHCloud):
 
 
 def main():
-    module = AnsibleHcloudPlacementGroup.define_module()
+    module = AnsibleHCloudPlacementGroup.define_module()
 
-    hcloud = AnsibleHcloudPlacementGroup(module)
+    hcloud = AnsibleHCloudPlacementGroup(module)
     state = module.params.get("state")
     if state == "absent":
         hcloud.delete_placement_group()

--- a/plugins/modules/hcloud_placement_group.py
+++ b/plugins/modules/hcloud_placement_group.py
@@ -110,11 +110,11 @@ hcloud_placement_group:
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.common.text.converters import to_native
 
-from ..module_utils.hcloud import Hcloud
+from ..module_utils.hcloud import AnsibleHCloud
 from ..module_utils.vendor.hcloud import HCloudException
 
 
-class AnsibleHcloudPlacementGroup(Hcloud):
+class AnsibleHcloudPlacementGroup(AnsibleHCloud):
     def __init__(self, module):
         super().__init__(module, "hcloud_placement_group")
         self.hcloud_placement_group = None

--- a/plugins/modules/hcloud_primary_ip.py
+++ b/plugins/modules/hcloud_primary_ip.py
@@ -134,11 +134,11 @@ hcloud_primary_ip:
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.common.text.converters import to_native
 
-from ..module_utils.hcloud import Hcloud
+from ..module_utils.hcloud import AnsibleHCloud
 from ..module_utils.vendor.hcloud import HCloudException
 
 
-class AnsibleHcloudPrimaryIP(Hcloud):
+class AnsibleHcloudPrimaryIP(AnsibleHCloud):
     def __init__(self, module):
         super().__init__(module, "hcloud_primary_ip")
         self.hcloud_primary_ip = None

--- a/plugins/modules/hcloud_primary_ip.py
+++ b/plugins/modules/hcloud_primary_ip.py
@@ -138,7 +138,7 @@ from ..module_utils.hcloud import AnsibleHCloud
 from ..module_utils.vendor.hcloud import HCloudException
 
 
-class AnsibleHcloudPrimaryIP(AnsibleHCloud):
+class AnsibleHCloudPrimaryIP(AnsibleHCloud):
     def __init__(self, module):
         super().__init__(module, "hcloud_primary_ip")
         self.hcloud_primary_ip = None
@@ -245,9 +245,9 @@ class AnsibleHcloudPrimaryIP(AnsibleHCloud):
 
 
 def main():
-    module = AnsibleHcloudPrimaryIP.define_module()
+    module = AnsibleHCloudPrimaryIP.define_module()
 
-    hcloud = AnsibleHcloudPrimaryIP(module)
+    hcloud = AnsibleHCloudPrimaryIP(module)
     state = module.params["state"]
     if state == "absent":
         hcloud.delete_primary_ip()

--- a/plugins/modules/hcloud_primary_ip_info.py
+++ b/plugins/modules/hcloud_primary_ip_info.py
@@ -120,11 +120,11 @@ hcloud_primary_ip_info:
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.common.text.converters import to_native
 
-from ..module_utils.hcloud import Hcloud
+from ..module_utils.hcloud import AnsibleHCloud
 from ..module_utils.vendor.hcloud import HCloudException
 
 
-class AnsibleHcloudPrimaryIPInfo(Hcloud):
+class AnsibleHcloudPrimaryIPInfo(AnsibleHCloud):
     def __init__(self, module):
         super().__init__(module, "hcloud_primary_ip_info")
         self.hcloud_primary_ip_info = None

--- a/plugins/modules/hcloud_primary_ip_info.py
+++ b/plugins/modules/hcloud_primary_ip_info.py
@@ -124,7 +124,7 @@ from ..module_utils.hcloud import AnsibleHCloud
 from ..module_utils.vendor.hcloud import HCloudException
 
 
-class AnsibleHcloudPrimaryIPInfo(AnsibleHCloud):
+class AnsibleHCloudPrimaryIPInfo(AnsibleHCloud):
     def __init__(self, module):
         super().__init__(module, "hcloud_primary_ip_info")
         self.hcloud_primary_ip_info = None
@@ -186,8 +186,8 @@ class AnsibleHcloudPrimaryIPInfo(AnsibleHCloud):
 
 
 def main():
-    module = AnsibleHcloudPrimaryIPInfo.define_module()
-    hcloud = AnsibleHcloudPrimaryIPInfo(module)
+    module = AnsibleHCloudPrimaryIPInfo.define_module()
+    hcloud = AnsibleHCloudPrimaryIPInfo(module)
 
     hcloud.get_primary_ips()
     result = hcloud.get_result()

--- a/plugins/modules/hcloud_rdns.py
+++ b/plugins/modules/hcloud_rdns.py
@@ -140,11 +140,11 @@ from ansible_collections.ansible.netcommon.plugins.module_utils.network.common i
     utils,
 )
 
-from ..module_utils.hcloud import Hcloud
+from ..module_utils.hcloud import AnsibleHCloud
 from ..module_utils.vendor.hcloud import HCloudException
 
 
-class AnsibleHcloudReverseDNS(Hcloud):
+class AnsibleHcloudReverseDNS(AnsibleHCloud):
     def __init__(self, module):
         super().__init__(module, "hcloud_rdns")
         self.hcloud_resource = None

--- a/plugins/modules/hcloud_rdns.py
+++ b/plugins/modules/hcloud_rdns.py
@@ -144,7 +144,7 @@ from ..module_utils.hcloud import AnsibleHCloud
 from ..module_utils.vendor.hcloud import HCloudException
 
 
-class AnsibleHcloudReverseDNS(AnsibleHCloud):
+class AnsibleHCloudReverseDNS(AnsibleHCloud):
     def __init__(self, module):
         super().__init__(module, "hcloud_rdns")
         self.hcloud_resource = None
@@ -334,9 +334,9 @@ class AnsibleHcloudReverseDNS(AnsibleHCloud):
 
 
 def main():
-    module = AnsibleHcloudReverseDNS.define_module()
+    module = AnsibleHCloudReverseDNS.define_module()
 
-    hcloud = AnsibleHcloudReverseDNS(module)
+    hcloud = AnsibleHCloudReverseDNS(module)
     state = module.params["state"]
     if state == "absent":
         hcloud.delete_rdns()

--- a/plugins/modules/hcloud_route.py
+++ b/plugins/modules/hcloud_route.py
@@ -95,7 +95,7 @@ from ..module_utils.vendor.hcloud import HCloudException
 from ..module_utils.vendor.hcloud.networks.domain import NetworkRoute
 
 
-class AnsibleHcloudRoute(AnsibleHCloud):
+class AnsibleHCloudRoute(AnsibleHCloud):
     def __init__(self, module):
         super().__init__(module, "hcloud_route")
         self.hcloud_network = None
@@ -173,9 +173,9 @@ class AnsibleHcloudRoute(AnsibleHCloud):
 
 
 def main():
-    module = AnsibleHcloudRoute.define_module()
+    module = AnsibleHCloudRoute.define_module()
 
-    hcloud = AnsibleHcloudRoute(module)
+    hcloud = AnsibleHCloudRoute(module)
     state = module.params["state"]
     if state == "absent":
         hcloud.delete_route()

--- a/plugins/modules/hcloud_route.py
+++ b/plugins/modules/hcloud_route.py
@@ -90,12 +90,12 @@ hcloud_route:
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.common.text.converters import to_native
 
-from ..module_utils.hcloud import Hcloud
+from ..module_utils.hcloud import AnsibleHCloud
 from ..module_utils.vendor.hcloud import HCloudException
 from ..module_utils.vendor.hcloud.networks.domain import NetworkRoute
 
 
-class AnsibleHcloudRoute(Hcloud):
+class AnsibleHcloudRoute(AnsibleHCloud):
     def __init__(self, module):
         super().__init__(module, "hcloud_route")
         self.hcloud_network = None

--- a/plugins/modules/hcloud_server.py
+++ b/plugins/modules/hcloud_server.py
@@ -333,7 +333,7 @@ from datetime import datetime, timedelta, timezone
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.common.text.converters import to_native
 
-from ..module_utils.hcloud import Hcloud
+from ..module_utils.hcloud import AnsibleHCloud
 from ..module_utils.vendor.hcloud import HCloudException
 from ..module_utils.vendor.hcloud.firewalls.domain import FirewallResource
 from ..module_utils.vendor.hcloud.servers.domain import (
@@ -344,7 +344,7 @@ from ..module_utils.vendor.hcloud.ssh_keys.domain import SSHKey
 from ..module_utils.vendor.hcloud.volumes.domain import Volume
 
 
-class AnsibleHcloudServer(Hcloud):
+class AnsibleHcloudServer(AnsibleHCloud):
     def __init__(self, module):
         super().__init__(module, "hcloud_server")
         self.hcloud_server = None

--- a/plugins/modules/hcloud_server.py
+++ b/plugins/modules/hcloud_server.py
@@ -344,7 +344,7 @@ from ..module_utils.vendor.hcloud.ssh_keys.domain import SSHKey
 from ..module_utils.vendor.hcloud.volumes.domain import Volume
 
 
-class AnsibleHcloudServer(AnsibleHCloud):
+class AnsibleHCloudServer(AnsibleHCloud):
     def __init__(self, module):
         super().__init__(module, "hcloud_server")
         self.hcloud_server = None
@@ -906,9 +906,9 @@ class AnsibleHcloudServer(AnsibleHCloud):
 
 
 def main():
-    module = AnsibleHcloudServer.define_module()
+    module = AnsibleHCloudServer.define_module()
 
-    hcloud = AnsibleHcloudServer(module)
+    hcloud = AnsibleHCloudServer(module)
     state = module.params.get("state")
     if state == "absent":
         hcloud.delete_server()

--- a/plugins/modules/hcloud_server_info.py
+++ b/plugins/modules/hcloud_server_info.py
@@ -144,7 +144,7 @@ from ..module_utils.hcloud import AnsibleHCloud
 from ..module_utils.vendor.hcloud import HCloudException
 
 
-class AnsibleHcloudServerInfo(AnsibleHCloud):
+class AnsibleHCloudServerInfo(AnsibleHCloud):
     def __init__(self, module):
         super().__init__(module, "hcloud_server_info")
         self.hcloud_server_info = None
@@ -214,8 +214,8 @@ class AnsibleHcloudServerInfo(AnsibleHCloud):
 
 
 def main():
-    module = AnsibleHcloudServerInfo.define_module()
-    hcloud = AnsibleHcloudServerInfo(module)
+    module = AnsibleHCloudServerInfo.define_module()
+    hcloud = AnsibleHCloudServerInfo(module)
 
     hcloud.get_servers()
     result = hcloud.get_result()

--- a/plugins/modules/hcloud_server_info.py
+++ b/plugins/modules/hcloud_server_info.py
@@ -140,11 +140,11 @@ hcloud_server_info:
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.common.text.converters import to_native
 
-from ..module_utils.hcloud import Hcloud
+from ..module_utils.hcloud import AnsibleHCloud
 from ..module_utils.vendor.hcloud import HCloudException
 
 
-class AnsibleHcloudServerInfo(Hcloud):
+class AnsibleHcloudServerInfo(AnsibleHCloud):
     def __init__(self, module):
         super().__init__(module, "hcloud_server_info")
         self.hcloud_server_info = None

--- a/plugins/modules/hcloud_server_network.py
+++ b/plugins/modules/hcloud_server_network.py
@@ -115,11 +115,11 @@ hcloud_server_network:
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.common.text.converters import to_native
 
-from ..module_utils.hcloud import Hcloud
+from ..module_utils.hcloud import AnsibleHCloud
 from ..module_utils.vendor.hcloud import APIException, HCloudException
 
 
-class AnsibleHcloudServerNetwork(Hcloud):
+class AnsibleHcloudServerNetwork(AnsibleHCloud):
     def __init__(self, module):
         super().__init__(module, "hcloud_server_network")
         self.hcloud_network = None

--- a/plugins/modules/hcloud_server_network.py
+++ b/plugins/modules/hcloud_server_network.py
@@ -119,7 +119,7 @@ from ..module_utils.hcloud import AnsibleHCloud
 from ..module_utils.vendor.hcloud import APIException, HCloudException
 
 
-class AnsibleHcloudServerNetwork(AnsibleHCloud):
+class AnsibleHCloudServerNetwork(AnsibleHCloud):
     def __init__(self, module):
         super().__init__(module, "hcloud_server_network")
         self.hcloud_network = None
@@ -224,9 +224,9 @@ class AnsibleHcloudServerNetwork(AnsibleHCloud):
 
 
 def main():
-    module = AnsibleHcloudServerNetwork.define_module()
+    module = AnsibleHCloudServerNetwork.define_module()
 
-    hcloud = AnsibleHcloudServerNetwork(module)
+    hcloud = AnsibleHCloudServerNetwork(module)
     state = module.params["state"]
     if state == "absent":
         hcloud.delete_server_network()

--- a/plugins/modules/hcloud_server_type_info.py
+++ b/plugins/modules/hcloud_server_type_info.py
@@ -127,7 +127,7 @@ from ..module_utils.hcloud import AnsibleHCloud
 from ..module_utils.vendor.hcloud import HCloudException
 
 
-class AnsibleHcloudServerTypeInfo(AnsibleHCloud):
+class AnsibleHCloudServerTypeInfo(AnsibleHCloud):
     def __init__(self, module):
         super().__init__(module, "hcloud_server_type_info")
         self.hcloud_server_type_info = None
@@ -184,8 +184,8 @@ class AnsibleHcloudServerTypeInfo(AnsibleHCloud):
 
 
 def main():
-    module = AnsibleHcloudServerTypeInfo.define_module()
-    hcloud = AnsibleHcloudServerTypeInfo(module)
+    module = AnsibleHCloudServerTypeInfo.define_module()
+    hcloud = AnsibleHCloudServerTypeInfo(module)
 
     hcloud.get_server_types()
     result = hcloud.get_result()

--- a/plugins/modules/hcloud_server_type_info.py
+++ b/plugins/modules/hcloud_server_type_info.py
@@ -123,11 +123,11 @@ hcloud_server_type_info:
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.common.text.converters import to_native
 
-from ..module_utils.hcloud import Hcloud
+from ..module_utils.hcloud import AnsibleHCloud
 from ..module_utils.vendor.hcloud import HCloudException
 
 
-class AnsibleHcloudServerTypeInfo(Hcloud):
+class AnsibleHcloudServerTypeInfo(AnsibleHCloud):
     def __init__(self, module):
         super().__init__(module, "hcloud_server_type_info")
         self.hcloud_server_type_info = None

--- a/plugins/modules/hcloud_ssh_key.py
+++ b/plugins/modules/hcloud_ssh_key.py
@@ -113,11 +113,11 @@ hcloud_ssh_key:
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.common.text.converters import to_native
 
-from ..module_utils.hcloud import Hcloud
+from ..module_utils.hcloud import AnsibleHCloud
 from ..module_utils.vendor.hcloud import HCloudException
 
 
-class AnsibleHcloudSSHKey(Hcloud):
+class AnsibleHcloudSSHKey(AnsibleHCloud):
     def __init__(self, module):
         super().__init__(module, "hcloud_ssh_key")
         self.hcloud_ssh_key = None

--- a/plugins/modules/hcloud_ssh_key.py
+++ b/plugins/modules/hcloud_ssh_key.py
@@ -117,7 +117,7 @@ from ..module_utils.hcloud import AnsibleHCloud
 from ..module_utils.vendor.hcloud import HCloudException
 
 
-class AnsibleHcloudSSHKey(AnsibleHCloud):
+class AnsibleHCloudSSHKey(AnsibleHCloud):
     def __init__(self, module):
         super().__init__(module, "hcloud_ssh_key")
         self.hcloud_ssh_key = None
@@ -215,9 +215,9 @@ class AnsibleHcloudSSHKey(AnsibleHCloud):
 
 
 def main():
-    module = AnsibleHcloudSSHKey.define_module()
+    module = AnsibleHCloudSSHKey.define_module()
 
-    hcloud = AnsibleHcloudSSHKey(module)
+    hcloud = AnsibleHCloudSSHKey(module)
     state = module.params.get("state")
     if state == "absent":
         hcloud.delete_ssh_key()

--- a/plugins/modules/hcloud_ssh_key_info.py
+++ b/plugins/modules/hcloud_ssh_key_info.py
@@ -77,11 +77,11 @@ hcloud_ssh_key_info:
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.common.text.converters import to_native
 
-from ..module_utils.hcloud import Hcloud
+from ..module_utils.hcloud import AnsibleHCloud
 from ..module_utils.vendor.hcloud import HCloudException
 
 
-class AnsibleHcloudSSHKeyInfo(Hcloud):
+class AnsibleHcloudSSHKeyInfo(AnsibleHCloud):
     def __init__(self, module):
         super().__init__(module, "hcloud_ssh_key_info")
         self.hcloud_ssh_key_info = None

--- a/plugins/modules/hcloud_ssh_key_info.py
+++ b/plugins/modules/hcloud_ssh_key_info.py
@@ -81,7 +81,7 @@ from ..module_utils.hcloud import AnsibleHCloud
 from ..module_utils.vendor.hcloud import HCloudException
 
 
-class AnsibleHcloudSSHKeyInfo(AnsibleHCloud):
+class AnsibleHCloudSSHKeyInfo(AnsibleHCloud):
     def __init__(self, module):
         super().__init__(module, "hcloud_ssh_key_info")
         self.hcloud_ssh_key_info = None
@@ -137,8 +137,8 @@ class AnsibleHcloudSSHKeyInfo(AnsibleHCloud):
 
 
 def main():
-    module = AnsibleHcloudSSHKeyInfo.define_module()
-    hcloud = AnsibleHcloudSSHKeyInfo(module)
+    module = AnsibleHCloudSSHKeyInfo.define_module()
+    hcloud = AnsibleHCloudSSHKeyInfo(module)
 
     hcloud.get_ssh_keys()
     result = hcloud.get_result()

--- a/plugins/modules/hcloud_subnetwork.py
+++ b/plugins/modules/hcloud_subnetwork.py
@@ -127,12 +127,12 @@ hcloud_subnetwork:
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.common.text.converters import to_native
 
-from ..module_utils.hcloud import Hcloud
+from ..module_utils.hcloud import AnsibleHCloud
 from ..module_utils.vendor.hcloud import HCloudException
 from ..module_utils.vendor.hcloud.networks.domain import NetworkSubnet
 
 
-class AnsibleHcloudSubnetwork(Hcloud):
+class AnsibleHcloudSubnetwork(AnsibleHCloud):
     def __init__(self, module):
         super().__init__(module, "hcloud_subnetwork")
         self.hcloud_network = None

--- a/plugins/modules/hcloud_subnetwork.py
+++ b/plugins/modules/hcloud_subnetwork.py
@@ -132,7 +132,7 @@ from ..module_utils.vendor.hcloud import HCloudException
 from ..module_utils.vendor.hcloud.networks.domain import NetworkSubnet
 
 
-class AnsibleHcloudSubnetwork(AnsibleHCloud):
+class AnsibleHCloudSubnetwork(AnsibleHCloud):
     def __init__(self, module):
         super().__init__(module, "hcloud_subnetwork")
         self.hcloud_network = None
@@ -219,9 +219,9 @@ class AnsibleHcloudSubnetwork(AnsibleHCloud):
 
 
 def main():
-    module = AnsibleHcloudSubnetwork.define_module()
+    module = AnsibleHCloudSubnetwork.define_module()
 
-    hcloud = AnsibleHcloudSubnetwork(module)
+    hcloud = AnsibleHCloudSubnetwork(module)
     state = module.params["state"]
     if state == "absent":
         hcloud.delete_subnetwork()

--- a/plugins/modules/hcloud_volume.py
+++ b/plugins/modules/hcloud_volume.py
@@ -164,7 +164,7 @@ from ..module_utils.hcloud import AnsibleHCloud
 from ..module_utils.vendor.hcloud import HCloudException
 
 
-class AnsibleHcloudVolume(AnsibleHCloud):
+class AnsibleHCloudVolume(AnsibleHCloud):
     def __init__(self, module):
         super().__init__(module, "hcloud_volume")
         self.hcloud_volume = None
@@ -311,9 +311,9 @@ class AnsibleHcloudVolume(AnsibleHCloud):
 
 
 def main():
-    module = AnsibleHcloudVolume.define_module()
+    module = AnsibleHCloudVolume.define_module()
 
-    hcloud = AnsibleHcloudVolume(module)
+    hcloud = AnsibleHCloudVolume(module)
     state = module.params.get("state")
     if state == "absent":
         module.fail_on_missing_params(required_params=["name"])

--- a/plugins/modules/hcloud_volume.py
+++ b/plugins/modules/hcloud_volume.py
@@ -160,11 +160,11 @@ hcloud_volume:
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.common.text.converters import to_native
 
-from ..module_utils.hcloud import Hcloud
+from ..module_utils.hcloud import AnsibleHCloud
 from ..module_utils.vendor.hcloud import HCloudException
 
 
-class AnsibleHcloudVolume(Hcloud):
+class AnsibleHcloudVolume(AnsibleHCloud):
     def __init__(self, module):
         super().__init__(module, "hcloud_volume")
         self.hcloud_volume = None

--- a/plugins/modules/hcloud_volume_info.py
+++ b/plugins/modules/hcloud_volume_info.py
@@ -98,7 +98,7 @@ from ..module_utils.hcloud import AnsibleHCloud
 from ..module_utils.vendor.hcloud import HCloudException
 
 
-class AnsibleHcloudVolumeInfo(AnsibleHCloud):
+class AnsibleHCloudVolumeInfo(AnsibleHCloud):
     def __init__(self, module):
         super().__init__(module, "hcloud_volume_info")
         self.hcloud_volume_info = None
@@ -156,8 +156,8 @@ class AnsibleHcloudVolumeInfo(AnsibleHCloud):
 
 
 def main():
-    module = AnsibleHcloudVolumeInfo.define_module()
-    hcloud = AnsibleHcloudVolumeInfo(module)
+    module = AnsibleHCloudVolumeInfo.define_module()
+    hcloud = AnsibleHCloudVolumeInfo(module)
 
     hcloud.get_volumes()
     result = hcloud.get_result()

--- a/plugins/modules/hcloud_volume_info.py
+++ b/plugins/modules/hcloud_volume_info.py
@@ -94,11 +94,11 @@ hcloud_volume_info:
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.common.text.converters import to_native
 
-from ..module_utils.hcloud import Hcloud
+from ..module_utils.hcloud import AnsibleHCloud
 from ..module_utils.vendor.hcloud import HCloudException
 
 
-class AnsibleHcloudVolumeInfo(Hcloud):
+class AnsibleHcloudVolumeInfo(AnsibleHCloud):
     def __init__(self, module):
         super().__init__(module, "hcloud_volume_info")
         self.hcloud_volume_info = None

--- a/tests/unit/module_utils/test_hcloud.py
+++ b/tests/unit/module_utils/test_hcloud.py
@@ -2,7 +2,7 @@ import traceback
 from datetime import datetime, timezone
 from unittest.mock import MagicMock
 
-from ansible_collections.hetzner.hcloud.plugins.module_utils.hcloud import Hcloud
+from ansible_collections.hetzner.hcloud.plugins.module_utils.hcloud import AnsibleHCloud
 from ansible_collections.hetzner.hcloud.plugins.module_utils.vendor.hcloud import (
     APIException,
 )
@@ -21,7 +21,7 @@ def test_hcloud_fail_json_hcloud():
         "endpoint": "https://api.hetzner.cloud/v1",
     }
 
-    hcloud = Hcloud(module, "hcloud_test")
+    hcloud = AnsibleHCloud(module, "hcloud_test")
 
     try:
         raise APIException(


### PR DESCRIPTION
##### SUMMARY

- Use an explicit `AnsibleHCloud` class name to prevent confusion with the bundled hcloud library.
- Fix Ansible modules class names: `Hcloud` → `HCloud` 