### PR TITLE
refactor: don't use ISO deprecated field

### DIFF
--- a/plugins/modules/hcloud_iso_info.py
+++ b/plugins/modules/hcloud_iso_info.py
@@ -148,7 +148,9 @@ class AnsibleHCloudIsoInfo(AnsibleHCloud):
                     "description": to_native(iso_info.description),
                     "type": iso_info.type,
                     "architecture": iso_info.architecture,
-                    "deprecated": iso_info.deprecated,
+                    "deprecated": (
+                        iso_info.deprecation.unavailable_after if iso_info.deprecation is not None else None
+                    ),
                     "deprecation": {
                         "announced": iso_info.deprecation.announced.isoformat(),
                         "unavailable_after": iso_info.deprecation.unavailable_after.isoformat(),


### PR DESCRIPTION
##### SUMMARY

The deprecated field is deprecated, we must use the deprecation object instead.

##### COMPONENT NAME

hcloud_iso_info