### PR TITLE
test: fix vswitch subnets ip_range

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -20,7 +20,6 @@ exclude_paths:
   - tests/integration/targets/hcloud_server
   - tests/integration/targets/hcloud_server_network
   - tests/integration/targets/hcloud_ssh_key
-  - tests/integration/targets/hcloud_subnetwork
   - tests/integration/targets/hcloud_volume
   - tests/integration/targets/setup_selfsigned_certificate
   - tests/integration/targets/setup_ssh_keypair

--- a/tests/integration/targets/hcloud_subnetwork/defaults/main/main.yml
+++ b/tests/integration/targets/hcloud_subnetwork/defaults/main/main.yml
@@ -2,4 +2,22 @@
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 ---
 hcloud_network_name: "{{ hcloud_ns }}"
-hetzner_vswitch_id: 43065
+# Pool of external Hetzner vSwitch ID, this prevents using the same vSwitch id twice in
+# different jobs.
+hetzner_vswitch_ids:
+  - 43065
+  - 44166
+  - 44167
+  - 44168
+  - 44170
+  - 44171
+  - 44172
+  - 44173
+  - 44174
+  - 44175
+  - 44176
+  - 44177
+  - 44178
+  - 44179
+  - 44180
+  - 44181

--- a/tests/integration/targets/hcloud_subnetwork/tasks/cleanup.yml
+++ b/tests/integration/targets/hcloud_subnetwork/tasks/cleanup.yml
@@ -1,0 +1,5 @@
+---
+- name: Cleanup test_network
+  hetzner.hcloud.hcloud_network:
+    name: "{{ hcloud_network_name }}"
+    state: absent

--- a/tests/integration/targets/hcloud_subnetwork/tasks/prepare.yml
+++ b/tests/integration/targets/hcloud_subnetwork/tasks/prepare.yml
@@ -1,0 +1,11 @@
+---
+- name: Create test_network
+  hetzner.hcloud.hcloud_network:
+    name: "{{ hcloud_network_name }}"
+    ip_range: "10.0.0.0/16"
+    state: present
+  register: test_network
+
+- name: Select hetzner vswitch id from pool
+  ansible.builtin.set_fact:
+    test_vswitch_id: "{{ hetzner_vswitch_ids | random }}"

--- a/tests/integration/targets/hcloud_subnetwork/tasks/test.yml
+++ b/tests/integration/targets/hcloud_subnetwork/tasks/test.yml
@@ -1,125 +1,103 @@
 # Copyright: (c) 2019, Hetzner Cloud GmbH <info@hetzner-cloud.de>
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 ---
-- name: setup
-  hetzner.hcloud.hcloud_network:
-    name: "{{ hcloud_network_name }}"
-    ip_range: "10.0.0.0/8"
-    state: present
-  register: network
-- name: verify setup
-  assert:
-    that:
-      - network is success
-
-- name: test missing required parameters on create route
+- name: Test missing required parameters
   hetzner.hcloud.hcloud_subnetwork:
     network: "{{ hcloud_network_name }}"
     state: present
-  register: result
   ignore_errors: true
-- name: verify fail test missing required parameters on create route
-  assert:
+  register: result
+- name: Verify missing required parameters
+  ansible.builtin.assert:
     that:
       - result is failed
       - 'result.msg == "missing required arguments: ip_range, network_zone, type"'
 
-- name: test create subnetwork with checkmode
+- name: Test create with checkmode
   hetzner.hcloud.hcloud_subnetwork:
     network: "{{ hcloud_network_name }}"
-    ip_range: "10.0.0.0/16"
-    type: "server"
-    network_zone: "eu-central"
+    network_zone: eu-central
+    type: cloud
+    ip_range: 10.0.0.0/24
     state: present
-  register: result
   check_mode: true
-- name: verify test create subnetwork with checkmode
-  assert:
+  register: result
+- name: Verify create with checkmode
+  ansible.builtin.assert:
     that:
       - result is changed
 
-- name: test create subnetwork
+- name: Test create
   hetzner.hcloud.hcloud_subnetwork:
     network: "{{ hcloud_network_name }}"
-    ip_range: "10.0.0.0/16"
-    type: "cloud"
-    network_zone: "eu-central"
-    state: present
-  register: subnet
-- name: verify create subnetwork
-  assert:
-    that:
-      - subnet is changed
-      - subnet.hcloud_subnetwork.network == "{{ hcloud_network_name }}"
-      - subnet.hcloud_subnetwork.ip_range == "10.0.0.0/16"
-      - subnet.hcloud_subnetwork.type == "cloud"
-      - subnet.hcloud_subnetwork.network_zone == "eu-central"
-
-- name: test create subnetwork idempotency
-  hetzner.hcloud.hcloud_subnetwork:
-    network: "{{ hcloud_network_name }}"
-    ip_range: "10.0.0.0/16"
-    type: "cloud"
-    network_zone: "eu-central"
+    network_zone: eu-central
+    type: cloud
+    ip_range: 10.0.0.0/24
     state: present
   register: result
-- name: verify create subnetwork idempotency
-  assert:
+- name: Verify create
+  ansible.builtin.assert:
+    that:
+      - result is changed
+      - result.hcloud_subnetwork.network == "{{ hcloud_network_name }}"
+      - result.hcloud_subnetwork.network_zone == "eu-central"
+      - result.hcloud_subnetwork.type == "cloud"
+      - result.hcloud_subnetwork.ip_range == "10.0.0.0/24"
+
+- name: Test create idempotency
+  hetzner.hcloud.hcloud_subnetwork:
+    network: "{{ hcloud_network_name }}"
+    network_zone: eu-central
+    type: cloud
+    ip_range: 10.0.0.0/24
+    state: present
+  register: result
+- name: Verify create idempotency
+  ansible.builtin.assert:
     that:
       - result is not changed
 
-- name: test absent subnetwork
+- name: Test delete
   hetzner.hcloud.hcloud_subnetwork:
     network: "{{ hcloud_network_name }}"
-    ip_range: "10.0.0.0/16"
-    type: "cloud"
-    network_zone: "eu-central"
+    network_zone: eu-central
+    type: cloud
+    ip_range: 10.0.0.0/24
     state: absent
   register: result
-- name: verify test absent subnetwork
-  assert:
+- name: Verify delete
+  ansible.builtin.assert:
     that:
       - result is changed
 
-- name: test vswitch subnetwork
+- name: Test create with vswitch
   hetzner.hcloud.hcloud_subnetwork:
     network: "{{ hcloud_network_name }}"
-    ip_range: "10.0.0.0/16"
-    type: "vswitch"
-    network_zone: "eu-central"
-    vswitch_id: "{{ hetzner_vswitch_id }}"
+    network_zone: eu-central
+    type: vswitch
+    ip_range: 10.0.1.0/24
+    vswitch_id: "{{ test_vswitch_id }}"
     state: present
-  register: subnet
-- name: verify test vswitch subnetwork
-  assert:
-    that:
-      - subnet is changed
-      - subnet.hcloud_subnetwork.network == "{{ hcloud_network_name }}"
-      - subnet.hcloud_subnetwork.ip_range == "10.0.0.0/16"
-      - subnet.hcloud_subnetwork.type == "vswitch"
-      - subnet.hcloud_subnetwork.network_zone == "eu-central"
-      - subnet.hcloud_subnetwork.vswitch_id == hetzner_vswitch_id
-
-- name: test absent subnetwork
-  hetzner.hcloud.hcloud_subnetwork:
-    network: "{{ hcloud_network_name }}"
-    ip_range: "10.0.0.0/16"
-    type: "vswitch"
-    network_zone: "eu-central"
-    vswitch_id: "{{ hetzner_vswitch_id }}"
-    state: absent
-  register: subnet
-- name: verify test absent subnetwork
-  assert:
+  register: result
+- name: Verify create with vswitch
+  ansible.builtin.assert:
     that:
       - result is changed
+      - result.hcloud_subnetwork.network == "{{ hcloud_network_name }}"
+      - result.hcloud_subnetwork.network_zone == "eu-central"
+      - result.hcloud_subnetwork.type == "vswitch"
+      - result.hcloud_subnetwork.ip_range == "10.0.1.0/24"
+      - result.hcloud_subnetwork.vswitch_id | string == test_vswitch_id
 
-- name: cleanup
-  hetzner.hcloud.hcloud_network:
-    name: "{{hcloud_network_name}}"
+- name: Test delete with vswitch
+  hetzner.hcloud.hcloud_subnetwork:
+    network: "{{ hcloud_network_name }}"
+    network_zone: eu-central
+    type: vswitch
+    ip_range: 10.0.1.0/24
     state: absent
-  register: result
-- name: verify cleanup
-  assert:
+  register: subnet
+- name: Verify delete with vswitch
+  ansible.builtin.assert:
     that:
-      - result is success
+      - result is changed

--- a/tests/utils/ci.sh
+++ b/tests/utils/ci.sh
@@ -36,7 +36,7 @@ test_group="${entry_point_args[3]:-}"
 export PYTHONIOENCODING="utf-8"
 export PIP_DISABLE_PIP_VERSION_CHECK=true
 export PIP_NO_WARN_SCRIPT_LOCATION=false # Negative options are a bit weird: https://pip.pypa.io/en/stable/topics/configuration/#boolean-options
-export ANSIBLE_COLLECTIONS_PATHS="$PWD/../.."
+export ANSIBLE_COLLECTIONS_PATH="$PWD/../.."
 
 command -v python
 python -V
@@ -82,7 +82,7 @@ fi
 pip install rstcheck
 
 # Ensure we can write other collections to this dir
-sudo chown "$(whoami)" "$ANSIBLE_COLLECTIONS_PATHS"
+sudo chown "$(whoami)" "$ANSIBLE_COLLECTIONS_PATH"
 
 pip install -r tests/integration/requirements.txt -c tests/constraints.txt
 ansible-galaxy -vvv collection install -r tests/requirements.yml

--- a/tests/utils/gitlab/gitlab.sh
+++ b/tests/utils/gitlab/gitlab.sh
@@ -44,10 +44,10 @@ if [ "${ansible_version}" == "devel" ]; then
 else
   retry pip install "https://github.com/ansible/ansible/archive/stable-${ansible_version}.tar.gz" --disable-pip-version-check
 fi
-export ANSIBLE_COLLECTIONS_PATHS="${HOME}/.ansible"
+export ANSIBLE_COLLECTIONS_PATH="${HOME}/.ansible"
 # shellcheck disable=SC2034
 SHIPPABLE_RESULT_DIR="$(pwd)/shippable"
-TEST_DIR="${ANSIBLE_COLLECTIONS_PATHS}/ansible_collections/hetzner/hcloud"
+TEST_DIR="${ANSIBLE_COLLECTIONS_PATH}/ansible_collections/hetzner/hcloud"
 rm -rf  "${TEST_DIR}"
 mkdir -p "${TEST_DIR}"
 cp -r "." "${TEST_DIR}"


### PR DESCRIPTION
##### SUMMARY

The vswitch subnet validation changed: the subnet ip_range must be smaller than the network ip_range **AND** must not start with the same IP.
 
See https://github.com/ansible-collections/hetzner.hcloud/runs/17672011247

In addition, I reworked the tests to use the new testing framework.