### PR TITLE
chore: add venv dependency to lint-docs target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,11 @@ lint: venv
 	venv/bin/pylint plugins
 
 lint-docs: venv
-	venv/bin/antsibull-docs lint-collection-docs --plugin-docs .
+	venv/bin/antsibull-docs lint-collection-docs \
+		--plugin-docs \
+		--validate-collection-refs self \
+		--skip-rstcheck \
+		.
 
 clean:
 	git clean -xdf \

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ venv:
 lint: venv
 	venv/bin/pylint plugins
 
-lint-docs:
+lint-docs: venv
 	venv/bin/antsibull-docs lint-collection-docs --plugin-docs .
 
 clean:


### PR DESCRIPTION
##### SUMMARY

Missing venv when running lint-docs from a clean repo.
