### PR TITLE
chore: don't format changelogs files

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -25,6 +25,7 @@ repos:
     hooks:
       - id: prettier
         files: \.(md|ya?ml)$
+        exclude: ^changelogs/(dev-changelog\.md|changelog\.yaml)$
 
   - repo: https://github.com/asottile/pyupgrade
     rev: v3.15.0


### PR DESCRIPTION
pre-commit autofixes at slowing down the release process. Let's ignore the format of the changelog files.