### PR TITLE
feat: add server_types to datacenter info module

### DIFF
--- a/changelogs/fragments/add-server_types-to-datacenter-info.yaml
+++ b/changelogs/fragments/add-server_types-to-datacenter-info.yaml
@@ -1,0 +1,2 @@
+minor_changes:
+  - hcloud_datacenter_info - Add `server_types` field

--- a/plugins/modules/hcloud_datacenter_info.py
+++ b/plugins/modules/hcloud_datacenter_info.py
@@ -72,6 +72,29 @@ hcloud_datacenter_info:
             returned: always
             type: str
             sample: fsn1
+        server_types:
+            description: The Server types the Datacenter can handle
+            returned: always
+            type: dict
+            contains:
+                available:
+                    description: IDs of Server types that are supported and for which the Datacenter has enough resources left
+                    returned: always
+                    type: list
+                    elements: int
+                    sample: [1, 2, 3]
+                available_for_migration:
+                    description: IDs of Server types that are supported and for which the Datacenter has enough resources left
+                    returned: always
+                    type: list
+                    elements: int
+                    sample: [1, 2, 3]
+                supported:
+                    description: IDs of Server types that are supported in the Datacenter
+                    returned: always
+                    type: list
+                    elements: int
+                    sample: [1, 2, 3]
 """
 
 from typing import List, Optional
@@ -93,15 +116,22 @@ class AnsibleHCloudDatacenterInfo(AnsibleHCloud):
         tmp = []
 
         for datacenter in self.hcloud_datacenter_info:
-            if datacenter is not None:
-                tmp.append(
-                    {
-                        "id": to_native(datacenter.id),
-                        "name": to_native(datacenter.name),
-                        "description": to_native(datacenter.description),
-                        "location": to_native(datacenter.location.name),
-                    }
-                )
+            if datacenter is None:
+                continue
+
+            tmp.append(
+                {
+                    "id": to_native(datacenter.id),
+                    "name": to_native(datacenter.name),
+                    "description": to_native(datacenter.description),
+                    "location": to_native(datacenter.location.name),
+                    "server_types": {
+                        "available": [o.id for o in datacenter.server_types.available],
+                        "available_for_migration": [o.id for o in datacenter.server_types.available_for_migration],
+                        "supported": [o.id for o in datacenter.server_types.supported],
+                    },
+                }
+            )
 
         return tmp
 

--- a/plugins/modules/hcloud_datacenter_info.py
+++ b/plugins/modules/hcloud_datacenter_info.py
@@ -35,9 +35,27 @@ EXAMPLES = """
 - name: Gather hcloud datacenter info
   hetzner.hcloud.hcloud_datacenter_info:
   register: output
+
 - name: Print the gathered info
   debug:
     var: output
+
+- name: List available server_types in a datacenter
+  block:
+    - name: Gather a hcloud datacenter
+      hetzner.hcloud.hcloud_datacenter_info:
+        name: fsn1-dc14
+      register: output
+
+    - name: Gather a hcloud datacenter available server_types
+      hetzner.hcloud.hcloud_server_type_info:
+        id: "{{ item }}"
+      loop: "{{ output.hcloud_datacenter_info[0].server_types.available }}"
+      register: available_server_types
+
+    - name: Print a hcloud datacenter available server_types
+      ansible.builtin.debug:
+        var: available_server_types.results | map(attribute='hcloud_server_type_info')
 """
 
 RETURN = """


### PR DESCRIPTION
##### SUMMARY

Closes #204 

Return the `server_types` dict when querying the datacenters.

##### ISSUE TYPE

- Feature Pull Request


##### COMPONENT NAME

 hcloud_datacenter_info
