### PR TITLE
ci: fix gitlab stages

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -5,6 +5,7 @@ include:
       - pre-commit.yml
 
 stages:
+  - test
   - sanity
   - integration
 


### PR DESCRIPTION
The test stage is missing and required by the imported CI templates.