### PR TITLE
test: setup new temporary project service for integration tests 

### DIFF
--- a/tests/integration/targets/hcloud_certificate/defaults/main/main.yml
+++ b/tests/integration/targets/hcloud_certificate/defaults/main/main.yml
@@ -2,4 +2,4 @@
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 ---
 hcloud_certificate_name: "{{ hcloud_ns }}"
-hcloud_dns_test_domain: "{{ hcloud_ns }}-{{ 100 | random }}.hc-certs.de"
+hcloud_dns_test_domain: "{{ (hcloud_ns + 100 | random | string) | md5 }}.hc-integrations-test.de"

--- a/tests/integration/targets/hcloud_image_info/defaults/main/main.yml
+++ b/tests/integration/targets/hcloud_image_info/defaults/main/main.yml
@@ -1,6 +1,6 @@
 # Copyright: (c) 2019, Hetzner Cloud GmbH <info@hetzner-cloud.de>
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 ---
-hcloud_snapshot_id: 10164049
-hcloud_snapshot_name: always-there-snapshot
+hcloud_server_name: "{{ hcloud_ns }}"
+hcloud_snapshot_name: "{{ hcloud_ns }}"
 hcloud_image_name: ubuntu-22.04

--- a/tests/integration/targets/hcloud_image_info/meta/main.yml
+++ b/tests/integration/targets/hcloud_image_info/meta/main.yml
@@ -1,0 +1,3 @@
+---
+dependencies:
+  - setup_hcloud_cli

--- a/tests/integration/targets/hcloud_image_info/tasks/cleanup.yml
+++ b/tests/integration/targets/hcloud_image_info/tasks/cleanup.yml
@@ -1,0 +1,5 @@
+---
+- name: Cleanup test_server
+  hetzner.hcloud.hcloud_server:
+    name: "{{ hcloud_server_name }}"
+    state: absent

--- a/tests/integration/targets/hcloud_image_info/tasks/prepare.yml
+++ b/tests/integration/targets/hcloud_image_info/tasks/prepare.yml
@@ -1,0 +1,24 @@
+---
+- name: Create test_server
+  hetzner.hcloud.hcloud_server:
+    name: "{{ hcloud_server_name }}"
+    server_type: cx11
+    image: ubuntu-22.04
+    state: stopped
+  register: test_server
+
+- name: Create test_snapshot
+  ansible.builtin.script:
+    cmd: >
+      {{ hcloud_cli_path }} server create-image
+      --type snapshot
+      --description "{{ hcloud_snapshot_name }}"
+      --label key=value
+      "{{ test_server.hcloud_server.id }}"
+      | awk '{print $2}'
+  register: test_snapshot
+  delegate_to: localhost
+
+- name: Set test_snapshot_id
+  ansible.builtin.set_fact:
+    test_snapshot_id: "{{ test_snapshot.stdout_lines[0] }}"

--- a/tests/integration/targets/hcloud_image_info/tasks/prepare.yml
+++ b/tests/integration/targets/hcloud_image_info/tasks/prepare.yml
@@ -17,7 +17,6 @@
       "{{ test_server.hcloud_server.id }}"
       | awk '{print $2}'
   register: test_snapshot
-  delegate_to: localhost
 
 - name: Set test_snapshot_id
   ansible.builtin.set_fact:

--- a/tests/integration/targets/hcloud_image_info/tasks/test.yml
+++ b/tests/integration/targets/hcloud_image_info/tasks/test.yml
@@ -30,7 +30,7 @@
 
 - name: Gather hcloud_image_info with correct id
   hetzner.hcloud.hcloud_image_info:
-    id: "{{ hcloud_snapshot_id }}"
+    id: "{{ test_snapshot_id }}"
     type: snapshot
   register: result
 - name: Verify hcloud_image_info with correct id
@@ -40,7 +40,7 @@
 
 - name: Gather hcloud_image_info with wrong id
   hetzner.hcloud.hcloud_image_info:
-    id: "{{ hcloud_snapshot_id }}4321"
+    id: "{{ test_snapshot_id }}4321"
     type: snapshot
   ignore_errors: true
   register: result

--- a/tests/integration/targets/hcloud_load_balancer_target/defaults/main/main.yml
+++ b/tests/integration/targets/hcloud_load_balancer_target/defaults/main/main.yml
@@ -3,4 +3,5 @@
 ---
 hcloud_server_name: "{{ hcloud_ns }}"
 hcloud_load_balancer_name: "{{ hcloud_ns }}"
-hcloud_testing_ip: "176.9.59.39"
+
+hetzner_server_ip: 142.132.203.104

--- a/tests/integration/targets/hcloud_load_balancer_target/tasks/test.yml
+++ b/tests/integration/targets/hcloud_load_balancer_target/tasks/test.yml
@@ -122,8 +122,8 @@
 - name: test create ip target
   hetzner.hcloud.hcloud_load_balancer_target:
     type: "ip"
-    load_balancer: "{{hcloud_load_balancer_name}}"
-    ip: "{{hcloud_testing_ip}}"
+    load_balancer: "{{ hcloud_load_balancer_name }}"
+    ip: "{{ hetzner_server_ip }}"
     state: present
   register: load_balancer_target
 - name: verify create ip target
@@ -131,7 +131,7 @@
     that:
       - load_balancer_target is changed
       - load_balancer_target.hcloud_load_balancer_target.type == "ip"
-      - load_balancer_target.hcloud_load_balancer_target.ip == hcloud_testing_ip
+      - load_balancer_target.hcloud_load_balancer_target.ip == hetzner_server_ip
       - load_balancer_target.hcloud_load_balancer_target.load_balancer == hcloud_load_balancer_name
 
 - name: cleanup load_balancer

--- a/tests/integration/targets/hcloud_subnetwork/defaults/main/main.yml
+++ b/tests/integration/targets/hcloud_subnetwork/defaults/main/main.yml
@@ -2,4 +2,4 @@
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 ---
 hcloud_network_name: "{{ hcloud_ns }}"
-hetzner_vswitch_id: 15311
+hetzner_vswitch_id: 43065

--- a/tests/integration/targets/setup_hcloud_cli/tasks/main.yml
+++ b/tests/integration/targets/setup_hcloud_cli/tasks/main.yml
@@ -1,0 +1,19 @@
+---
+- name: Install hcloud cli
+  delegate_to: localhost
+  block:
+    - name: Create temporary file for hcloud_cli_path
+      ansible.builtin.tempfile:
+        state: directory
+      register: _tmp_hcloud_cli
+
+    - name: Download hcloud cli from Github releases
+      ansible.builtin.unarchive:
+        src: https://github.com/hetznercloud/cli/releases/download/v1.37.0/hcloud-linux-amd64.tar.gz
+        dest: "{{ _tmp_hcloud_cli.path }}"
+        remote_src: true
+        extra_opts: [hcloud]
+
+    - name: Set hcloud_cli_path
+      ansible.builtin.set_fact:
+        hcloud_cli_path: "{{ _tmp_hcloud_cli.path }}/hcloud"

--- a/tests/integration/targets/setup_hcloud_cli/tasks/main.yml
+++ b/tests/integration/targets/setup_hcloud_cli/tasks/main.yml
@@ -1,19 +1,16 @@
 ---
-- name: Install hcloud cli
-  delegate_to: localhost
-  block:
-    - name: Create temporary file for hcloud_cli_path
-      ansible.builtin.tempfile:
-        state: directory
-      register: _tmp_hcloud_cli
+- name: Create temporary file for hcloud_cli_path
+  ansible.builtin.tempfile:
+    state: directory
+  register: _tmp_hcloud_cli
 
-    - name: Download hcloud cli from Github releases
-      ansible.builtin.unarchive:
-        src: https://github.com/hetznercloud/cli/releases/download/v1.37.0/hcloud-linux-amd64.tar.gz
-        dest: "{{ _tmp_hcloud_cli.path }}"
-        remote_src: true
-        extra_opts: [hcloud]
+- name: Download hcloud cli from Github releases
+  ansible.builtin.unarchive:
+    src: https://github.com/hetznercloud/cli/releases/download/v1.37.0/hcloud-linux-amd64.tar.gz
+    dest: "{{ _tmp_hcloud_cli.path }}"
+    remote_src: true
+    extra_opts: [hcloud]
 
-    - name: Set hcloud_cli_path
-      ansible.builtin.set_fact:
-        hcloud_cli_path: "{{ _tmp_hcloud_cli.path }}/hcloud"
+- name: Set hcloud_cli_path
+  ansible.builtin.set_fact:
+    hcloud_cli_path: "{{ _tmp_hcloud_cli.path }}/hcloud"


### PR DESCRIPTION
##### SUMMARY

Setup new temporary project service for integration tests.

- Use the hc-integrations-test.de domain for certificates creation
- Use new Hetzner account vSwitch
- Use new Hetzner account server IP
- Create snapshots during setup (instead of "always-there-snapshot")
