### PR TITLE
test: improve tests using setup_selfsigned_certificate helper

### DIFF
--- a/tests/integration/requirements.txt
+++ b/tests/integration/requirements.txt
@@ -1,3 +1,5 @@
 netaddr
+cryptography
+
 python-dateutil
 requests

--- a/tests/integration/targets/hcloud_certificate/tasks/cleanup.yml
+++ b/tests/integration/targets/hcloud_certificate/tasks/cleanup.yml
@@ -1,0 +1,5 @@
+---
+- name: cleanup test certificate
+  hetzner.hcloud.hcloud_certificate:
+    name: "{{ hcloud_certificate_name }}"
+    state: absent

--- a/tests/integration/targets/hcloud_certificate/tasks/test.yml
+++ b/tests/integration/targets/hcloud_certificate/tasks/test.yml
@@ -15,8 +15,8 @@
 - name: test create certificate with check mode
   hetzner.hcloud.hcloud_certificate:
     name: "{{ hcloud_certificate_name }}"
-    certificate: "{{ certificate_example_com }}"
-    private_key: "{{ certificate_example_com_key }}"
+    certificate: "{{ test_certificate_content }}"
+    private_key: "{{ test_certificate_privatekey_content }}"
   register: result
   check_mode: true
 - name: test create certificate with check mode
@@ -27,8 +27,8 @@
 - name: test create certificate
   hetzner.hcloud.hcloud_certificate:
     name: "{{ hcloud_certificate_name }}"
-    certificate: "{{ certificate_example_com }}"
-    private_key: "{{ certificate_example_com_key }}"
+    certificate: "{{ test_certificate_content }}"
+    private_key: "{{ test_certificate_privatekey_content }}"
     labels:
       key: value
       my-label: label
@@ -44,8 +44,8 @@
 - name: test create certificate idempotence
   hetzner.hcloud.hcloud_certificate:
     name: "{{ hcloud_certificate_name }}"
-    certificate: "{{ certificate_example_com }}"
-    private_key: "{{ certificate_example_com_key }}"
+    certificate: "{{ test_certificate_content }}"
+    private_key: "{{ test_certificate_privatekey_content }}"
   register: result
 - name: verify create certificate idempotence
   assert:
@@ -144,12 +144,12 @@
       - result.hcloud_certificate.name == "{{ hcloud_certificate_name }}"
       - result.hcloud_certificate.domain_names[0] == "{{ hcloud_dns_test_domain }}"
 
-- name: absent certificate
+- name: test delete certificate
   hetzner.hcloud.hcloud_certificate:
     id: "{{ result.hcloud_certificate.id }}"
     state: absent
   register: result
-- name: verify absent certificate
+- name: verify test delete certificate
   assert:
     that:
       - result is success

--- a/tests/integration/targets/hcloud_certificate_info/tasks/cleanup.yml
+++ b/tests/integration/targets/hcloud_certificate_info/tasks/cleanup.yml
@@ -1,0 +1,5 @@
+---
+- name: Cleanup test_certificate
+  hetzner.hcloud.hcloud_certificate:
+    name: "{{ hcloud_certificate_name }}"
+    state: absent

--- a/tests/integration/targets/hcloud_certificate_info/tasks/prepare.yml
+++ b/tests/integration/targets/hcloud_certificate_info/tasks/prepare.yml
@@ -1,0 +1,10 @@
+---
+- name: Create test_certificate
+  hetzner.hcloud.hcloud_certificate:
+    name: "{{ hcloud_certificate_name }}"
+    certificate: "{{ test_certificate_content }}"
+    private_key: "{{ test_certificate_privatekey_content }}"
+    labels:
+      key: value
+      my-label: label
+  register: test_certificate

--- a/tests/integration/targets/hcloud_certificate_info/tasks/test.yml
+++ b/tests/integration/targets/hcloud_certificate_info/tasks/test.yml
@@ -1,23 +1,6 @@
 # Copyright: (c) 2019, Hetzner Cloud GmbH <info@hetzner-cloud.de>
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 ---
-- name: create certificate
-  hetzner.hcloud.hcloud_certificate:
-    name: "{{ hcloud_certificate_name }}"
-    certificate: "{{ certificate_example_com }}"
-    private_key: "{{ certificate_example_com_key }}"
-    labels:
-      key: value
-      my-label: label
-  register: certificate
-- name: verify create certificate
-  assert:
-    that:
-      - certificate is changed
-      - certificate.hcloud_certificate.name == "{{ hcloud_certificate_name }}"
-      - certificate.hcloud_certificate.domain_names[0] ==  "www.example.com"
-      - certificate.hcloud_certificate.labels.key == "value"
-
 - name: test gather hcloud certificate infos in check mode
   hetzner.hcloud.hcloud_certificate_info:
   register: hcloud_certificate
@@ -53,13 +36,3 @@
   assert:
     that:
       - hcloud_certificate.hcloud_certificate_info | list | count == 0
-
-- name: absent certificate
-  hetzner.hcloud.hcloud_certificate:
-    id: "{{ certificate.hcloud_certificate.id }}"
-    state: absent
-  register: result
-- name: verify absent certificate
-  assert:
-    that:
-      - result is success

--- a/tests/integration/targets/setup_selfsigned_certificate/tasks/main.yml
+++ b/tests/integration/targets/setup_selfsigned_certificate/tasks/main.yml
@@ -1,27 +1,35 @@
-# Copyright: (c) 2020, Hetzner Cloud GmbH <info@hetzner-cloud.de>
-# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+---
+- name: Create temporary file for test_certificate
+  ansible.builtin.tempfile:
+    suffix: "{{ hcloud_certificate_name }}"
+  register: _tmp_certificate_file
 
-- name: create a cert temp file
-  tempfile:
-    state: file
-  register: certificate_example_com
-  tags:
-    - prepare
-- name: create a key temp file
-  tempfile:
-    state: file
-  register: certificate_example_com_key
-  tags:
-    - prepare
-    -
-- name: generate certificate
-  shell: openssl req -nodes -new -x509 -keyout {{ certificate_example_com_key.path }} -out {{ certificate_example_com.path }} -subj "/C=DE/ST=Munich/L=Bavaria/O=Dis/CN=www.example.com"
-  tags:
-    - prepare
+- name: Create certificate privatekey file
+  community.crypto.openssl_privatekey:
+    path: "{{ _tmp_certificate_file.path }}.key"
+    return_content: true
+  register: _certificate_privatekey_file
 
-- name: set facts for future roles
+- name: Create certificate signing request file
+  community.crypto.openssl_csr:
+    privatekey_path: "{{ _tmp_certificate_file.path }}.key"
+    path: "{{ _tmp_certificate_file.path }}.csr"
+    country_name: DE
+    locality_name: Bavaria
+    state_or_province_name: Munich
+    organization_name: Dis
+    common_name: www.example.com
+
+- name: Create certificate file
+  community.crypto.x509_certificate:
+    privatekey_path: "{{ _tmp_certificate_file.path }}.key"
+    csr_path: "{{ _tmp_certificate_file.path }}.csr"
+    path: "{{ _tmp_certificate_file.path }}.crt"
+    provider: selfsigned
+    return_content: true
+  register: _certificate_file
+
+- name: Save certificate files content
   set_fact:
-    certificate_example_com: "{{ lookup('file',certificate_example_com.path) }}"
-    certificate_example_com_key: "{{ lookup('file',certificate_example_com_key.path) }}"
-  tags:
-    - prepare
+    test_certificate_privatekey_content: "{{ _certificate_privatekey_file.privatekey }}"
+    test_certificate_content: "{{ _certificate_file.certificate }}"

--- a/tests/requirements.yml
+++ b/tests/requirements.yml
@@ -1,4 +1,5 @@
 ---
 collections:
   - ansible.netcommon
+  - community.crypto
   - community.general


### PR DESCRIPTION
##### SUMMARY

- Improve the setup_selfsigned_certificate helper
- Use the community.crypto collection instead of handmade tasks.
- Implement the new testing framework (prepare.yml/cleanup.yml #239)

