### PR TITLE
ci: pin python version to 3.11

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Setup python
         uses: actions/setup-python@v4
         with:
-          python-version: 3.x
+          python-version: "3.11"
           cache: pip
           cache-dependency-path: requirements.txt
 

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -53,7 +53,7 @@ jobs:
       - name: Setup python
         uses: actions/setup-python@v4
         with:
-          python-version: 3.x
+          python-version: "3.11"
       - name: Install dependencies
         run: pip install antsibull-changelog
 

--- a/.github/workflows/vendor.yml
+++ b/.github/workflows/vendor.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Setup python
         uses: actions/setup-python@v4
         with:
-          python-version: 3.x
+          python-version: "3.11"
 
       - name: Ensure vendors are not diverging
         run: make vendor-check


### PR DESCRIPTION
##### SUMMARY

This is an attempt to fix the linting job: https://github.com/ansible-collections/hetzner.hcloud/actions/runs/6692855477/job/18182866932

Run on python 3.11 until the following ticket is solved: https://github.com/aio-libs/aiohttp/issues/7675
