### PR TITLE
ci: force push antsibull-changelog changes

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -76,4 +76,4 @@ jobs:
           git add changelogs/ CHANGELOG.rst
           git commit -m "chore(main): changelog for version ${{ needs.release-please.outputs.version }}"
 
-          git push origin ${{ needs.release-please.outputs.branch }}
+          git push --force origin ${{ needs.release-please.outputs.branch }}

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -5,6 +5,10 @@ on:
 
 name: release-please
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   release-please:
     # The secret HCLOUD_BOT_TOKEN is only available on the main repo, not in forks.


### PR DESCRIPTION
##### SUMMARY

pre-commit.ci automatically pushes styling commit to the release please branch and might render the checkout in CI out of sync with the origin. This makes sure the release-please workflow does not fail by force pushing to the branch.