### PR TITLE
build: don't include v prefix in version tags

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -23,6 +23,7 @@ jobs:
           token: ${{ secrets.HCLOUD_BOT_TOKEN }}
           release-type: simple
           package-name: hetzner.hcloud
+          include-v-in-tag: false
 
           # We use antsibull-changelog for the actual user-facing changelog.
           changelog-path: changelogs/dev-changelog.md

--- a/changelogs/dev-changelog.md
+++ b/changelogs/dev-changelog.md
@@ -2,11 +2,10 @@
 
 ## [2.1.2](https://github.com/ansible-collections/hetzner.hcloud/compare/2.1.1...v2.1.2) (2023-10-05)
 
-
 ### Bug Fixes
 
-* firewall port argument is required with udp or tcp ([#345](https://github.com/ansible-collections/hetzner.hcloud/issues/345)) ([76c1abf](https://github.com/ansible-collections/hetzner.hcloud/commit/76c1abf44764778aa6e11bae57df5ee5f69a947b))
-* invalid field in load_balancer_service health_check.http return data ([#333](https://github.com/ansible-collections/hetzner.hcloud/issues/333)) ([fb35516](https://github.com/ansible-collections/hetzner.hcloud/commit/fb35516e7609fad4dd3fa75138dbc603f83d9aa0))
+- firewall port argument is required with udp or tcp ([#345](https://github.com/ansible-collections/hetzner.hcloud/issues/345)) ([76c1abf](https://github.com/ansible-collections/hetzner.hcloud/commit/76c1abf44764778aa6e11bae57df5ee5f69a947b))
+- invalid field in load_balancer_service health_check.http return data ([#333](https://github.com/ansible-collections/hetzner.hcloud/issues/333)) ([fb35516](https://github.com/ansible-collections/hetzner.hcloud/commit/fb35516e7609fad4dd3fa75138dbc603f83d9aa0))
 
 ## Dev Changelog
 


### PR DESCRIPTION
##### SUMMARY

The version tag regex allowing to publish to ansible-galaxy does not allow versions to be prefixed with a v: 
https://github.com/ansible/zuul-config/blob/468493fef435a6152d982fc7c41fe2ff2066e139/zuul.d/pipelines.yaml#L146-L155

Introducing the v prefix is also breaking with the previous tag naming convention.