### PR TITLE
Fix string formatting error in _check_and_warn_deprecated_server

### DIFF
--- a/plugins/modules/hcloud_server.py
+++ b/plugins/modules/hcloud_server.py
@@ -548,7 +548,7 @@ class AnsibleHCloudServer(AnsibleHCloud):
             )
         else:
             self.module.warn(
-                "Attention: The server plan % is deprecated and will no longer be available for order as of "
+                "Attention: The server plan %s is deprecated and will no longer be available for order as of "
                 % server_type.name
                 + "%s. Existing servers of that plan will continue to work as before "
                 % server_type.deprecation.unavailable_after.strftime("%Y-%m-%d")


### PR DESCRIPTION


##### SUMMARY
after deprecating server type warning should be shown but due to error in string message there is crash.
```
 File "/tmp/ansible_hcloud_server_payload__bgoim7j/ansible_hcloud_server_payload.zip/ansible_collections/hetzner/hcloud/plugins/modules/hcloud_server.py", line 942, in <module>
  File "/tmp/ansible_hcloud_server_payload__bgoim7j/ansible_hcloud_server_payload.zip/ansible_collections/hetzner/hcloud/plugins/modules/hcloud_server.py", line 925, in main
  File "/tmp/ansible_hcloud_server_payload__bgoim7j/ansible_hcloud_server_payload.zip/ansible_collections/hetzner/hcloud/plugins/modules/hcloud_server.py", line 858, in present_server
  File "/tmp/ansible_hcloud_server_payload__bgoim7j/ansible_hcloud_server_payload.zip/ansible_collections/hetzner/hcloud/plugins/modules/hcloud_server.py", line 405, in _create_server
  File "/tmp/ansible_hcloud_server_payload__bgoim7j/ansible_hcloud_server_payload.zip/ansible_collections/hetzner/hcloud/plugins/modules/hcloud_server.py", line 541, in _get_server_type
  File "/tmp/ansible_hcloud_server_payload__bgoim7j/ansible_hcloud_server_payload.zip/ansible_collections/hetzner/hcloud/plugins/modules/hcloud_server.py", line 558, in _check_and_warn_deprecated_server
TypeError: %i format: a real number is required, not str
```

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
hetzner.hcloud

