### PR TITLE
fix: consistently fail on invalid ID in `*_info` modules

### DIFF
--- a/changelogs/fragments/consistently-fail-on-invalid-id.yml
+++ b/changelogs/fragments/consistently-fail-on-invalid-id.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - "`*_info` - Consistently fail on invalid ID in `*_info` modules."

--- a/changelogs/fragments/fix-error-on-location_info-invalid-id.yml
+++ b/changelogs/fragments/fix-error-on-location_info-invalid-id.yml
@@ -1,2 +1,0 @@
-bugfixes:
-  - hcloud_location_info - Do not error when querying a location using an invalid id.

--- a/plugins/modules/hcloud_certificate_info.py
+++ b/plugins/modules/hcloud_certificate_info.py
@@ -16,6 +16,7 @@ options:
     id:
         description:
             - The ID of the certificate you want to get.
+            - The module will fail if the provided ID is invalid.
         type: int
     name:
         description:

--- a/plugins/modules/hcloud_datacenter_info.py
+++ b/plugins/modules/hcloud_datacenter_info.py
@@ -20,6 +20,7 @@ options:
     id:
         description:
             - The ID of the datacenter you want to get.
+            - The module will fail if the provided ID is invalid.
         type: int
     name:
         description:

--- a/plugins/modules/hcloud_floating_ip_info.py
+++ b/plugins/modules/hcloud_floating_ip_info.py
@@ -20,6 +20,7 @@ options:
     id:
         description:
             - The ID of the Floating IP you want to get.
+            - The module will fail if the provided ID is invalid.
         type: int
     label_selector:
         description:

--- a/plugins/modules/hcloud_image_info.py
+++ b/plugins/modules/hcloud_image_info.py
@@ -21,6 +21,7 @@ options:
     id:
         description:
             - The ID of the image you want to get.
+            - The module will fail if the provided ID is invalid.
         type: int
     name:
         description:

--- a/plugins/modules/hcloud_iso_info.py
+++ b/plugins/modules/hcloud_iso_info.py
@@ -22,6 +22,7 @@ options:
     id:
         description:
             - The ID of the ISO image you want to get.
+            - The module will fail if the provided ID is invalid.
         type: int
     name:
         description:

--- a/plugins/modules/hcloud_load_balancer_info.py
+++ b/plugins/modules/hcloud_load_balancer_info.py
@@ -21,6 +21,7 @@ options:
     id:
         description:
             - The ID of the Load Balancers you want to get.
+            - The module will fail if the provided ID is invalid.
         type: int
     name:
         description:

--- a/plugins/modules/hcloud_load_balancer_type_info.py
+++ b/plugins/modules/hcloud_load_balancer_type_info.py
@@ -21,6 +21,7 @@ options:
     id:
         description:
             - The ID of the Load Balancer type you want to get.
+            - The module will fail if the provided ID is invalid.
         type: int
     name:
         description:

--- a/plugins/modules/hcloud_location_info.py
+++ b/plugins/modules/hcloud_location_info.py
@@ -79,7 +79,7 @@ from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.common.text.converters import to_native
 
 from ..module_utils.hcloud import AnsibleHCloud
-from ..module_utils.vendor.hcloud import APIException, HCloudException
+from ..module_utils.vendor.hcloud import HCloudException
 
 
 class AnsibleHCloudLocationInfo(AnsibleHCloud):

--- a/plugins/modules/hcloud_location_info.py
+++ b/plugins/modules/hcloud_location_info.py
@@ -21,6 +21,7 @@ options:
     id:
         description:
             - The ID of the location you want to get.
+            - The module will fail if the provided ID is invalid.
         type: int
     name:
         description:
@@ -105,12 +106,7 @@ class AnsibleHCloudLocationInfo(AnsibleHCloud):
     def get_locations(self):
         try:
             if self.module.params.get("id") is not None:
-                try:
-                    self.hcloud_location_info = [self.client.locations.get_by_id(self.module.params.get("id"))]
-                except APIException as exception:
-                    self.hcloud_location_info = []
-                    if exception.code != "not_found":
-                        raise exception
+                self.hcloud_location_info = [self.client.locations.get_by_id(self.module.params.get("id"))]
             elif self.module.params.get("name") is not None:
                 self.hcloud_location_info = [self.client.locations.get_by_name(self.module.params.get("name"))]
             else:

--- a/plugins/modules/hcloud_network_info.py
+++ b/plugins/modules/hcloud_network_info.py
@@ -21,6 +21,7 @@ options:
     id:
         description:
             - The ID of the network you want to get.
+            - The module will fail if the provided ID is invalid.
         type: int
     name:
         description:

--- a/plugins/modules/hcloud_primary_ip_info.py
+++ b/plugins/modules/hcloud_primary_ip_info.py
@@ -21,6 +21,7 @@ options:
     id:
         description:
             - The ID of the Primary IP you want to get.
+            - The module will fail if the provided ID is invalid.
         type: int
     name:
         description:

--- a/plugins/modules/hcloud_server_info.py
+++ b/plugins/modules/hcloud_server_info.py
@@ -21,6 +21,7 @@ options:
     id:
         description:
             - The ID of the server you want to get.
+            - The module will fail if the provided ID is invalid.
         type: int
     name:
         description:

--- a/plugins/modules/hcloud_server_type_info.py
+++ b/plugins/modules/hcloud_server_type_info.py
@@ -21,6 +21,7 @@ options:
     id:
         description:
             - The ID of the server type you want to get.
+            - The module will fail if the provided ID is invalid.
         type: int
     name:
         description:

--- a/plugins/modules/hcloud_ssh_key_info.py
+++ b/plugins/modules/hcloud_ssh_key_info.py
@@ -16,6 +16,7 @@ options:
     id:
         description:
             - The ID of the ssh key you want to get.
+            - The module will fail if the provided ID is invalid.
         type: int
     name:
         description:

--- a/plugins/modules/hcloud_volume_info.py
+++ b/plugins/modules/hcloud_volume_info.py
@@ -20,6 +20,7 @@ options:
     id:
         description:
             - The ID of the Volume you want to get.
+            - The module will fail if the provided ID is invalid.
         type: int
     name:
         description:

--- a/tests/integration/targets/hcloud_location_info/tasks/test.yml
+++ b/tests/integration/targets/hcloud_location_info/tasks/test.yml
@@ -49,7 +49,8 @@
   hetzner.hcloud.hcloud_location_info:
     id: 4711
   register: result
+  ignore_errors: true
 - name: Verify hcloud_location_info with wrong id
   ansible.builtin.assert:
     that:
-      - result.hcloud_location_info | list | count == 0
+      - result is failed

--- a/tests/integration/targets/hcloud_network_info/tasks/test.yml
+++ b/tests/integration/targets/hcloud_network_info/tasks/test.yml
@@ -103,12 +103,13 @@
 
 - name: test gather hcloud network info with wrong id
   hetzner.hcloud.hcloud_network_info:
-    name: "4711"
+    id: "4711"
   register: hcloud_network
+  ignore_errors: true
 - name: verify test gather hcloud network with wrong id
   assert:
     that:
-      - hcloud_network.hcloud_network_info | list | count == 0
+      - hcloud_network is failed
 
 - name: cleanup
   hetzner.hcloud.hcloud_network:

--- a/tests/integration/targets/hcloud_server_info/tasks/test.yml
+++ b/tests/integration/targets/hcloud_server_info/tasks/test.yml
@@ -82,12 +82,13 @@
 
 - name: test gather hcloud server infos with wrong id
   hetzner.hcloud.hcloud_server_info:
-    name: "4711"
+    id: "4711"
   register: server
+  ignore_errors: true
 - name: verify test gather hcloud server infos with wrong id
   assert:
     that:
-      - server.hcloud_server_info | list | count == 0
+      - server is failed
 
 - name: cleanup
   hetzner.hcloud.hcloud_server:

--- a/tests/integration/targets/hcloud_volume_info/tasks/test.yml
+++ b/tests/integration/targets/hcloud_volume_info/tasks/test.yml
@@ -83,12 +83,13 @@
 
 - name: test gather hcloud volume infos with wrong id
   hetzner.hcloud.hcloud_volume_info:
-    name: "4711"
+    id: "4711"
   register: hcloud_volume
+  ignore_errors: true
 - name: verify test gather hcloud volume infos with wrong id
   assert:
     that:
-      - hcloud_volume.hcloud_volume_info | list | count == 0
+      - hcloud_volume is failed
 
 - name: cleanup
   hetzner.hcloud.hcloud_volume:


### PR DESCRIPTION
##### SUMMARY

Document and make sure we fail when querying an invalid ID.

Partially reverts #292
Fixes #298 

The missing tests will be implemented in #299

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

`*_info`
