### PR TITLE
chore: prepare v2.1.1

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,14 @@ Hetzner Cloud Ansible Collection Release Notes
 .. contents:: Topics
 
 
+v2.1.1
+======
+
+Bugfixes
+--------
+
+- hcloud_server - Fix string formatting error on deprecated server type warning
+
 v2.1.0
 ======
 

--- a/changelogs/changelog.yaml
+++ b/changelogs/changelog.yaml
@@ -401,3 +401,10 @@ releases:
     - query-hcloud_floating_ip_info-by-name.yml
     - use-collection-version-in-user-agent.yml
     release_date: '2023-08-17'
+  2.1.1:
+    changes:
+      bugfixes:
+      - hcloud_server - Fix string formatting error on deprecated server type warning
+    fragments:
+    - fix-string-formatting-error-on-deprecated-server-type-warning.yml
+    release_date: '2023-08-23'

--- a/changelogs/fragments/fix-string-formatting-error-on-deprecated-server-type-warning.yml
+++ b/changelogs/fragments/fix-string-formatting-error-on-deprecated-server-type-warning.yml
@@ -1,2 +1,0 @@
-bugfixes:
-  - hcloud_server - Fix string formatting error on deprecated server type warning

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -1,6 +1,6 @@
 namespace: hetzner
 name: hcloud
-version: 2.1.0
+version: 2.1.1
 readme: README.md
 authors:
   - Hetzner Cloud (github.com/hetznercloud)

--- a/plugins/module_utils/version.py
+++ b/plugins/module_utils/version.py
@@ -1,1 +1,1 @@
-version = "2.1.0"
+version = "2.1.1"


### PR DESCRIPTION
##### SUMMARY

Prepare v2.1.1 release.

This should also trigger a new publish process, since 2.1.0 never had the change to be published to ansible-galaxy.