### PR TITLE
chore: update README badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
-[![Build Status](https://dev.azure.com/ansible/hetzner.hcloud/_apis/build/status/CI?branchName=master)](https://dev.azure.com/ansible/hetzner.hcloud/_build?definitionId=35)
+[![Galaxy version](https://img.shields.io/badge/dynamic/json?label=galaxy&prefix=v&url=https://galaxy.ansible.com/api/v2/collections/hetzner/hcloud/&query=latest_version.version)](https://galaxy.ansible.com/hetzner/hcloud)
+[![GitHub version](https://img.shields.io/github/v/release/ansible-collections/hetzner.hcloud)](https://github.com/ansible-collections/hetzner.hcloud/releases)
+[![Build Status](https://dev.azure.com/ansible/hetzner.hcloud/_apis/build/status/ci?branchName=main)](https://dev.azure.com/ansible/hetzner.hcloud/_build?definitionId=35)
 [![Codecov](https://img.shields.io/codecov/c/github/ansible-collections/hetzner.hcloud)](https://codecov.io/gh/ansible-collections/hetzner.hcloud)
 
 # Ansible Collection: hetzner.hcloud


### PR DESCRIPTION
##### SUMMARY

Add Github version badge and Ansible Galaxy version. Fix the azure build status to target the main branch.

We can check that the Github and Ansible Galaxy version match by looking at the badges.

