### PR TITLE
ci: explicitly declare pre-commit job

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -15,6 +15,9 @@ variables:
 default:
   image: python:$PYTHON_VERSION
 
+pre-commit:
+  extends: [.pre-commit]
+
 sanity:
   stage: sanity
   allow_failure: true


### PR DESCRIPTION
##### SUMMARY

The pre-commit template does not set the job automatically.
