### PR TITLE
ci: reduce usage when pushing release-please updates

### DIFF
--- a/.azure-pipelines/azure-pipelines.yml
+++ b/.azure-pipelines/azure-pipelines.yml
@@ -5,6 +5,7 @@ trigger:
 
 pr:
   autoCancel: true
+  drafts: false
   branches:
     include: [main, stable-1]
 

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -24,6 +24,7 @@ jobs:
           release-type: simple
           package-name: hetzner.hcloud
           include-v-in-tag: false
+          draft-pull-request: true
 
           # We use antsibull-changelog for the actual user-facing changelog.
           changelog-path: changelogs/dev-changelog.md


### PR DESCRIPTION
##### SUMMARY

Disable azure pipelines for draft pull requests and ask release-please to create draft pull requests. This should reduce the amount of CI usage around the release please workflow.
