### PR TITLE
fix: do not error on location_info invalid id

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -19,7 +19,6 @@ exclude_paths:
   - tests/integration/targets/hcloud_load_balancer_service
   - tests/integration/targets/hcloud_load_balancer_target
   - tests/integration/targets/hcloud_load_balancer_type_info
-  - tests/integration/targets/hcloud_location_info
   - tests/integration/targets/hcloud_network
   - tests/integration/targets/hcloud_network_info
   - tests/integration/targets/hcloud_placement_group

--- a/changelogs/fragments/fix-error-on-location_info-invalid-id.yml
+++ b/changelogs/fragments/fix-error-on-location_info-invalid-id.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - hcloud_location_info - Do not error when querying a location using an invalid id.

--- a/plugins/modules/hcloud_location_info.py
+++ b/plugins/modules/hcloud_location_info.py
@@ -78,7 +78,7 @@ from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.common.text.converters import to_native
 
 from ..module_utils.hcloud import AnsibleHCloud
-from ..module_utils.vendor.hcloud import HCloudException
+from ..module_utils.vendor.hcloud import APIException, HCloudException
 
 
 class AnsibleHCloudLocationInfo(AnsibleHCloud):
@@ -105,7 +105,12 @@ class AnsibleHCloudLocationInfo(AnsibleHCloud):
     def get_locations(self):
         try:
             if self.module.params.get("id") is not None:
-                self.hcloud_location_info = [self.client.locations.get_by_id(self.module.params.get("id"))]
+                try:
+                    self.hcloud_location_info = [self.client.locations.get_by_id(self.module.params.get("id"))]
+                except APIException as exception:
+                    self.hcloud_location_info = []
+                    if exception.code != "not_found":
+                        raise exception
             elif self.module.params.get("name") is not None:
                 self.hcloud_location_info = [self.client.locations.get_by_name(self.module.params.get("name"))]
             else:

--- a/tests/integration/targets/hcloud_location_info/defaults/main/main.yml
+++ b/tests/integration/targets/hcloud_location_info/defaults/main/main.yml
@@ -1,5 +1,5 @@
 # Copyright: (c) 2019, Hetzner Cloud GmbH <info@hetzner-cloud.de>
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 ---
-hcloud_location_name: "fsn1"
 hcloud_location_id: 1
+hcloud_location_name: fsn1

--- a/tests/integration/targets/hcloud_location_info/tasks/test.yml
+++ b/tests/integration/targets/hcloud_location_info/tasks/test.yml
@@ -1,57 +1,55 @@
 # Copyright: (c) 2019, Hetzner Cloud GmbH <info@hetzner-cloud.de>
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 ---
-- name: test gather hcloud location infos
+- name: Gather hcloud_location_info
   hetzner.hcloud.hcloud_location_info:
-  register: hcloud_location
-
-- name: verify test gather hcloud location infos
-  assert:
+  register: result
+- name: Verify hcloud_location_info
+  ansible.builtin.assert:
     that:
-      - hcloud_location.hcloud_location_info | list | count >= 5
+      - result.hcloud_location_info | list | count >= 5
 
-- name: test gather hcloud location infos in check mode
+- name: Gather hcloud_location_info in check mode
   hetzner.hcloud.hcloud_location_info:
   check_mode: true
-  register: hcloud_location
-
-- name: verify test gather hcloud location infos in check mode
-  assert:
+  register: result
+- name: Verify hcloud_location_info in check mode
+  ansible.builtin.assert:
     that:
-      - hcloud_location.hcloud_location_info | list | count >= 5
+      - result.hcloud_location_info | list | count >= 5
 
-- name: test gather hcloud location infos with correct name
+- name: Gather hcloud_location_info with correct name
   hetzner.hcloud.hcloud_location_info:
-    name: "{{hcloud_location_name}}"
-  register: hcloud_location
-- name: verify test gather hcloud location with correct name
-  assert:
+    name: "{{ hcloud_location_name }}"
+  register: result
+- name: Verify hcloud_location_info with correct name
+  ansible.builtin.assert:
     that:
-      - hcloud_location.hcloud_location_info|selectattr('name','equalto','{{ hcloud_location_name }}') | list | count == 1
+      - result.hcloud_location_info | selectattr('name', 'equalto', '{{ hcloud_location_name }}') | list | count == 1
 
-- name: test gather hcloud location infos with wrong name
+- name: Gather hcloud_location_info with wrong name
   hetzner.hcloud.hcloud_location_info:
-    name: "{{hcloud_location_name}}1"
-  register: hcloud_location
-- name: verify test gather hcloud location with wrong name
-  assert:
+    name: "{{ hcloud_location_name }}1"
+  register: result
+- name: Verify hcloud_location_info with wrong name
+  ansible.builtin.assert:
     that:
-      - hcloud_location.hcloud_location_info | list | count == 0
+      - result.hcloud_location_info | list | count == 0
 
-- name: test gather hcloud location infos with correct id
+- name: Gather hcloud_location_info with correct id
   hetzner.hcloud.hcloud_location_info:
-    id: "{{hcloud_location_id}}"
-  register: hcloud_location
-- name: verify test gather hcloud location with correct id
-  assert:
+    id: "{{ hcloud_location_id }}"
+  register: result
+- name: Verify hcloud_location_info with correct id
+  ansible.builtin.assert:
     that:
-      - hcloud_location.hcloud_location_info|selectattr('name','equalto','{{ hcloud_location_name }}') | list | count == 1
+      - result.hcloud_location_info | selectattr('name', 'equalto', '{{ hcloud_location_name }}') | list | count == 1
 
-- name: test gather hcloud location infos with wrong id
+- name: Gather hcloud_location_info with wrong id
   hetzner.hcloud.hcloud_location_info:
     id: 4711
-  register: hcloud_location
-- name: verify test gather hcloud location with wrong id
-  assert:
+  register: result
+- name: Verify hcloud_location_info with wrong id
+  ansible.builtin.assert:
     that:
-      - hcloud_location.hcloud_location_info | list | count == 0
+      - result.hcloud_location_info | list | count == 0

--- a/tests/integration/targets/hcloud_location_info/tasks/test.yml
+++ b/tests/integration/targets/hcloud_location_info/tasks/test.yml
@@ -49,7 +49,7 @@
 
 - name: test gather hcloud location infos with wrong id
   hetzner.hcloud.hcloud_location_info:
-    name: "4711"
+    id: 4711
   register: hcloud_location
 - name: verify test gather hcloud location with wrong id
   assert:


### PR DESCRIPTION
##### SUMMARY

The location info module crashed when querying a location using an invalid ID

The "with wrong id" test was using the name parameter instead of the id parameter, so the test could not catch this.

We might find similar error in other modules.

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME
hcloud_location_info