### PR TITLE
refactor: fix pylint invalid variable name

### DIFF
--- a/plugins/inventory/hcloud.py
+++ b/plugins/inventory/hcloud.py
@@ -309,12 +309,12 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
 
         try:
             server_dict["ansible_host"] = self._get_server_ansible_host(server)
-        except AnsibleError as e:
+        except AnsibleError as exception:
             # Log warning that for this host can not be connected to, using the
             # method specified in `connect_with`. Users might use `compose` to
             # override the connection method, or implement custom logic, so we
             # do not need to abort if nothing matched.
-            self.display.v(f"[hcloud] {e}", server.name)
+            self.display.v(f"[hcloud] {exception}", server.name)
 
         return server_dict
 

--- a/plugins/modules/hcloud_certificate.py
+++ b/plugins/modules/hcloud_certificate.py
@@ -166,8 +166,8 @@ class AnsibleHCloudCertificate(AnsibleHCloud):
             elif self.module.params.get("name") is not None:
                 self.hcloud_certificate = self.client.certificates.get_by_name(self.module.params.get("name"))
 
-        except HCloudException as e:
-            self.fail_json_hcloud(e)
+        except HCloudException as exception:
+            self.fail_json_hcloud(exception)
 
     def _create_certificate(self):
         self.module.fail_on_missing_params(required_params=["name"])
@@ -183,8 +183,8 @@ class AnsibleHCloudCertificate(AnsibleHCloud):
             if not self.module.check_mode:
                 try:
                     self.client.certificates.create(**params)
-                except HCloudException as e:
-                    self.fail_json_hcloud(e)
+                except HCloudException as exception:
+                    self.fail_json_hcloud(exception)
         else:
             self.module.fail_on_missing_params(required_params=["domain_names"])
             params["domain_names"] = self.module.params.get("domain_names")
@@ -192,8 +192,8 @@ class AnsibleHCloudCertificate(AnsibleHCloud):
                 try:
                     resp = self.client.certificates.create_managed(**params)
                     resp.action.wait_until_finished(max_retries=1000)
-                except HCloudException as e:
-                    self.fail_json_hcloud(e)
+                except HCloudException as exception:
+                    self.fail_json_hcloud(exception)
 
         self._mark_as_changed()
         self._get_certificate()
@@ -212,8 +212,8 @@ class AnsibleHCloudCertificate(AnsibleHCloud):
                 if not self.module.check_mode:
                     self.hcloud_certificate.update(labels=labels)
                 self._mark_as_changed()
-        except HCloudException as e:
-            self.fail_json_hcloud(e)
+        except HCloudException as exception:
+            self.fail_json_hcloud(exception)
         self._get_certificate()
 
     def present_certificate(self):
@@ -229,8 +229,8 @@ class AnsibleHCloudCertificate(AnsibleHCloud):
             if not self.module.check_mode:
                 try:
                     self.client.certificates.delete(self.hcloud_certificate)
-                except HCloudException as e:
-                    self.fail_json_hcloud(e)
+                except HCloudException as exception:
+                    self.fail_json_hcloud(exception)
             self._mark_as_changed()
         self.hcloud_certificate = None
 

--- a/plugins/modules/hcloud_certificate_info.py
+++ b/plugins/modules/hcloud_certificate_info.py
@@ -127,8 +127,8 @@ class AnsibleHCloudCertificateInfo(AnsibleHCloud):
             else:
                 self.hcloud_certificate_info = self.client.certificates.get_all()
 
-        except HCloudException as e:
-            self.fail_json_hcloud(e)
+        except HCloudException as exception:
+            self.fail_json_hcloud(exception)
 
     @classmethod
     def define_module(cls):

--- a/plugins/modules/hcloud_datacenter_info.py
+++ b/plugins/modules/hcloud_datacenter_info.py
@@ -111,8 +111,8 @@ class AnsibleHCloudDatacenterInfo(AnsibleHCloud):
             else:
                 self.hcloud_datacenter_info = self.client.datacenters.get_all()
 
-        except HCloudException as e:
-            self.fail_json_hcloud(e)
+        except HCloudException as exception:
+            self.fail_json_hcloud(exception)
 
     @classmethod
     def define_module(cls):

--- a/plugins/modules/hcloud_firewall.py
+++ b/plugins/modules/hcloud_firewall.py
@@ -206,8 +206,8 @@ class AnsibleHCloudFirewall(AnsibleHCloud):
             elif self.module.params.get("name") is not None:
                 self.hcloud_firewall = self.client.firewalls.get_by_name(self.module.params.get("name"))
 
-        except HCloudException as e:
-            self.fail_json_hcloud(e)
+        except HCloudException as exception:
+            self.fail_json_hcloud(exception)
 
     def _create_firewall(self):
         self.module.fail_on_missing_params(required_params=["name"])
@@ -231,8 +231,8 @@ class AnsibleHCloudFirewall(AnsibleHCloud):
         if not self.module.check_mode:
             try:
                 self.client.firewalls.create(**params)
-            except HCloudException as e:
-                self.fail_json_hcloud(e, params=params)
+            except HCloudException as exception:
+                self.fail_json_hcloud(exception, params=params)
         self._mark_as_changed()
         self._get_firewall()
 
@@ -284,14 +284,14 @@ class AnsibleHCloudFirewall(AnsibleHCloud):
                     try:
                         self.client.firewalls.delete(self.hcloud_firewall)
                         break
-                    except APIException as e:
-                        if "is still in use" in e.message:
+                    except APIException as exception:
+                        if "is still in use" in exception.message:
                             retry_count = retry_count + 1
                             time.sleep(0.5 * retry_count)
                         else:
-                            self.fail_json_hcloud(e)
-                    except HCloudException as e:
-                        self.fail_json_hcloud(e)
+                            self.fail_json_hcloud(exception)
+                    except HCloudException as exception:
+                        self.fail_json_hcloud(exception)
             self._mark_as_changed()
         self.hcloud_firewall = None
 

--- a/plugins/modules/hcloud_floating_ip.py
+++ b/plugins/modules/hcloud_floating_ip.py
@@ -196,8 +196,8 @@ class AnsibleHCloudFloatingIP(AnsibleHCloud):
                 self.hcloud_floating_ip = self.client.floating_ips.get_by_id(self.module.params.get("id"))
             else:
                 self.hcloud_floating_ip = self.client.floating_ips.get_by_name(self.module.params.get("name"))
-        except HCloudException as e:
-            self.fail_json_hcloud(e)
+        except HCloudException as exception:
+            self.fail_json_hcloud(exception)
 
     def _create_floating_ip(self):
         self.module.fail_on_missing_params(required_params=["type"])
@@ -223,8 +223,8 @@ class AnsibleHCloudFloatingIP(AnsibleHCloud):
                 delete_protection = self.module.params.get("delete_protection")
                 if delete_protection is not None:
                     self.hcloud_floating_ip.change_protection(delete=delete_protection).wait_until_finished()
-        except HCloudException as e:
-            self.fail_json_hcloud(e)
+        except HCloudException as exception:
+            self.fail_json_hcloud(exception)
         self._mark_as_changed()
         self._get_floating_ip()
 
@@ -271,8 +271,8 @@ class AnsibleHCloudFloatingIP(AnsibleHCloud):
                 self._mark_as_changed()
 
             self._get_floating_ip()
-        except HCloudException as e:
-            self.fail_json_hcloud(e)
+        except HCloudException as exception:
+            self.fail_json_hcloud(exception)
 
     def present_floating_ip(self):
         self._get_floating_ip()
@@ -296,8 +296,8 @@ class AnsibleHCloudFloatingIP(AnsibleHCloud):
                     )
                 self._mark_as_changed()
             self.hcloud_floating_ip = None
-        except HCloudException as e:
-            self.fail_json_hcloud(e)
+        except HCloudException as exception:
+            self.fail_json_hcloud(exception)
 
     @classmethod
     def define_module(cls):

--- a/plugins/modules/hcloud_floating_ip_info.py
+++ b/plugins/modules/hcloud_floating_ip_info.py
@@ -146,8 +146,8 @@ class AnsibleHCloudFloatingIPInfo(AnsibleHCloud):
             else:
                 self.hcloud_floating_ip_info = self.client.floating_ips.get_all()
 
-        except HCloudException as e:
-            self.fail_json_hcloud(e)
+        except HCloudException as exception:
+            self.fail_json_hcloud(exception)
 
     @classmethod
     def define_module(cls):

--- a/plugins/modules/hcloud_image_info.py
+++ b/plugins/modules/hcloud_image_info.py
@@ -173,8 +173,8 @@ class AnsibleHCloudImageInfo(AnsibleHCloud):
 
                 self.hcloud_image_info = self.client.images.get_all(**params)
 
-        except HCloudException as e:
-            self.fail_json_hcloud(e)
+        except HCloudException as exception:
+            self.fail_json_hcloud(exception)
 
     @classmethod
     def define_module(cls):

--- a/plugins/modules/hcloud_iso_info.py
+++ b/plugins/modules/hcloud_iso_info.py
@@ -139,8 +139,8 @@ class AnsibleHCloudIsoInfo(AnsibleHCloud):
                     include_wildcard_architecture=self.module.params.get("include_wildcard_architecture"),
                 )
 
-        except Exception as e:
-            self.module.fail_json(msg=e.message)
+        except Exception as exception:
+            self.module.fail_json(msg=exception.message)
 
     @classmethod
     def define_module(cls):

--- a/plugins/modules/hcloud_load_balancer.py
+++ b/plugins/modules/hcloud_load_balancer.py
@@ -178,8 +178,8 @@ class AnsibleHCloudLoadBalancer(AnsibleHCloud):
                 self.hcloud_load_balancer = self.client.load_balancers.get_by_id(self.module.params.get("id"))
             else:
                 self.hcloud_load_balancer = self.client.load_balancers.get_by_name(self.module.params.get("name"))
-        except HCloudException as e:
-            self.fail_json_hcloud(e)
+        except HCloudException as exception:
+            self.fail_json_hcloud(exception)
 
     def _create_load_balancer(self):
         self.module.fail_on_missing_params(required_params=["name", "load_balancer_type"])
@@ -207,8 +207,8 @@ class AnsibleHCloudLoadBalancer(AnsibleHCloud):
                 if delete_protection is not None:
                     self._get_load_balancer()
                     self.hcloud_load_balancer.change_protection(delete=delete_protection).wait_until_finished()
-        except HCloudException as e:
-            self.fail_json_hcloud(e)
+        except HCloudException as exception:
+            self.fail_json_hcloud(exception)
         self._mark_as_changed()
         self._get_load_balancer()
 
@@ -253,8 +253,8 @@ class AnsibleHCloudLoadBalancer(AnsibleHCloud):
 
                 self._mark_as_changed()
             self._get_load_balancer()
-        except HCloudException as e:
-            self.fail_json_hcloud(e)
+        except HCloudException as exception:
+            self.fail_json_hcloud(exception)
 
     def present_load_balancer(self):
         self._get_load_balancer()
@@ -271,8 +271,8 @@ class AnsibleHCloudLoadBalancer(AnsibleHCloud):
                     self.client.load_balancers.delete(self.hcloud_load_balancer)
                 self._mark_as_changed()
             self.hcloud_load_balancer = None
-        except HCloudException as e:
-            self.fail_json_hcloud(e)
+        except HCloudException as exception:
+            self.fail_json_hcloud(exception)
 
     @classmethod
     def define_module(cls):

--- a/plugins/modules/hcloud_load_balancer_info.py
+++ b/plugins/modules/hcloud_load_balancer_info.py
@@ -390,8 +390,8 @@ class AnsibleHCloudLoadBalancerInfo(AnsibleHCloud):
 
                 self.hcloud_load_balancer_info = self.client.load_balancers.get_all(**params)
 
-        except HCloudException as e:
-            self.fail_json_hcloud(e)
+        except HCloudException as exception:
+            self.fail_json_hcloud(exception)
 
     @classmethod
     def define_module(cls):

--- a/plugins/modules/hcloud_load_balancer_network.py
+++ b/plugins/modules/hcloud_load_balancer_network.py
@@ -125,8 +125,8 @@ class AnsibleHCloudLoadBalancerNetwork(AnsibleHCloud):
                 self.module.fail_json(msg=f"Load balancer does not exist: {load_balancer_name}")
 
             self.hcloud_load_balancer_network = None
-        except HCloudException as e:
-            self.fail_json_hcloud(e)
+        except HCloudException as exception:
+            self.fail_json_hcloud(exception)
 
     def _get_load_balancer_network(self):
         for privateNet in self.hcloud_load_balancer.private_net:
@@ -142,8 +142,8 @@ class AnsibleHCloudLoadBalancerNetwork(AnsibleHCloud):
         if not self.module.check_mode:
             try:
                 self.hcloud_load_balancer.attach_to_network(**params).wait_until_finished()
-            except HCloudException as e:
-                self.fail_json_hcloud(e)
+            except HCloudException as exception:
+                self.fail_json_hcloud(exception)
 
         self._mark_as_changed()
         self._get_load_balancer_and_network()
@@ -165,8 +165,8 @@ class AnsibleHCloudLoadBalancerNetwork(AnsibleHCloud):
                         self.hcloud_load_balancer_network.network
                     ).wait_until_finished()
                     self._mark_as_changed()
-                except HCloudException as e:
-                    self.fail_json_hcloud(e)
+                except HCloudException as exception:
+                    self.fail_json_hcloud(exception)
 
         self.hcloud_load_balancer_network = None
 

--- a/plugins/modules/hcloud_load_balancer_network.py
+++ b/plugins/modules/hcloud_load_balancer_network.py
@@ -129,9 +129,9 @@ class AnsibleHCloudLoadBalancerNetwork(AnsibleHCloud):
             self.fail_json_hcloud(exception)
 
     def _get_load_balancer_network(self):
-        for privateNet in self.hcloud_load_balancer.private_net:
-            if privateNet.network.id == self.hcloud_network.id:
-                self.hcloud_load_balancer_network = privateNet
+        for private_net in self.hcloud_load_balancer.private_net:
+            if private_net.network.id == self.hcloud_network.id:
+                self.hcloud_load_balancer_network = private_net
 
     def _create_load_balancer_network(self):
         params = {"network": self.hcloud_network}

--- a/plugins/modules/hcloud_load_balancer_service.py
+++ b/plugins/modules/hcloud_load_balancer_service.py
@@ -346,8 +346,8 @@ class AnsibleHCloudLoadBalancerService(AnsibleHCloud):
                 self.module.fail_json(msg=f"Load balancer does not exist: {load_balancer_name}")
 
             self._get_load_balancer_service()
-        except HCloudException as e:
-            self.fail_json_hcloud(e)
+        except HCloudException as exception:
+            self.fail_json_hcloud(exception)
 
     def _create_load_balancer_service(self):
         self.module.fail_on_missing_params(required_params=["protocol"])
@@ -376,8 +376,8 @@ class AnsibleHCloudLoadBalancerService(AnsibleHCloud):
                 self.hcloud_load_balancer.add_service(LoadBalancerService(**params)).wait_until_finished(
                     max_retries=1000
                 )
-            except HCloudException as e:
-                self.fail_json_hcloud(e)
+            except HCloudException as exception:
+                self.fail_json_hcloud(exception)
         self._mark_as_changed()
         self._get_load_balancer()
         self._get_load_balancer_service()
@@ -402,8 +402,8 @@ class AnsibleHCloudLoadBalancerService(AnsibleHCloud):
                             hcloud_cert = self.client.certificates.get_by_name(certificate)
                         except Exception:
                             hcloud_cert = self.client.certificates.get_by_id(certificate)
-                    except HCloudException as e:
-                        self.fail_json_hcloud(e)
+                    except HCloudException as exception:
+                        self.fail_json_hcloud(exception)
                     service_http.certificates.append(hcloud_cert)
 
         return service_http
@@ -472,8 +472,8 @@ class AnsibleHCloudLoadBalancerService(AnsibleHCloud):
                 self.hcloud_load_balancer.update_service(LoadBalancerService(**params)).wait_until_finished(
                     max_retries=1000
                 )
-        except HCloudException as e:
-            self.fail_json_hcloud(e)
+        except HCloudException as exception:
+            self.fail_json_hcloud(exception)
         self._get_load_balancer()
 
         if changed:
@@ -500,12 +500,12 @@ class AnsibleHCloudLoadBalancerService(AnsibleHCloud):
                         self.hcloud_load_balancer.delete_service(self.hcloud_load_balancer_service).wait_until_finished(
                             max_retries=1000
                         )
-                    except HCloudException as e:
-                        self.fail_json_hcloud(e)
+                    except HCloudException as exception:
+                        self.fail_json_hcloud(exception)
                 self._mark_as_changed()
             self.hcloud_load_balancer_service = None
-        except APIException as e:
-            self.fail_json_hcloud(e)
+        except APIException as exception:
+            self.fail_json_hcloud(exception)
 
     @classmethod
     def define_module(cls):

--- a/plugins/modules/hcloud_load_balancer_target.py
+++ b/plugins/modules/hcloud_load_balancer_target.py
@@ -183,8 +183,8 @@ class AnsibleHCloudLoadBalancerTarget(AnsibleHCloud):
                     self.module.fail_json(msg=f"Server not found: {server_name}")
 
             self.hcloud_load_balancer_target = None
-        except HCloudException as e:
-            self.fail_json_hcloud(e)
+        except HCloudException as exception:
+            self.fail_json_hcloud(exception)
 
     def _get_load_balancer_target(self):
         for target in self.hcloud_load_balancer.targets:
@@ -226,13 +226,13 @@ class AnsibleHCloudLoadBalancerTarget(AnsibleHCloud):
         if not self.module.check_mode:
             try:
                 self.hcloud_load_balancer.add_target(**params).wait_until_finished()
-            except APIException as e:
-                if e.code == "locked" or e.code == "conflict":
+            except APIException as exception:
+                if exception.code == "locked" or exception.code == "conflict":
                     self._create_load_balancer_target()
                 else:
-                    self.fail_json_hcloud(e)
-            except HCloudException as e:
-                self.fail_json_hcloud(e)
+                    self.fail_json_hcloud(exception)
+            except HCloudException as exception:
+                self.fail_json_hcloud(exception)
 
         self._mark_as_changed()
         self._get_load_balancer_and_target()
@@ -271,8 +271,8 @@ class AnsibleHCloudLoadBalancerTarget(AnsibleHCloud):
                     )
                 try:
                     self.hcloud_load_balancer.remove_target(target).wait_until_finished()
-                except HCloudException as e:
-                    self.fail_json_hcloud(e)
+                except HCloudException as exception:
+                    self.fail_json_hcloud(exception)
             self._mark_as_changed()
         self.hcloud_load_balancer_target = None
 

--- a/plugins/modules/hcloud_load_balancer_type_info.py
+++ b/plugins/modules/hcloud_load_balancer_type_info.py
@@ -128,8 +128,8 @@ class AnsibleHCloudLoadBalancerTypeInfo(AnsibleHCloud):
             else:
                 self.hcloud_load_balancer_type_info = self.client.load_balancer_types.get_all()
 
-        except HCloudException as e:
-            self.fail_json_hcloud(e)
+        except HCloudException as exception:
+            self.fail_json_hcloud(exception)
 
     @classmethod
     def define_module(cls):

--- a/plugins/modules/hcloud_location_info.py
+++ b/plugins/modules/hcloud_location_info.py
@@ -112,8 +112,8 @@ class AnsibleHCloudLocationInfo(AnsibleHCloud):
             else:
                 self.hcloud_location_info = self.client.locations.get_all()
 
-        except HCloudException as e:
-            self.fail_json_hcloud(e)
+        except HCloudException as exception:
+            self.fail_json_hcloud(exception)
 
     @classmethod
     def define_module(cls):

--- a/plugins/modules/hcloud_network.py
+++ b/plugins/modules/hcloud_network.py
@@ -144,8 +144,8 @@ class AnsibleHCloudNetwork(AnsibleHCloud):
                 self.hcloud_network = self.client.networks.get_by_id(self.module.params.get("id"))
             else:
                 self.hcloud_network = self.client.networks.get_by_name(self.module.params.get("name"))
-        except HCloudException as e:
-            self.fail_json_hcloud(e)
+        except HCloudException as exception:
+            self.fail_json_hcloud(exception)
 
     def _create_network(self):
         self.module.fail_on_missing_params(required_params=["name", "ip_range"])
@@ -167,8 +167,8 @@ class AnsibleHCloudNetwork(AnsibleHCloud):
                 if delete_protection is not None:
                     self._get_network()
                     self.hcloud_network.change_protection(delete=delete_protection).wait_until_finished()
-        except HCloudException as e:
-            self.fail_json_hcloud(e)
+        except HCloudException as exception:
+            self.fail_json_hcloud(exception)
         self._mark_as_changed()
         self._get_network()
 
@@ -200,8 +200,8 @@ class AnsibleHCloudNetwork(AnsibleHCloud):
                 if not self.module.check_mode:
                     self.hcloud_network.change_protection(delete=delete_protection).wait_until_finished()
                 self._mark_as_changed()
-        except HCloudException as e:
-            self.fail_json_hcloud(e)
+        except HCloudException as exception:
+            self.fail_json_hcloud(exception)
         self._get_network()
 
     def present_network(self):
@@ -218,8 +218,8 @@ class AnsibleHCloudNetwork(AnsibleHCloud):
                 if not self.module.check_mode:
                     self.client.networks.delete(self.hcloud_network)
                 self._mark_as_changed()
-        except HCloudException as e:
-            self.fail_json_hcloud(e)
+        except HCloudException as exception:
+            self.fail_json_hcloud(exception)
         self.hcloud_network = None
 
     @classmethod

--- a/plugins/modules/hcloud_network_info.py
+++ b/plugins/modules/hcloud_network_info.py
@@ -262,8 +262,8 @@ class AnsibleHCloudNetworkInfo(AnsibleHCloud):
             else:
                 self.hcloud_network_info = self.client.networks.get_all()
 
-        except HCloudException as e:
-            self.fail_json_hcloud(e)
+        except HCloudException as exception:
+            self.fail_json_hcloud(exception)
 
     @classmethod
     def define_module(cls):

--- a/plugins/modules/hcloud_placement_group.py
+++ b/plugins/modules/hcloud_placement_group.py
@@ -134,8 +134,8 @@ class AnsibleHCloudPlacementGroup(AnsibleHCloud):
                 self.hcloud_placement_group = self.client.placement_groups.get_by_id(self.module.params.get("id"))
             elif self.module.params.get("name") is not None:
                 self.hcloud_placement_group = self.client.placement_groups.get_by_name(self.module.params.get("name"))
-        except HCloudException as e:
-            self.fail_json_hcloud(e)
+        except HCloudException as exception:
+            self.fail_json_hcloud(exception)
 
     def _create_placement_group(self):
         self.module.fail_on_missing_params(required_params=["name"])
@@ -147,8 +147,8 @@ class AnsibleHCloudPlacementGroup(AnsibleHCloud):
         if not self.module.check_mode:
             try:
                 self.client.placement_groups.create(**params)
-            except HCloudException as e:
-                self.fail_json_hcloud(e, params=params)
+            except HCloudException as exception:
+                self.fail_json_hcloud(exception, params=params)
         self._mark_as_changed()
         self._get_placement_group()
 

--- a/plugins/modules/hcloud_primary_ip.py
+++ b/plugins/modules/hcloud_primary_ip.py
@@ -160,8 +160,8 @@ class AnsibleHCloudPrimaryIP(AnsibleHCloud):
                 self.hcloud_primary_ip = self.client.primary_ips.get_by_id(self.module.params.get("id"))
             else:
                 self.hcloud_primary_ip = self.client.primary_ips.get_by_name(self.module.params.get("name"))
-        except HCloudException as e:
-            self.fail_json_hcloud(e)
+        except HCloudException as exception:
+            self.fail_json_hcloud(exception)
 
     def _create_primary_ip(self):
         self.module.fail_on_missing_params(required_params=["type", "datacenter"])
@@ -181,8 +181,8 @@ class AnsibleHCloudPrimaryIP(AnsibleHCloud):
                 delete_protection = self.module.params.get("delete_protection")
                 if delete_protection is not None:
                     self.hcloud_primary_ip.change_protection(delete=delete_protection).wait_until_finished()
-        except HCloudException as e:
-            self.fail_json_hcloud(e)
+        except HCloudException as exception:
+            self.fail_json_hcloud(exception)
         self._mark_as_changed()
         self._get_primary_ip()
 
@@ -201,8 +201,8 @@ class AnsibleHCloudPrimaryIP(AnsibleHCloud):
                 self._mark_as_changed()
 
             self._get_primary_ip()
-        except HCloudException as e:
-            self.fail_json_hcloud(e)
+        except HCloudException as exception:
+            self.fail_json_hcloud(exception)
 
     def present_primary_ip(self):
         self._get_primary_ip()
@@ -219,8 +219,8 @@ class AnsibleHCloudPrimaryIP(AnsibleHCloud):
                     self.client.primary_ips.delete(self.hcloud_primary_ip)
                 self._mark_as_changed()
             self.hcloud_primary_ip = None
-        except HCloudException as e:
-            self.fail_json_hcloud(e)
+        except HCloudException as exception:
+            self.fail_json_hcloud(exception)
 
     @classmethod
     def define_module(cls):

--- a/plugins/modules/hcloud_primary_ip_info.py
+++ b/plugins/modules/hcloud_primary_ip_info.py
@@ -170,8 +170,8 @@ class AnsibleHCloudPrimaryIPInfo(AnsibleHCloud):
             else:
                 self.hcloud_primary_ip_info = self.client.primary_ips.get_all()
 
-        except HCloudException as e:
-            self.fail_json_hcloud(e)
+        except HCloudException as exception:
+            self.fail_json_hcloud(exception)
 
     @classmethod
     def define_module(cls):

--- a/plugins/modules/hcloud_rdns.py
+++ b/plugins/modules/hcloud_rdns.py
@@ -187,8 +187,8 @@ class AnsibleHCloudReverseDNS(AnsibleHCloud):
                 self.hcloud_resource = self.client.load_balancers.get_by_name(self.module.params.get("load_balancer"))
                 if self.hcloud_resource is None:
                     self.module.fail_json(msg="The selected Load Balancer does not exist")
-        except HCloudException as e:
-            self.fail_json_hcloud(e)
+        except HCloudException as exception:
+            self.fail_json_hcloud(exception)
 
     def _get_rdns(self):
         ip_address = self.module.params.get("ip_address")
@@ -268,8 +268,8 @@ class AnsibleHCloudReverseDNS(AnsibleHCloud):
         if not self.module.check_mode:
             try:
                 self.hcloud_resource.change_dns_ptr(**params).wait_until_finished()
-            except HCloudException as e:
-                self.fail_json_hcloud(e)
+            except HCloudException as exception:
+                self.fail_json_hcloud(exception)
         self._mark_as_changed()
         self._get_resource()
         self._get_rdns()
@@ -285,8 +285,8 @@ class AnsibleHCloudReverseDNS(AnsibleHCloud):
             if not self.module.check_mode:
                 try:
                     self.hcloud_resource.change_dns_ptr(**params).wait_until_finished()
-                except HCloudException as e:
-                    self.fail_json_hcloud(e)
+                except HCloudException as exception:
+                    self.fail_json_hcloud(exception)
             self._mark_as_changed()
             self._get_resource()
             self._get_rdns()
@@ -306,8 +306,8 @@ class AnsibleHCloudReverseDNS(AnsibleHCloud):
             if not self.module.check_mode:
                 try:
                     self.hcloud_resource.change_dns_ptr(ip=self.hcloud_rdns["ip_address"], dns_ptr=None)
-                except HCloudException as e:
-                    self.fail_json_hcloud(e)
+                except HCloudException as exception:
+                    self.fail_json_hcloud(exception)
             self._mark_as_changed()
         self.hcloud_rdns = None
 

--- a/plugins/modules/hcloud_route.py
+++ b/plugins/modules/hcloud_route.py
@@ -112,8 +112,8 @@ class AnsibleHCloudRoute(AnsibleHCloud):
         try:
             self.hcloud_network = self.client.networks.get_by_name(self.module.params.get("network"))
             self.hcloud_route = None
-        except HCloudException as e:
-            self.fail_json_hcloud(e)
+        except HCloudException as exception:
+            self.fail_json_hcloud(exception)
 
     def _get_route(self):
         destination = self.module.params.get("destination")
@@ -130,8 +130,8 @@ class AnsibleHCloudRoute(AnsibleHCloud):
         if not self.module.check_mode:
             try:
                 self.hcloud_network.add_route(route=route).wait_until_finished()
-            except HCloudException as e:
-                self.fail_json_hcloud(e)
+            except HCloudException as exception:
+                self.fail_json_hcloud(exception)
 
         self._mark_as_changed()
         self._get_network()
@@ -150,8 +150,8 @@ class AnsibleHCloudRoute(AnsibleHCloud):
             if not self.module.check_mode:
                 try:
                     self.hcloud_network.delete_route(self.hcloud_route).wait_until_finished()
-                except HCloudException as e:
-                    self.fail_json_hcloud(e)
+                except HCloudException as exception:
+                    self.fail_json_hcloud(exception)
             self._mark_as_changed()
         self.hcloud_route = None
 

--- a/plugins/modules/hcloud_server.py
+++ b/plugins/modules/hcloud_server.py
@@ -411,16 +411,16 @@ class AnsibleHCloudServer(AnsibleHCloud):
         }
 
         if self.module.params.get("ipv4") is not None:
-            p = self.client.primary_ips.get_by_name(self.module.params.get("ipv4"))
-            if not p:
-                p = self.client.primary_ips.get_by_id(self.module.params.get("ipv4"))
-            params["public_net"].ipv4 = p
+            primary_ip = self.client.primary_ips.get_by_name(self.module.params.get("ipv4"))
+            if not primary_ip:
+                primary_ip = self.client.primary_ips.get_by_id(self.module.params.get("ipv4"))
+            params["public_net"].ipv4 = primary_ip
 
         if self.module.params.get("ipv6") is not None:
-            p = self.client.primary_ips.get_by_name(self.module.params.get("ipv6"))
-            if not p:
-                p = self.client.primary_ips.get_by_id(self.module.params.get("ipv6"))
-            params["public_net"].ipv6 = p
+            primary_ip = self.client.primary_ips.get_by_name(self.module.params.get("ipv6"))
+            if not primary_ip:
+                primary_ip = self.client.primary_ips.get_by_id(self.module.params.get("ipv6"))
+            params["public_net"].ipv6 = primary_ip
 
         if self.module.params.get("private_networks") is not None:
             _networks = []

--- a/plugins/modules/hcloud_server.py
+++ b/plugins/modules/hcloud_server.py
@@ -389,8 +389,8 @@ class AnsibleHCloudServer(AnsibleHCloud):
                 self.hcloud_server = self.client.servers.get_by_id(self.module.params.get("id"))
             else:
                 self.hcloud_server = self.client.servers.get_by_name(self.module.params.get("name"))
-        except HCloudException as e:
-            self.fail_json_hcloud(e)
+        except HCloudException as exception:
+            self.fail_json_hcloud(exception)
 
     def _create_server(self):
         self.module.fail_on_missing_params(required_params=["name", "server_type", "image"])
@@ -482,8 +482,8 @@ class AnsibleHCloudServer(AnsibleHCloud):
                         delete=delete_protection,
                         rebuild=rebuild_protection,
                     ).wait_until_finished()
-            except HCloudException as e:
-                self.fail_json_hcloud(e)
+            except HCloudException as exception:
+                self.fail_json_hcloud(exception)
         self._mark_as_changed()
         self._get_server()
 
@@ -501,8 +501,8 @@ class AnsibleHCloudServer(AnsibleHCloud):
         else:
             try:
                 image = self.client.images.get_by_id(self.module.params.get("image"))
-            except HCloudException as e:
-                self.fail_json_hcloud(e, msg=f"Image {self.module.params.get('image')} was not found")
+            except HCloudException as exception:
+                self.fail_json_hcloud(exception, msg=f"Image {self.module.params.get('image')} was not found")
         if image.deprecated is not None:
             available_until = image.deprecated + timedelta(days=90)
             if self.module.params.get("allow_deprecated_image"):
@@ -525,9 +525,9 @@ class AnsibleHCloudServer(AnsibleHCloud):
         if server_type is None:
             try:
                 server_type = self.client.server_types.get_by_id(self.module.params.get("server_type"))
-            except HCloudException as e:
+            except HCloudException as exception:
                 self.fail_json_hcloud(
-                    e,
+                    exception,
                     msg=f"server_type {self.module.params.get('server_type')} was not found",
                 )
 
@@ -566,9 +566,9 @@ class AnsibleHCloudServer(AnsibleHCloud):
         if placement_group is None:
             try:
                 placement_group = self.client.placement_groups.get_by_id(self.module.params.get("placement_group"))
-            except HCloudException as e:
+            except HCloudException as exception:
                 self.fail_json_hcloud(
-                    e,
+                    exception,
                     msg=f"placement_group {self.module.params.get('placement_group')} was not found",
                 )
 
@@ -582,8 +582,8 @@ class AnsibleHCloudServer(AnsibleHCloud):
         if primary_ip is None:
             try:
                 primary_ip = self.client.primary_ips.get_by_id(self.module.params.get(field))
-            except HCloudException as e:
-                self.fail_json_hcloud(e, msg=f"primary_ip {self.module.params.get(field)} was not found")
+            except HCloudException as exception:
+                self.fail_json_hcloud(exception, msg=f"primary_ip {self.module.params.get(field)} was not found")
 
         return primary_ip
 
@@ -777,8 +777,8 @@ class AnsibleHCloudServer(AnsibleHCloud):
                     ).wait_until_finished()
                 self._mark_as_changed()
             self._get_server()
-        except HCloudException as e:
-            self.fail_json_hcloud(e)
+        except HCloudException as exception:
+            self.fail_json_hcloud(exception)
 
     def _set_rescue_mode(self, rescue_mode):
         if self.module.params.get("ssh_keys"):
@@ -802,8 +802,8 @@ class AnsibleHCloudServer(AnsibleHCloud):
                         self.client.servers.power_on(self.hcloud_server).wait_until_finished()
                     self._mark_as_changed()
                 self._get_server()
-        except HCloudException as e:
-            self.fail_json_hcloud(e)
+        except HCloudException as exception:
+            self.fail_json_hcloud(exception)
 
     def stop_server(self):
         try:
@@ -813,8 +813,8 @@ class AnsibleHCloudServer(AnsibleHCloud):
                         self.client.servers.power_off(self.hcloud_server).wait_until_finished()
                     self._mark_as_changed()
                 self._get_server()
-        except HCloudException as e:
-            self.fail_json_hcloud(e)
+        except HCloudException as exception:
+            self.fail_json_hcloud(exception)
 
     def stop_server_if_forced(self):
         previous_server_status = self.hcloud_server.status
@@ -844,8 +844,8 @@ class AnsibleHCloudServer(AnsibleHCloud):
             self._mark_as_changed()
 
             self._get_server()
-        except HCloudException as e:
-            self.fail_json_hcloud(e)
+        except HCloudException as exception:
+            self.fail_json_hcloud(exception)
 
     def present_server(self):
         self._get_server()
@@ -862,8 +862,8 @@ class AnsibleHCloudServer(AnsibleHCloud):
                     self.client.servers.delete(self.hcloud_server).wait_until_finished()
                 self._mark_as_changed()
             self.hcloud_server = None
-        except HCloudException as e:
-            self.fail_json_hcloud(e)
+        except HCloudException as exception:
+            self.fail_json_hcloud(exception)
 
     @classmethod
     def define_module(cls):

--- a/plugins/modules/hcloud_server_info.py
+++ b/plugins/modules/hcloud_server_info.py
@@ -198,8 +198,8 @@ class AnsibleHCloudServerInfo(AnsibleHCloud):
             else:
                 self.hcloud_server_info = self.client.servers.get_all()
 
-        except HCloudException as e:
-            self.fail_json_hcloud(e)
+        except HCloudException as exception:
+            self.fail_json_hcloud(exception)
 
     @classmethod
     def define_module(cls):

--- a/plugins/modules/hcloud_server_network.py
+++ b/plugins/modules/hcloud_server_network.py
@@ -139,8 +139,8 @@ class AnsibleHCloudServerNetwork(AnsibleHCloud):
             self.hcloud_network = self.client.networks.get_by_name(self.module.params.get("network"))
             self.hcloud_server = self.client.servers.get_by_name(self.module.params.get("server"))
             self.hcloud_server_network = None
-        except HCloudException as e:
-            self.fail_json_hcloud(e)
+        except HCloudException as exception:
+            self.fail_json_hcloud(exception)
 
     def _get_server_network(self):
         for privateNet in self.hcloud_server.private_net:
@@ -160,8 +160,8 @@ class AnsibleHCloudServerNetwork(AnsibleHCloud):
         if not self.module.check_mode:
             try:
                 self.hcloud_server.attach_to_network(**params).wait_until_finished()
-            except HCloudException as e:
-                self.fail_json_hcloud(e)
+            except HCloudException as exception:
+                self.fail_json_hcloud(exception)
 
         self._mark_as_changed()
         self._get_server_and_network()
@@ -178,8 +178,8 @@ class AnsibleHCloudServerNetwork(AnsibleHCloud):
             if not self.module.check_mode:
                 try:
                     self.hcloud_server.change_alias_ips(**params).wait_until_finished()
-                except APIException as e:
-                    self.fail_json_hcloud(e)
+                except APIException as exception:
+                    self.fail_json_hcloud(exception)
 
             self._mark_as_changed()
         self._get_server_and_network()
@@ -200,8 +200,8 @@ class AnsibleHCloudServerNetwork(AnsibleHCloud):
             if not self.module.check_mode:
                 try:
                     self.hcloud_server.detach_from_network(self.hcloud_server_network.network).wait_until_finished()
-                except HCloudException as e:
-                    self.fail_json_hcloud(e)
+                except HCloudException as exception:
+                    self.fail_json_hcloud(exception)
             self._mark_as_changed()
         self.hcloud_server_network = None
 

--- a/plugins/modules/hcloud_server_network.py
+++ b/plugins/modules/hcloud_server_network.py
@@ -143,9 +143,9 @@ class AnsibleHCloudServerNetwork(AnsibleHCloud):
             self.fail_json_hcloud(exception)
 
     def _get_server_network(self):
-        for privateNet in self.hcloud_server.private_net:
-            if privateNet.network.id == self.hcloud_network.id:
-                self.hcloud_server_network = privateNet
+        for private_net in self.hcloud_server.private_net:
+            if private_net.network.id == self.hcloud_network.id:
+                self.hcloud_server_network = private_net
 
     def _create_server_network(self):
         params = {

--- a/plugins/modules/hcloud_server_type_info.py
+++ b/plugins/modules/hcloud_server_type_info.py
@@ -169,8 +169,8 @@ class AnsibleHCloudServerTypeInfo(AnsibleHCloud):
             else:
                 self.hcloud_server_type_info = self.client.server_types.get_all()
 
-        except HCloudException as e:
-            self.fail_json_hcloud(e)
+        except HCloudException as exception:
+            self.fail_json_hcloud(exception)
 
     @classmethod
     def define_module(cls):

--- a/plugins/modules/hcloud_ssh_key.py
+++ b/plugins/modules/hcloud_ssh_key.py
@@ -140,8 +140,8 @@ class AnsibleHCloudSSHKey(AnsibleHCloud):
             elif self.module.params.get("name") is not None:
                 self.hcloud_ssh_key = self.client.ssh_keys.get_by_name(self.module.params.get("name"))
 
-        except HCloudException as e:
-            self.fail_json_hcloud(e)
+        except HCloudException as exception:
+            self.fail_json_hcloud(exception)
 
     def _create_ssh_key(self):
         self.module.fail_on_missing_params(required_params=["name", "public_key"])
@@ -154,8 +154,8 @@ class AnsibleHCloudSSHKey(AnsibleHCloud):
         if not self.module.check_mode:
             try:
                 self.client.ssh_keys.create(**params)
-            except HCloudException as e:
-                self.fail_json_hcloud(e)
+            except HCloudException as exception:
+                self.fail_json_hcloud(exception)
         self._mark_as_changed()
         self._get_ssh_key()
 
@@ -188,8 +188,8 @@ class AnsibleHCloudSSHKey(AnsibleHCloud):
             if not self.module.check_mode:
                 try:
                     self.client.ssh_keys.delete(self.hcloud_ssh_key)
-                except HCloudException as e:
-                    self.fail_json_hcloud(e)
+                except HCloudException as exception:
+                    self.fail_json_hcloud(exception)
             self._mark_as_changed()
         self.hcloud_ssh_key = None
 

--- a/plugins/modules/hcloud_ssh_key_info.py
+++ b/plugins/modules/hcloud_ssh_key_info.py
@@ -120,8 +120,8 @@ class AnsibleHCloudSSHKeyInfo(AnsibleHCloud):
             else:
                 self.hcloud_ssh_key_info = self.client.ssh_keys.get_all()
 
-        except HCloudException as e:
-            self.fail_json_hcloud(e)
+        except HCloudException as exception:
+            self.fail_json_hcloud(exception)
 
     @classmethod
     def define_module(cls):

--- a/plugins/modules/hcloud_subnetwork.py
+++ b/plugins/modules/hcloud_subnetwork.py
@@ -152,8 +152,8 @@ class AnsibleHCloudSubnetwork(AnsibleHCloud):
         try:
             self.hcloud_network = self.client.networks.get_by_name(self.module.params.get("network"))
             self.hcloud_subnetwork = None
-        except HCloudException as e:
-            self.fail_json_hcloud(e)
+        except HCloudException as exception:
+            self.fail_json_hcloud(exception)
 
     def _get_subnetwork(self):
         subnet_ip_range = self.module.params.get("ip_range")
@@ -174,8 +174,8 @@ class AnsibleHCloudSubnetwork(AnsibleHCloud):
         if not self.module.check_mode:
             try:
                 self.hcloud_network.add_subnet(subnet=NetworkSubnet(**params)).wait_until_finished()
-            except HCloudException as e:
-                self.fail_json_hcloud(e)
+            except HCloudException as exception:
+                self.fail_json_hcloud(exception)
 
         self._mark_as_changed()
         self._get_network()
@@ -194,8 +194,8 @@ class AnsibleHCloudSubnetwork(AnsibleHCloud):
             if not self.module.check_mode:
                 try:
                     self.hcloud_network.delete_subnet(self.hcloud_subnetwork).wait_until_finished()
-                except HCloudException as e:
-                    self.fail_json_hcloud(e)
+                except HCloudException as exception:
+                    self.fail_json_hcloud(exception)
             self._mark_as_changed()
         self.hcloud_subnetwork = None
 

--- a/plugins/modules/hcloud_volume.py
+++ b/plugins/modules/hcloud_volume.py
@@ -191,8 +191,8 @@ class AnsibleHCloudVolume(AnsibleHCloud):
                 self.hcloud_volume = self.client.volumes.get_by_id(self.module.params.get("id"))
             else:
                 self.hcloud_volume = self.client.volumes.get_by_name(self.module.params.get("name"))
-        except HCloudException as e:
-            self.fail_json_hcloud(e)
+        except HCloudException as exception:
+            self.fail_json_hcloud(exception)
 
     def _create_volume(self):
         self.module.fail_on_missing_params(required_params=["name", "size"])
@@ -219,8 +219,8 @@ class AnsibleHCloudVolume(AnsibleHCloud):
                 if delete_protection is not None:
                     self._get_volume()
                     self.hcloud_volume.change_protection(delete=delete_protection).wait_until_finished()
-            except HCloudException as e:
-                self.fail_json_hcloud(e)
+            except HCloudException as exception:
+                self.fail_json_hcloud(exception)
         self._mark_as_changed()
         self._get_volume()
 
@@ -262,8 +262,8 @@ class AnsibleHCloudVolume(AnsibleHCloud):
                 self._mark_as_changed()
 
             self._get_volume()
-        except HCloudException as e:
-            self.fail_json_hcloud(e)
+        except HCloudException as exception:
+            self.fail_json_hcloud(exception)
 
     def present_volume(self):
         self._get_volume()
@@ -282,8 +282,8 @@ class AnsibleHCloudVolume(AnsibleHCloud):
                     self.client.volumes.delete(self.hcloud_volume)
                 self._mark_as_changed()
             self.hcloud_volume = None
-        except HCloudException as e:
-            self.fail_json_hcloud(e)
+        except HCloudException as exception:
+            self.fail_json_hcloud(exception)
 
     @classmethod
     def define_module(cls):

--- a/plugins/modules/hcloud_volume_info.py
+++ b/plugins/modules/hcloud_volume_info.py
@@ -140,8 +140,8 @@ class AnsibleHCloudVolumeInfo(AnsibleHCloud):
             else:
                 self.hcloud_volume_info = self.client.volumes.get_all()
 
-        except HCloudException as e:
-            self.fail_json_hcloud(e)
+        except HCloudException as exception:
+            self.fail_json_hcloud(exception)
 
     @classmethod
     def define_module(cls):


### PR DESCRIPTION
##### SUMMARY

Pylint complains about too short/meaningless variable names. We want to be explicit when naming variables. 
