### PR TITLE
test: setup new temporary project service for integration tests (stable-1)

### DIFF
--- a/tests/integration/targets/hcloud_certificate/defaults/main.yml
+++ b/tests/integration/targets/hcloud_certificate/defaults/main.yml
@@ -3,4 +3,4 @@
 ---
 hcloud_prefix: "tests"
 hcloud_certificate_name: "{{hcloud_prefix}}-integration"
-hcloud_dns_test_domain: "{{hcloud_prefix | truncate(19, False, 'ans')}}-{{100 | random }}.hc-certs.de"
+hcloud_dns_test_domain: "{{ (hcloud_prefix + 100 | random | string) | md5 }}.hc-integrations-test.de"

--- a/tests/integration/targets/hcloud_image_info/defaults/main.yml
+++ b/tests/integration/targets/hcloud_image_info/defaults/main.yml
@@ -2,6 +2,6 @@
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 ---
 hcloud_prefix: "tests"
-hcloud_test_image_name: "always-there-snapshot"
-hcloud_test_image_id: 10164049
+hcloud_server_name: "{{ hcloud_prefix }}"
+hcloud_snapshot_name: "{{ hcloud_prefix }}"
 hcloud_test_image_name_os: "ubuntu-22.04"

--- a/tests/integration/targets/hcloud_image_info/meta/main.yml
+++ b/tests/integration/targets/hcloud_image_info/meta/main.yml
@@ -1,0 +1,3 @@
+---
+dependencies:
+  - setup_hcloud_cli

--- a/tests/integration/targets/hcloud_image_info/tasks/main.yml
+++ b/tests/integration/targets/hcloud_image_info/tasks/main.yml
@@ -1,6 +1,36 @@
 # Copyright: (c) 2019, Hetzner Cloud GmbH <info@hetzner-cloud.de>
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 ---
+
+- name: Cleanup test_server
+  hetzner.hcloud.hcloud_server:
+    name: "{{ hcloud_server_name }}"
+    state: absent
+
+
+- name: Create test_server
+  hetzner.hcloud.hcloud_server:
+    name: "{{ hcloud_server_name }}"
+    server_type: cx11
+    image: ubuntu-22.04
+    state: stopped
+  register: test_server
+
+- name: Create test_snapshot
+  ansible.builtin.script:
+    cmd: >
+      {{ hcloud_cli_path }} server create-image
+      --type snapshot
+      --description "{{ hcloud_snapshot_name }}"
+      --label key=value
+      "{{ test_server.hcloud_server.id }}"
+      | awk '{print $2}'
+  register: test_snapshot
+
+- name: Set test_snapshot_id
+  ansible.builtin.set_fact:
+    test_snapshot_id: "{{ test_snapshot.stdout_lines[0] }}"
+
 - name: test gather hcloud image infos with type system
   hcloud_image_info:
   register: hcloud_images
@@ -27,7 +57,7 @@
 - name: verify test gather hcloud image with correct label selector
   assert:
     that:
-      - hcloud_images.hcloud_image_info|selectattr('description','equalto','{{ hcloud_test_image_name }}') | list | count == 1
+      - hcloud_images.hcloud_image_info|selectattr('description','equalto','{{ hcloud_snapshot_name }}') | list | count == 1
 
 - name: test gather hcloud image infos with wrong label selector
   hcloud_image_info:
@@ -41,17 +71,17 @@
 
 - name: test gather hcloud image infos with correct id
   hcloud_image_info:
-    id: "{{hcloud_test_image_id}}"
+    id: "{{test_snapshot_id}}"
     type: snapshot
   register: hcloud_images
 - name: verify test gather hcloud image with correct id
   assert:
     that:
-      - hcloud_images.hcloud_image_info|selectattr('description','equalto','{{ hcloud_test_image_name }}') | list | count == 1
+      - hcloud_images.hcloud_image_info|selectattr('description','equalto','{{ hcloud_snapshot_name }}') | list | count == 1
 
 - name: test gather hcloud image infos with wrong id
   hcloud_image_info:
-    id: "{{hcloud_test_image_id}}1"
+    id: "{{test_snapshot_id}}1"
     type: snapshot
   ignore_errors: true
   register: result
@@ -90,3 +120,9 @@
     that:
       - hcloud_images.hcloud_image_info | selectattr('architecture','equalto','x86') | list | count == 0
       - hcloud_images.hcloud_image_info | selectattr('architecture','equalto','arm') | list | count  > 2
+
+---
+- name: Cleanup test_server
+  hetzner.hcloud.hcloud_server:
+    name: "{{ hcloud_server_name }}"
+    state: absent

--- a/tests/integration/targets/hcloud_image_info/tasks/main.yml
+++ b/tests/integration/targets/hcloud_image_info/tasks/main.yml
@@ -1,12 +1,10 @@
 # Copyright: (c) 2019, Hetzner Cloud GmbH <info@hetzner-cloud.de>
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 ---
-
 - name: Cleanup test_server
   hetzner.hcloud.hcloud_server:
     name: "{{ hcloud_server_name }}"
     state: absent
-
 
 - name: Create test_server
   hetzner.hcloud.hcloud_server:
@@ -121,7 +119,6 @@
       - hcloud_images.hcloud_image_info | selectattr('architecture','equalto','x86') | list | count == 0
       - hcloud_images.hcloud_image_info | selectattr('architecture','equalto','arm') | list | count  > 2
 
----
 - name: Cleanup test_server
   hetzner.hcloud.hcloud_server:
     name: "{{ hcloud_server_name }}"

--- a/tests/integration/targets/hcloud_load_balancer_target/defaults/main.yml
+++ b/tests/integration/targets/hcloud_load_balancer_target/defaults/main.yml
@@ -4,4 +4,4 @@
 hcloud_prefix: "tests"
 hcloud_server_name: "{{ hcloud_prefix | truncate(45, True, '', 0) }}-lb-t"
 hcloud_load_balancer_name: "{{hcloud_prefix}}-lb-target"
-hcloud_testing_ip: "176.9.59.39"
+hetzner_server_ip: "142.132.203.104"

--- a/tests/integration/targets/hcloud_load_balancer_target/tasks/main.yml
+++ b/tests/integration/targets/hcloud_load_balancer_target/tasks/main.yml
@@ -123,7 +123,7 @@
   hcloud_load_balancer_target:
     type: "ip"
     load_balancer: "{{hcloud_load_balancer_name}}"
-    ip: "{{hcloud_testing_ip}}"
+    ip: "{{hetzner_server_ip}}"
     state: present
   register: load_balancer_target
 - name: verify create ip target
@@ -131,7 +131,7 @@
     that:
       - load_balancer_target is changed
       - load_balancer_target.hcloud_load_balancer_target.type == "ip"
-      - load_balancer_target.hcloud_load_balancer_target.ip == hcloud_testing_ip
+      - load_balancer_target.hcloud_load_balancer_target.ip == hetzner_server_ip
       - load_balancer_target.hcloud_load_balancer_target.load_balancer == hcloud_load_balancer_name
 
 - name: cleanup load_balancer

--- a/tests/integration/targets/hcloud_subnetwork/defaults/main.yml
+++ b/tests/integration/targets/hcloud_subnetwork/defaults/main.yml
@@ -3,4 +3,4 @@
 ---
 hcloud_prefix: "tests"
 hcloud_network_name: "{{hcloud_prefix}}-s"
-hetzner_vswitch_id: 15311
+hetzner_vswitch_id: 43065

--- a/tests/integration/targets/setup_hcloud_cli/tasks/main.yml
+++ b/tests/integration/targets/setup_hcloud_cli/tasks/main.yml
@@ -1,0 +1,16 @@
+---
+- name: Create temporary file for hcloud_cli_path
+  ansible.builtin.tempfile:
+    state: directory
+  register: _tmp_hcloud_cli
+
+- name: Download hcloud cli from Github releases
+  ansible.builtin.unarchive:
+    src: https://github.com/hetznercloud/cli/releases/download/v1.37.0/hcloud-linux-amd64.tar.gz
+    dest: "{{ _tmp_hcloud_cli.path }}"
+    remote_src: true
+    extra_opts: [hcloud]
+
+- name: Set hcloud_cli_path
+  ansible.builtin.set_fact:
+    hcloud_cli_path: "{{ _tmp_hcloud_cli.path }}/hcloud"


### PR DESCRIPTION
##### SUMMARY

Backport of https://github.com/ansible-collections/hetzner.hcloud/commit/62ab0570c85540991caafe6d3523aa8992d8f84e (https://github.com/ansible-collections/hetzner.hcloud/pull/316) to branch `stable-1`

