### PR TITLE
fix: firewall port argument is required with udp or tcp

### DIFF
--- a/changelogs/fragments/require-firewall-port-argument-on-tcp-or-udp-protocol.yaml
+++ b/changelogs/fragments/require-firewall-port-argument-on-tcp-or-udp-protocol.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - hcloud_firewall - The port argument is required when the firewall rule protocol is `udp` or `tcp`.

--- a/plugins/modules/hcloud_firewall.py
+++ b/plugins/modules/hcloud_firewall.py
@@ -314,6 +314,10 @@ class AnsibleHCloudFirewall(AnsibleHCloud):
                         description={"type": "str"},
                     ),
                     required_together=[["direction", "protocol"]],
+                    required_if=[
+                        ["protocol", "udp", ["port"]],
+                        ["protocol", "tcp", ["port"]],
+                    ],
                 ),
                 labels={"type": "dict"},
                 state={


### PR DESCRIPTION
##### SUMMARY

When managing a tcp/udp firewall rule, provide a clear error message when the port is missing from the rule.

Closes #344

##### ISSUE TYPE

- Bugfix Pull Request


##### COMPONENT NAME

hcloud_firewall
