### PR TITLE
feat: add deprecation field to hcloud_iso_info

### DIFF
--- a/changelogs/fragments/add-deprecation-field-to-iso-info.yaml
+++ b/changelogs/fragments/add-deprecation-field-to-iso-info.yaml
@@ -1,0 +1,2 @@
+minor_changes:
+  - hcloud_iso_info - Add deprecation field

--- a/plugins/modules/hcloud_iso_info.py
+++ b/plugins/modules/hcloud_iso_info.py
@@ -90,10 +90,33 @@ hcloud_iso_info:
             description: >
                 ISO 8601 timestamp of deprecation, None if ISO is still available.
                 After the deprecation time it will no longer be possible to attach the
-                ISO to servers.
+                ISO to servers. This field is deprecated. Use `deprecation` instead.
             returned: always
             type: str
             sample: "2024-12-01T00:00:00+00:00"
+        deprecation:
+            description: >
+                Describes if, when & how the resources was deprecated. If this field is
+                set to None the resource is not deprecated. If it has a value, it is
+                considered deprecated.
+            returned: if the resource is deprecated
+            type: dict
+            contains:
+                announced:
+                    description: Date of when the deprecation was announced.
+                    returned: always
+                    type: str
+                    sample: "2021-11-01T00:00:00+00:00"
+                unavailable_after:
+                    description: >
+                      After the time in this field, the resource will not be available
+                      from the general listing endpoint of the resource type, and it can
+                      not be used in new resources. For example, if this is an image,
+                      you can not create new servers with this image after the mentioned
+                      date.
+                    returned: always
+                    type: str
+                    sample: "2021-12-01T00:00:00+00:00"
 """
 
 from typing import List, Optional
@@ -126,6 +149,12 @@ class AnsibleHCloudIsoInfo(AnsibleHCloud):
                     "type": iso_info.type,
                     "architecture": iso_info.architecture,
                     "deprecated": iso_info.deprecated,
+                    "deprecation": {
+                        "announced": iso_info.deprecation.announced.isoformat(),
+                        "unavailable_after": iso_info.deprecation.unavailable_after.isoformat(),
+                    }
+                    if iso_info.deprecation is not None
+                    else None,
                 }
             )
 

--- a/tests/integration/targets/hcloud_iso_info/defaults/main/main.yml
+++ b/tests/integration/targets/hcloud_iso_info/defaults/main/main.yml
@@ -5,8 +5,3 @@ hcloud_iso_id: 551
 hcloud_iso_name: systemrescuecd-x86-5.2.2.iso
 hcloud_iso_type: public
 hcloud_iso_architecture: x86
-
-hcloud_iso_deprecated_id: 10433
-hcloud_iso_deprecated_name: vyos-1.4-rolling-202111150317-amd64.iso
-hcloud_iso_deprecated_announced: "2023-10-05T08:27:01+00:00"
-hcloud_iso_deprecated_unavailable_after: "2023-11-05T08:27:01+00:00"

--- a/tests/integration/targets/hcloud_iso_info/defaults/main/main.yml
+++ b/tests/integration/targets/hcloud_iso_info/defaults/main/main.yml
@@ -5,3 +5,8 @@ hcloud_iso_id: 551
 hcloud_iso_name: systemrescuecd-x86-5.2.2.iso
 hcloud_iso_type: public
 hcloud_iso_architecture: x86
+
+hcloud_iso_deprecated_id: 10433
+hcloud_iso_deprecated_name: vyos-1.4-rolling-202111150317-amd64.iso
+hcloud_iso_deprecated_announced: "2023-10-05T08:27:01+00:00"
+hcloud_iso_deprecated_unavailable_after: "2023-11-05T08:27:01+00:00"

--- a/tests/integration/targets/hcloud_iso_info/tasks/test.yml
+++ b/tests/integration/targets/hcloud_iso_info/tasks/test.yml
@@ -30,6 +30,8 @@
       - result.hcloud_iso_info[0].name == "{{ hcloud_iso_name }}"
       - result.hcloud_iso_info[0].architecture == "{{ hcloud_iso_architecture }}"
       - result.hcloud_iso_info[0].type == "{{ hcloud_iso_type }}"
+      - result.hcloud_iso_info[0].deprecated is none
+      - result.hcloud_iso_info[0].deprecation is none
 
 - name: Gather hcloud_iso_info with wrong id
   hetzner.hcloud.hcloud_iso_info:
@@ -69,16 +71,3 @@
       - result.hcloud_iso_info | list | count > 2
       - result.hcloud_iso_info | selectattr('architecture', 'equalto', 'x86') | list | count == 0
       - result.hcloud_iso_info | selectattr('architecture', 'equalto', 'arm') | list | count  > 2
-
-- name: Gather hcloud_iso_info with deprecation
-  hetzner.hcloud.hcloud_iso_info:
-    id: "{{ hcloud_iso_deprecated_id }}"
-  register: result
-- name: Verify hcloud_iso_info with correct id
-  ansible.builtin.assert:
-    that:
-      - result.hcloud_iso_info | list | count == 1
-      - result.hcloud_iso_info[0].id == "{{ hcloud_iso_deprecated_id }}"
-      - result.hcloud_iso_info[0].name == "{{ hcloud_iso_deprecated_name }}"
-      - result.hcloud_iso_info[0].deprecation.announced == "{{ hcloud_iso_deprecated_announced }}"
-      - result.hcloud_iso_info[0].deprecation.unavailable_after == "{{ hcloud_iso_deprecated_unavailable_after }}"

--- a/tests/integration/targets/hcloud_iso_info/tasks/test.yml
+++ b/tests/integration/targets/hcloud_iso_info/tasks/test.yml
@@ -69,3 +69,16 @@
       - result.hcloud_iso_info | list | count > 2
       - result.hcloud_iso_info | selectattr('architecture', 'equalto', 'x86') | list | count == 0
       - result.hcloud_iso_info | selectattr('architecture', 'equalto', 'arm') | list | count  > 2
+
+- name: Gather hcloud_iso_info with deprecation
+  hetzner.hcloud.hcloud_iso_info:
+    id: "{{ hcloud_iso_deprecated_id }}"
+  register: result
+- name: Verify hcloud_iso_info with correct id
+  ansible.builtin.assert:
+    that:
+      - result.hcloud_iso_info | list | count == 1
+      - result.hcloud_iso_info[0].id == "{{ hcloud_iso_deprecated_id }}"
+      - result.hcloud_iso_info[0].name == "{{ hcloud_iso_deprecated_name }}"
+      - result.hcloud_iso_info[0].deprecation.announced == "{{ hcloud_iso_deprecated_announced }}"
+      - result.hcloud_iso_info[0].deprecation.unavailable_after == "{{ hcloud_iso_deprecated_unavailable_after }}"


### PR DESCRIPTION
##### SUMMARY

See these changelog entries for the announcement:

- https://docs.hetzner.cloud/changelog#2023-10-12-deprecation-info-for-isos
- https://docs.hetzner.cloud/changelog#2023-10-12-field-deprecated-on-isos-is-now-deprecated


##### ISSUE TYPE

- Feature Pull Request


##### COMPONENT NAME
hcloud_iso_info


