### PR TITLE
refactor: move module vars out of `__init__`

### DIFF
--- a/plugins/module_utils/hcloud.py
+++ b/plugins/module_utils/hcloud.py
@@ -4,11 +4,17 @@
 
 
 import traceback
+from typing import Any, Dict, Optional
 
-from ansible.module_utils.basic import env_fallback, missing_required_lib
+from ansible.module_utils.basic import (
+    AnsibleModule as AnsibleModuleBase,
+    env_fallback,
+    missing_required_lib,
+)
 from ansible.module_utils.common.text.converters import to_native
 
-from ..module_utils.vendor import hcloud
+from ..module_utils.vendor.hcloud import APIException, Client, HCloudException
+from ..module_utils.vendor.hcloud.actions import ActionException
 from .version import version
 
 HAS_REQUESTS = True
@@ -25,10 +31,20 @@ except ImportError:
     HAS_DATEUTIL = False
 
 
+# Provide typing definitions to the AnsibleModule class
+class AnsibleModule(AnsibleModuleBase):
+    params: dict
+
+
 class AnsibleHCloud:
-    def __init__(self, module, represent):
+    represent: str
+
+    module: AnsibleModule
+
+    def __init__(self, module: AnsibleModule):
+        assert self.represent, f"represent property is not defined for {self.__class__.__name__}"
+
         self.module = module
-        self.represent = represent
         self.result = {"changed": False, self.represent: None}
         if not HAS_REQUESTS:
             module.fail_json(msg=missing_required_lib("requests"))
@@ -36,7 +52,13 @@ class AnsibleHCloud:
             module.fail_json(msg=missing_required_lib("python-dateutil"))
         self._build_client()
 
-    def fail_json_hcloud(self, exception, msg=None, params=None, **kwargs):
+    def fail_json_hcloud(
+        self,
+        exception: HCloudException,
+        msg: Optional[str] = None,
+        params: Any = None,
+        **kwargs,
+    ) -> None:
         last_traceback = traceback.format_exc()
 
         failure = {}
@@ -44,12 +66,12 @@ class AnsibleHCloud:
         if params is not None:
             failure["params"] = params
 
-        if isinstance(exception, hcloud.APIException):
+        if isinstance(exception, APIException):
             failure["message"] = exception.message
             failure["code"] = exception.code
             failure["details"] = exception.details
 
-        elif isinstance(exception, hcloud.actions.domain.ActionException):
+        elif isinstance(exception, ActionException):
             failure["action"] = {k: getattr(exception.action, k) for k in exception.action.__slots__}
 
         exception_message = to_native(exception)
@@ -60,15 +82,15 @@ class AnsibleHCloud:
 
         self.module.fail_json(msg=msg, exception=last_traceback, failure=failure, **kwargs)
 
-    def _build_client(self):
-        self.client = hcloud.Client(
+    def _build_client(self) -> None:
+        self.client = Client(
             token=self.module.params["api_token"],
             api_endpoint=self.module.params["endpoint"],
             application_name="ansible-module",
             application_version=version,
         )
 
-    def _mark_as_changed(self):
+    def _mark_as_changed(self) -> None:
         self.result["changed"] = True
 
     @classmethod
@@ -80,17 +102,17 @@ class AnsibleHCloud:
                 "fallback": (env_fallback, ["HCLOUD_TOKEN"]),
                 "no_log": True,
             },
-            "endpoint": {"type": "str", "default": "https://api.hetzner.cloud/v1"},
+            "endpoint": {
+                "type": "str",
+                "default": "https://api.hetzner.cloud/v1",
+            },
         }
 
-    def _prepare_result(self):
-        """Prepare the result for every module
-
-        :return: dict
-        """
+    def _prepare_result(self) -> Dict[str, Any]:
+        """Prepare the result for every module"""
         return {}
 
-    def get_result(self):
+    def get_result(self) -> Dict[str, Any]:
         if getattr(self, self.represent) is not None:
             self.result[self.represent] = self._prepare_result()
         return self.result

--- a/plugins/module_utils/hcloud.py
+++ b/plugins/module_utils/hcloud.py
@@ -42,7 +42,8 @@ class AnsibleHCloud:
     module: AnsibleModule
 
     def __init__(self, module: AnsibleModule):
-        assert self.represent, f"represent property is not defined for {self.__class__.__name__}"
+        if not self.represent:
+            raise NotImplementedError(f"represent property is not defined for {self.__class__.__name__}")
 
         self.module = module
         self.result = {"changed": False, self.represent: None}

--- a/plugins/modules/hcloud_certificate.py
+++ b/plugins/modules/hcloud_certificate.py
@@ -134,17 +134,20 @@ hcloud_certificate:
             type: dict
 """
 
+from typing import Optional
+
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.common.text.converters import to_native
 
 from ..module_utils.hcloud import AnsibleHCloud
 from ..module_utils.vendor.hcloud import HCloudException
+from ..module_utils.vendor.hcloud.certificates import BoundCertificate
 
 
 class AnsibleHCloudCertificate(AnsibleHCloud):
-    def __init__(self, module):
-        super().__init__(module, "hcloud_certificate")
-        self.hcloud_certificate = None
+    represent = "hcloud_certificate"
+
+    hcloud_certificate: Optional[BoundCertificate] = None
 
     def _prepare_result(self):
         return {

--- a/plugins/modules/hcloud_certificate_info.py
+++ b/plugins/modules/hcloud_certificate_info.py
@@ -83,17 +83,20 @@ hcloud_certificate_info:
             returned: always
             type: dict
 """
+from typing import List, Optional
+
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.common.text.converters import to_native
 
 from ..module_utils.hcloud import AnsibleHCloud
 from ..module_utils.vendor.hcloud import HCloudException
+from ..module_utils.vendor.hcloud.certificates import BoundCertificate
 
 
 class AnsibleHCloudCertificateInfo(AnsibleHCloud):
-    def __init__(self, module):
-        super().__init__(module, "hcloud_certificate_info")
-        self.hcloud_certificate_info = None
+    represent = "hcloud_certificate_info"
+
+    hcloud_certificate_info: Optional[List[BoundCertificate]] = None
 
     def _prepare_result(self):
         certificates = []

--- a/plugins/modules/hcloud_datacenter_info.py
+++ b/plugins/modules/hcloud_datacenter_info.py
@@ -74,17 +74,20 @@ hcloud_datacenter_info:
             sample: fsn1
 """
 
+from typing import List, Optional
+
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.common.text.converters import to_native
 
 from ..module_utils.hcloud import AnsibleHCloud
 from ..module_utils.vendor.hcloud import HCloudException
+from ..module_utils.vendor.hcloud.datacenters import BoundDatacenter
 
 
 class AnsibleHCloudDatacenterInfo(AnsibleHCloud):
-    def __init__(self, module):
-        super().__init__(module, "hcloud_datacenter_info")
-        self.hcloud_datacenter_info = None
+    represent = "hcloud_datacenter_info"
+
+    hcloud_datacenter_info: Optional[List[BoundDatacenter]] = None
 
     def _prepare_result(self):
         tmp = []

--- a/plugins/modules/hcloud_firewall.py
+++ b/plugins/modules/hcloud_firewall.py
@@ -167,19 +167,20 @@ hcloud_firewall:
 """
 
 import time
+from typing import Optional
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.common.text.converters import to_native
 
 from ..module_utils.hcloud import AnsibleHCloud
 from ..module_utils.vendor.hcloud import APIException, HCloudException
-from ..module_utils.vendor.hcloud.firewalls.domain import FirewallRule
+from ..module_utils.vendor.hcloud.firewalls import BoundFirewall, FirewallRule
 
 
 class AnsibleHCloudFirewall(AnsibleHCloud):
-    def __init__(self, module):
-        super().__init__(module, "hcloud_firewall")
-        self.hcloud_firewall = None
+    represent = "hcloud_firewall"
+
+    hcloud_firewall: Optional[BoundFirewall] = None
 
     def _prepare_result(self):
         return {

--- a/plugins/modules/hcloud_floating_ip.py
+++ b/plugins/modules/hcloud_floating_ip.py
@@ -161,17 +161,20 @@ hcloud_floating_ip:
                 mylabel: 123
 """
 
+from typing import Optional
+
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.common.text.converters import to_native
 
 from ..module_utils.hcloud import AnsibleHCloud
 from ..module_utils.vendor.hcloud import HCloudException
+from ..module_utils.vendor.hcloud.floating_ips import BoundFloatingIP
 
 
 class AnsibleHCloudFloatingIP(AnsibleHCloud):
-    def __init__(self, module):
-        super().__init__(module, "hcloud_floating_ip")
-        self.hcloud_floating_ip = None
+    represent = "hcloud_floating_ip"
+
+    hcloud_floating_ip: Optional[BoundFloatingIP] = None
 
     def _prepare_result(self):
         server = None

--- a/plugins/modules/hcloud_floating_ip_info.py
+++ b/plugins/modules/hcloud_floating_ip_info.py
@@ -97,17 +97,20 @@ hcloud_floating_ip_info:
             type: dict
 """
 
+from typing import List, Optional
+
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.common.text.converters import to_native
 
 from ..module_utils.hcloud import AnsibleHCloud
 from ..module_utils.vendor.hcloud import HCloudException
+from ..module_utils.vendor.hcloud.floating_ips import BoundFloatingIP
 
 
 class AnsibleHCloudFloatingIPInfo(AnsibleHCloud):
-    def __init__(self, module):
-        super().__init__(module, "hcloud_floating_ip_info")
-        self.hcloud_floating_ip_info = None
+    represent = "hcloud_floating_ip_info"
+
+    hcloud_floating_ip_info: Optional[List[BoundFloatingIP]] = None
 
     def _prepare_result(self):
         tmp = []

--- a/plugins/modules/hcloud_image_info.py
+++ b/plugins/modules/hcloud_image_info.py
@@ -109,17 +109,20 @@ hcloud_image_info:
             type: dict
 """
 
+from typing import List, Optional
+
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.common.text.converters import to_native
 
 from ..module_utils.hcloud import AnsibleHCloud
 from ..module_utils.vendor.hcloud import HCloudException
+from ..module_utils.vendor.hcloud.images import BoundImage
 
 
 class AnsibleHCloudImageInfo(AnsibleHCloud):
-    def __init__(self, module):
-        super().__init__(module, "hcloud_image_info")
-        self.hcloud_image_info = None
+    represent = "hcloud_image_info"
+
+    hcloud_image_info: Optional[List[BoundImage]] = None
 
     def _prepare_result(self):
         tmp = []

--- a/plugins/modules/hcloud_iso_info.py
+++ b/plugins/modules/hcloud_iso_info.py
@@ -96,16 +96,19 @@ hcloud_iso_info:
             sample: "2024-12-01T00:00:00+00:00"
 """
 
+from typing import List, Optional
+
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.common.text.converters import to_native
 
 from ..module_utils.hcloud import AnsibleHCloud
+from ..module_utils.vendor.hcloud.isos import BoundIso
 
 
 class AnsibleHCloudIsoInfo(AnsibleHCloud):
-    def __init__(self, module):
-        super().__init__(module, "hcloud_iso_info")
-        self.hcloud_iso_info = None
+    represent = "hcloud_iso_info"
+
+    hcloud_iso_info: Optional[List[BoundIso]] = None
 
     def _prepare_result(self):
         tmp = []

--- a/plugins/modules/hcloud_iso_info.py
+++ b/plugins/modules/hcloud_iso_info.py
@@ -102,6 +102,7 @@ from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.common.text.converters import to_native
 
 from ..module_utils.hcloud import AnsibleHCloud
+from ..module_utils.vendor.hcloud import HCloudException
 from ..module_utils.vendor.hcloud.isos import BoundIso
 
 
@@ -142,8 +143,8 @@ class AnsibleHCloudIsoInfo(AnsibleHCloud):
                     include_wildcard_architecture=self.module.params.get("include_wildcard_architecture"),
                 )
 
-        except Exception as exception:
-            self.module.fail_json(msg=exception.message)
+        except HCloudException as exception:
+            self.fail_json_hcloud(exception)
 
     @classmethod
     def define_module(cls):

--- a/plugins/modules/hcloud_load_balancer.py
+++ b/plugins/modules/hcloud_load_balancer.py
@@ -141,17 +141,20 @@ hcloud_load_balancer:
             sample: false
 """
 
+from typing import Optional
+
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.common.text.converters import to_native
 
 from ..module_utils.hcloud import AnsibleHCloud
 from ..module_utils.vendor.hcloud import HCloudException
+from ..module_utils.vendor.hcloud.load_balancers import BoundLoadBalancer
 
 
 class AnsibleHCloudLoadBalancer(AnsibleHCloud):
-    def __init__(self, module):
-        super().__init__(module, "hcloud_load_balancer")
-        self.hcloud_load_balancer = None
+    represent = "hcloud_load_balancer"
+
+    hcloud_load_balancer: Optional[BoundLoadBalancer] = None
 
     def _prepare_result(self):
         private_ipv4_address = (

--- a/plugins/modules/hcloud_load_balancer_info.py
+++ b/plugins/modules/hcloud_load_balancer_info.py
@@ -274,17 +274,20 @@ hcloud_load_balancer_info:
                                     sample: false
 """
 
+from typing import List, Optional
+
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.common.text.converters import to_native
 
 from ..module_utils.hcloud import AnsibleHCloud
 from ..module_utils.vendor.hcloud import HCloudException
+from ..module_utils.vendor.hcloud.load_balancers import BoundLoadBalancer
 
 
 class AnsibleHCloudLoadBalancerInfo(AnsibleHCloud):
-    def __init__(self, module):
-        super().__init__(module, "hcloud_load_balancer_info")
-        self.hcloud_load_balancer_info = None
+    represent = "hcloud_load_balancer_info"
+
+    hcloud_load_balancer_info: Optional[List[BoundLoadBalancer]] = None
 
     def _prepare_result(self):
         tmp = []

--- a/plugins/modules/hcloud_load_balancer_network.py
+++ b/plugins/modules/hcloud_load_balancer_network.py
@@ -91,19 +91,23 @@ hcloud_load_balancer_network:
             sample: 10.0.0.8
 """
 
+from typing import Optional
+
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.common.text.converters import to_native
 
 from ..module_utils.hcloud import AnsibleHCloud
 from ..module_utils.vendor.hcloud import HCloudException
+from ..module_utils.vendor.hcloud.load_balancers import BoundLoadBalancer, PrivateNet
+from ..module_utils.vendor.hcloud.networks import BoundNetwork
 
 
 class AnsibleHCloudLoadBalancerNetwork(AnsibleHCloud):
-    def __init__(self, module):
-        super().__init__(module, "hcloud_load_balancer_network")
-        self.hcloud_network = None
-        self.hcloud_load_balancer = None
-        self.hcloud_load_balancer_network = None
+    represent = "hcloud_load_balancer_network"
+
+    hcloud_network: Optional[BoundNetwork] = None
+    hcloud_load_balancer: Optional[BoundLoadBalancer] = None
+    hcloud_load_balancer_network: Optional[PrivateNet] = None
 
     def _prepare_result(self):
         return {

--- a/plugins/modules/hcloud_load_balancer_service.py
+++ b/plugins/modules/hcloud_load_balancer_service.py
@@ -279,12 +279,15 @@ hcloud_load_balancer_service:
                             sample: false
 """
 
+from typing import Optional
+
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.common.text.converters import to_native
 
 from ..module_utils.hcloud import AnsibleHCloud
 from ..module_utils.vendor.hcloud import APIException, HCloudException
-from ..module_utils.vendor.hcloud.load_balancers.domain import (
+from ..module_utils.vendor.hcloud.load_balancers import (
+    BoundLoadBalancer,
     LoadBalancerHealtCheckHttp,
     LoadBalancerHealthCheck,
     LoadBalancerService,
@@ -293,10 +296,10 @@ from ..module_utils.vendor.hcloud.load_balancers.domain import (
 
 
 class AnsibleHCloudLoadBalancerService(AnsibleHCloud):
-    def __init__(self, module):
-        super().__init__(module, "hcloud_load_balancer_service")
-        self.hcloud_load_balancer = None
-        self.hcloud_load_balancer_service = None
+    represent = "hcloud_load_balancer_service"
+
+    hcloud_load_balancer: Optional[BoundLoadBalancer] = None
+    hcloud_load_balancer_service: Optional[LoadBalancerService] = None
 
     def _prepare_result(self):
         http = None

--- a/plugins/modules/hcloud_load_balancer_target.py
+++ b/plugins/modules/hcloud_load_balancer_target.py
@@ -135,24 +135,28 @@ hcloud_load_balancer_target:
             returned: always
 """
 
+from typing import Optional
+
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.common.text.converters import to_native
 
 from ..module_utils.hcloud import AnsibleHCloud
 from ..module_utils.vendor.hcloud import APIException, HCloudException
-from ..module_utils.vendor.hcloud.load_balancers.domain import (
+from ..module_utils.vendor.hcloud.load_balancers import (
+    BoundLoadBalancer,
     LoadBalancerTarget,
     LoadBalancerTargetIP,
     LoadBalancerTargetLabelSelector,
 )
+from ..module_utils.vendor.hcloud.servers import BoundServer
 
 
 class AnsibleHCloudLoadBalancerTarget(AnsibleHCloud):
-    def __init__(self, module):
-        super().__init__(module, "hcloud_load_balancer_target")
-        self.hcloud_load_balancer = None
-        self.hcloud_load_balancer_target = None
-        self.hcloud_server = None
+    represent = "hcloud_load_balancer_target"
+
+    hcloud_load_balancer: Optional[BoundLoadBalancer] = None
+    hcloud_load_balancer_target: Optional[LoadBalancerTarget] = None
+    hcloud_server: Optional[BoundServer] = None
 
     def _prepare_result(self):
         result = {

--- a/plugins/modules/hcloud_load_balancer_type_info.py
+++ b/plugins/modules/hcloud_load_balancer_type_info.py
@@ -85,17 +85,20 @@ hcloud_load_balancer_type_info:
             sample: 5
 """
 
+from typing import List, Optional
+
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.common.text.converters import to_native
 
 from ..module_utils.hcloud import AnsibleHCloud
 from ..module_utils.vendor.hcloud import HCloudException
+from ..module_utils.vendor.hcloud.load_balancer_types import BoundLoadBalancerType
 
 
 class AnsibleHCloudLoadBalancerTypeInfo(AnsibleHCloud):
-    def __init__(self, module):
-        super().__init__(module, "hcloud_load_balancer_type_info")
-        self.hcloud_load_balancer_type_info = None
+    represent = "hcloud_load_balancer_type_info"
+
+    hcloud_load_balancer_type_info: Optional[List[BoundLoadBalancerType]] = None
 
     def _prepare_result(self):
         tmp = []

--- a/plugins/modules/hcloud_location_info.py
+++ b/plugins/modules/hcloud_location_info.py
@@ -75,17 +75,20 @@ hcloud_location_info:
             sample: Falkenstein
 """
 
+from typing import List, Optional
+
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.common.text.converters import to_native
 
 from ..module_utils.hcloud import AnsibleHCloud
 from ..module_utils.vendor.hcloud import HCloudException
+from ..module_utils.vendor.hcloud.locations import BoundLocation
 
 
 class AnsibleHCloudLocationInfo(AnsibleHCloud):
-    def __init__(self, module):
-        super().__init__(module, "hcloud_location_info")
-        self.hcloud_location_info = None
+    represent = "hcloud_location_info"
+
+    hcloud_location_info: Optional[List[BoundLocation]] = None
 
     def _prepare_result(self):
         tmp = []

--- a/plugins/modules/hcloud_network.py
+++ b/plugins/modules/hcloud_network.py
@@ -116,17 +116,20 @@ hcloud_network:
                 mylabel: 123
 """
 
+from typing import Optional
+
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.common.text.converters import to_native
 
 from ..module_utils.hcloud import AnsibleHCloud
 from ..module_utils.vendor.hcloud import HCloudException
+from ..module_utils.vendor.hcloud.networks import BoundNetwork
 
 
 class AnsibleHCloudNetwork(AnsibleHCloud):
-    def __init__(self, module):
-        super().__init__(module, "hcloud_network")
-        self.hcloud_network = None
+    represent = "hcloud_network"
+
+    hcloud_network: Optional[BoundNetwork] = None
 
     def _prepare_result(self):
         return {

--- a/plugins/modules/hcloud_network_info.py
+++ b/plugins/modules/hcloud_network_info.py
@@ -182,17 +182,20 @@ hcloud_network_info:
             type: dict
 """
 
+from typing import List, Optional
+
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.common.text.converters import to_native
 
 from ..module_utils.hcloud import AnsibleHCloud
 from ..module_utils.vendor.hcloud import HCloudException
+from ..module_utils.vendor.hcloud.networks import BoundNetwork
 
 
 class AnsibleHCloudNetworkInfo(AnsibleHCloud):
-    def __init__(self, module):
-        super().__init__(module, "hcloud_network_info")
-        self.hcloud_network_info = None
+    represent = "hcloud_network_info"
+
+    hcloud_network_info: Optional[List[BoundNetwork]] = None
 
     def _prepare_result(self):
         tmp = []

--- a/plugins/modules/hcloud_placement_group.py
+++ b/plugins/modules/hcloud_placement_group.py
@@ -107,17 +107,20 @@ hcloud_placement_group:
                 - 4712
 """
 
+from typing import Optional
+
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.common.text.converters import to_native
 
 from ..module_utils.hcloud import AnsibleHCloud
 from ..module_utils.vendor.hcloud import HCloudException
+from ..module_utils.vendor.hcloud.placement_groups import BoundPlacementGroup
 
 
 class AnsibleHCloudPlacementGroup(AnsibleHCloud):
-    def __init__(self, module):
-        super().__init__(module, "hcloud_placement_group")
-        self.hcloud_placement_group = None
+    represent = "hcloud_placement_group"
+
+    hcloud_placement_group: Optional[BoundPlacementGroup] = None
 
     def _prepare_result(self):
         return {

--- a/plugins/modules/hcloud_primary_ip.py
+++ b/plugins/modules/hcloud_primary_ip.py
@@ -131,17 +131,20 @@ hcloud_primary_ip:
                 mylabel: 123
 """
 
+from typing import Optional
+
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.common.text.converters import to_native
 
 from ..module_utils.hcloud import AnsibleHCloud
 from ..module_utils.vendor.hcloud import HCloudException
+from ..module_utils.vendor.hcloud.primary_ips import BoundPrimaryIP
 
 
 class AnsibleHCloudPrimaryIP(AnsibleHCloud):
-    def __init__(self, module):
-        super().__init__(module, "hcloud_primary_ip")
-        self.hcloud_primary_ip = None
+    represent = "hcloud_primary_ip"
+
+    hcloud_primary_ip: Optional[BoundPrimaryIP] = None
 
     def _prepare_result(self):
         return {

--- a/plugins/modules/hcloud_primary_ip_info.py
+++ b/plugins/modules/hcloud_primary_ip_info.py
@@ -118,17 +118,20 @@ hcloud_primary_ip_info:
             type: bool
 """
 
+from typing import List, Optional
+
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.common.text.converters import to_native
 
 from ..module_utils.hcloud import AnsibleHCloud
 from ..module_utils.vendor.hcloud import HCloudException
+from ..module_utils.vendor.hcloud.primary_ips import BoundPrimaryIP
 
 
 class AnsibleHCloudPrimaryIPInfo(AnsibleHCloud):
-    def __init__(self, module):
-        super().__init__(module, "hcloud_primary_ip_info")
-        self.hcloud_primary_ip_info = None
+    represent = "hcloud_primary_ip_info"
+
+    hcloud_primary_ip_info: Optional[List[BoundPrimaryIP]] = None
 
     def _prepare_result(self):
         tmp = []

--- a/plugins/modules/hcloud_rdns.py
+++ b/plugins/modules/hcloud_rdns.py
@@ -134,6 +134,8 @@ hcloud_rdns:
             sample: example.com
 """
 
+from typing import Any, Dict, Optional, Union
+
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.common.text.converters import to_native
 from ansible_collections.ansible.netcommon.plugins.module_utils.network.common import (
@@ -142,13 +144,17 @@ from ansible_collections.ansible.netcommon.plugins.module_utils.network.common i
 
 from ..module_utils.hcloud import AnsibleHCloud
 from ..module_utils.vendor.hcloud import HCloudException
+from ..module_utils.vendor.hcloud.floating_ips import BoundFloatingIP
+from ..module_utils.vendor.hcloud.load_balancers import BoundLoadBalancer
+from ..module_utils.vendor.hcloud.primary_ips import BoundPrimaryIP
+from ..module_utils.vendor.hcloud.servers import BoundServer
 
 
 class AnsibleHCloudReverseDNS(AnsibleHCloud):
-    def __init__(self, module):
-        super().__init__(module, "hcloud_rdns")
-        self.hcloud_resource = None
-        self.hcloud_rdns = None
+    represent = "hcloud_rdns"
+
+    hcloud_resource: Optional[Union[BoundServer, BoundFloatingIP, BoundLoadBalancer, BoundPrimaryIP]] = None
+    hcloud_rdns: Optional[Dict[str, Any]] = None
 
     def _prepare_result(self):
         result = {

--- a/plugins/modules/hcloud_route.py
+++ b/plugins/modules/hcloud_route.py
@@ -87,19 +87,21 @@ hcloud_route:
             sample: 10.0.0.1
 """
 
+from typing import Optional
+
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.common.text.converters import to_native
 
 from ..module_utils.hcloud import AnsibleHCloud
 from ..module_utils.vendor.hcloud import HCloudException
-from ..module_utils.vendor.hcloud.networks.domain import NetworkRoute
+from ..module_utils.vendor.hcloud.networks import BoundNetwork, NetworkRoute
 
 
 class AnsibleHCloudRoute(AnsibleHCloud):
-    def __init__(self, module):
-        super().__init__(module, "hcloud_route")
-        self.hcloud_network = None
-        self.hcloud_route = None
+    represent = "hcloud_route"
+
+    hcloud_network: Optional[BoundNetwork] = None
+    hcloud_route: Optional[NetworkRoute] = None
 
     def _prepare_result(self):
         return {

--- a/plugins/modules/hcloud_server.py
+++ b/plugins/modules/hcloud_server.py
@@ -329,25 +329,27 @@ hcloud_server:
 """
 
 from datetime import datetime, timedelta, timezone
+from typing import Optional
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.common.text.converters import to_native
 
 from ..module_utils.hcloud import AnsibleHCloud
 from ..module_utils.vendor.hcloud import HCloudException
-from ..module_utils.vendor.hcloud.firewalls.domain import FirewallResource
-from ..module_utils.vendor.hcloud.servers.domain import (
+from ..module_utils.vendor.hcloud.firewalls import FirewallResource
+from ..module_utils.vendor.hcloud.servers import (
+    BoundServer,
     Server,
     ServerCreatePublicNetwork,
 )
-from ..module_utils.vendor.hcloud.ssh_keys.domain import SSHKey
-from ..module_utils.vendor.hcloud.volumes.domain import Volume
+from ..module_utils.vendor.hcloud.ssh_keys import SSHKey
+from ..module_utils.vendor.hcloud.volumes import Volume
 
 
 class AnsibleHCloudServer(AnsibleHCloud):
-    def __init__(self, module):
-        super().__init__(module, "hcloud_server")
-        self.hcloud_server = None
+    represent = "hcloud_server"
+
+    hcloud_server: Optional[BoundServer] = None
 
     def _prepare_result(self):
         image = None if self.hcloud_server.image is None else to_native(self.hcloud_server.image.name)

--- a/plugins/modules/hcloud_server_info.py
+++ b/plugins/modules/hcloud_server_info.py
@@ -138,17 +138,20 @@ hcloud_server_info:
             version_added: "0.1.0"
 """
 
+from typing import List, Optional
+
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.common.text.converters import to_native
 
 from ..module_utils.hcloud import AnsibleHCloud
 from ..module_utils.vendor.hcloud import HCloudException
+from ..module_utils.vendor.hcloud.servers import BoundServer
 
 
 class AnsibleHCloudServerInfo(AnsibleHCloud):
-    def __init__(self, module):
-        super().__init__(module, "hcloud_server_info")
-        self.hcloud_server_info = None
+    represent = "hcloud_server_info"
+
+    hcloud_server_info: Optional[List[BoundServer]] = None
 
     def _prepare_result(self):
         tmp = []

--- a/plugins/modules/hcloud_server_network.py
+++ b/plugins/modules/hcloud_server_network.py
@@ -112,19 +112,23 @@ hcloud_server_network:
             sample: [10.1.0.1, ...]
 """
 
+from typing import Optional
+
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.common.text.converters import to_native
 
 from ..module_utils.hcloud import AnsibleHCloud
 from ..module_utils.vendor.hcloud import APIException, HCloudException
+from ..module_utils.vendor.hcloud.networks import BoundNetwork
+from ..module_utils.vendor.hcloud.servers import BoundServer, PrivateNet
 
 
 class AnsibleHCloudServerNetwork(AnsibleHCloud):
-    def __init__(self, module):
-        super().__init__(module, "hcloud_server_network")
-        self.hcloud_network = None
-        self.hcloud_server = None
-        self.hcloud_server_network = None
+    represent = "hcloud_server_network"
+
+    hcloud_network: Optional[BoundNetwork] = None
+    hcloud_server: Optional[BoundServer] = None
+    hcloud_server_network: Optional[PrivateNet] = None
 
     def _prepare_result(self):
         return {

--- a/plugins/modules/hcloud_server_type_info.py
+++ b/plugins/modules/hcloud_server_type_info.py
@@ -121,17 +121,20 @@ hcloud_server_type_info:
 
 """
 
+from typing import List, Optional
+
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.common.text.converters import to_native
 
 from ..module_utils.hcloud import AnsibleHCloud
 from ..module_utils.vendor.hcloud import HCloudException
+from ..module_utils.vendor.hcloud.server_types import BoundServerType
 
 
 class AnsibleHCloudServerTypeInfo(AnsibleHCloud):
-    def __init__(self, module):
-        super().__init__(module, "hcloud_server_type_info")
-        self.hcloud_server_type_info = None
+    represent = "hcloud_server_type_info"
+
+    hcloud_server_type_info: Optional[List[BoundServerType]] = None
 
     def _prepare_result(self):
         tmp = []

--- a/plugins/modules/hcloud_ssh_key.py
+++ b/plugins/modules/hcloud_ssh_key.py
@@ -110,17 +110,20 @@ hcloud_ssh_key:
                 mylabel: 123
 """
 
+from typing import Optional
+
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.common.text.converters import to_native
 
 from ..module_utils.hcloud import AnsibleHCloud
 from ..module_utils.vendor.hcloud import HCloudException
+from ..module_utils.vendor.hcloud.ssh_keys import BoundSSHKey
 
 
 class AnsibleHCloudSSHKey(AnsibleHCloud):
-    def __init__(self, module):
-        super().__init__(module, "hcloud_ssh_key")
-        self.hcloud_ssh_key = None
+    represent = "hcloud_ssh_key"
+
+    hcloud_ssh_key: Optional[BoundSSHKey] = None
 
     def _prepare_result(self):
         return {

--- a/plugins/modules/hcloud_ssh_key_info.py
+++ b/plugins/modules/hcloud_ssh_key_info.py
@@ -75,17 +75,20 @@ hcloud_ssh_key_info:
             returned: always
             type: dict
 """
+from typing import List, Optional
+
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.common.text.converters import to_native
 
 from ..module_utils.hcloud import AnsibleHCloud
 from ..module_utils.vendor.hcloud import HCloudException
+from ..module_utils.vendor.hcloud.ssh_keys import BoundSSHKey
 
 
 class AnsibleHCloudSSHKeyInfo(AnsibleHCloud):
-    def __init__(self, module):
-        super().__init__(module, "hcloud_ssh_key_info")
-        self.hcloud_ssh_key_info = None
+    represent = "hcloud_ssh_key_info"
+
+    hcloud_ssh_key_info: Optional[List[BoundSSHKey]] = None
 
     def _prepare_result(self):
         ssh_keys = []

--- a/plugins/modules/hcloud_subnetwork.py
+++ b/plugins/modules/hcloud_subnetwork.py
@@ -124,19 +124,21 @@ hcloud_subnetwork:
             sample: 10.0.0.1
 """
 
+from typing import Optional
+
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.common.text.converters import to_native
 
 from ..module_utils.hcloud import AnsibleHCloud
 from ..module_utils.vendor.hcloud import HCloudException
-from ..module_utils.vendor.hcloud.networks.domain import NetworkSubnet
+from ..module_utils.vendor.hcloud.networks import BoundNetwork, NetworkSubnet
 
 
 class AnsibleHCloudSubnetwork(AnsibleHCloud):
-    def __init__(self, module):
-        super().__init__(module, "hcloud_subnetwork")
-        self.hcloud_network = None
-        self.hcloud_subnetwork = None
+    represent = "hcloud_subnetwork"
+
+    hcloud_network: Optional[BoundNetwork] = None
+    hcloud_subnetwork: Optional[NetworkSubnet] = None
 
     def _prepare_result(self):
         return {

--- a/plugins/modules/hcloud_volume.py
+++ b/plugins/modules/hcloud_volume.py
@@ -157,17 +157,20 @@ hcloud_volume:
             version_added: "0.1.0"
 """
 
+from typing import Optional
+
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.common.text.converters import to_native
 
 from ..module_utils.hcloud import AnsibleHCloud
 from ..module_utils.vendor.hcloud import HCloudException
+from ..module_utils.vendor.hcloud.volumes import BoundVolume
 
 
 class AnsibleHCloudVolume(AnsibleHCloud):
-    def __init__(self, module):
-        super().__init__(module, "hcloud_volume")
-        self.hcloud_volume = None
+    represent = "hcloud_volume"
+
+    hcloud_volume: Optional[BoundVolume] = None
 
     def _prepare_result(self):
         server_name = None

--- a/plugins/modules/hcloud_volume_info.py
+++ b/plugins/modules/hcloud_volume_info.py
@@ -92,17 +92,20 @@ hcloud_volume_info:
             type: dict
 """
 
+from typing import List, Optional
+
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.common.text.converters import to_native
 
 from ..module_utils.hcloud import AnsibleHCloud
 from ..module_utils.vendor.hcloud import HCloudException
+from ..module_utils.vendor.hcloud.volumes import BoundVolume
 
 
 class AnsibleHCloudVolumeInfo(AnsibleHCloud):
-    def __init__(self, module):
-        super().__init__(module, "hcloud_volume_info")
-        self.hcloud_volume_info = None
+    represent = "hcloud_volume_info"
+
+    hcloud_volume_info: Optional[List[BoundVolume]] = None
 
     def _prepare_result(self):
         tmp = []

--- a/tests/unit/module_utils/test_hcloud.py
+++ b/tests/unit/module_utils/test_hcloud.py
@@ -6,7 +6,7 @@ from ansible_collections.hetzner.hcloud.plugins.module_utils.hcloud import Ansib
 from ansible_collections.hetzner.hcloud.plugins.module_utils.vendor.hcloud import (
     APIException,
 )
-from ansible_collections.hetzner.hcloud.plugins.module_utils.vendor.hcloud.actions.domain import (
+from ansible_collections.hetzner.hcloud.plugins.module_utils.vendor.hcloud.actions import (
     Action,
     ActionException,
     ActionFailedException,


### PR DESCRIPTION
##### SUMMARY

- move module vars out of `__init__`
- add modules type hints
- catch hcloud exception for api calls
