### PR TITLE
fix: invalid field in load_balancer_service health_check.http return data

### DIFF
--- a/changelogs/fragments/rename-load-balancer-service-http-health-check-dict.yaml
+++ b/changelogs/fragments/rename-load-balancer-service-http-health-check-dict.yaml
@@ -1,4 +1,4 @@
 bugfixes:
   - >
-    hcloud_load_balancer_service - In the returned data, rename the invalid
-    `health_check.http.certificates` field to `health_check.http.status_codes`.
+    hcloud_load_balancer_service - In the returned data, the invalid
+    `health_check.http.certificates` field was renamed to `health_check.http.status_codes`.

--- a/changelogs/fragments/rename-load-balancer-service-http-health-check-dict.yaml
+++ b/changelogs/fragments/rename-load-balancer-service-http-health-check-dict.yaml
@@ -1,0 +1,4 @@
+bugfixes:
+  - >
+    hcloud_load_balancer_service - In the returned data, rename the invalid
+    `health_check.http.certificates` field to `health_check.http.status_codes`.

--- a/plugins/modules/hcloud_load_balancer_service.py
+++ b/plugins/modules/hcloud_load_balancer_service.py
@@ -322,7 +322,7 @@ class AnsibleHCloudLoadBalancerService(AnsibleHCloud):
                 "domain": to_native(self.hcloud_load_balancer_service.health_check.http.domain),
                 "path": to_native(self.hcloud_load_balancer_service.health_check.http.path),
                 "response": to_native(self.hcloud_load_balancer_service.health_check.http.response),
-                "certificates": [
+                "status_codes": [
                     to_native(status_code)
                     for status_code in self.hcloud_load_balancer_service.health_check.http.status_codes
                 ],


### PR DESCRIPTION
##### SUMMARY

In the `hcloud_load_balancer_service` return data, the `health_check.http.certificates` field must be named `health_check.http.status_codes`.

https://docs.hetzner.cloud/#load-balancers-get-a-load-balancer

Fixes #332 

##### ISSUE TYPE

- Bugfix Pull Request


##### COMPONENT NAME

hcloud_load_balancer_service
