### PR TITLE
docs: remove hcloud-python requirements from modules

### DIFF
--- a/plugins/inventory/hcloud.py
+++ b/plugins/inventory/hcloud.py
@@ -7,8 +7,8 @@ DOCUMENTATION = r"""
       - Lukas Kaemmerling (@lkaemmerling)
     short_description: Ansible dynamic inventory plugin for the Hetzner Cloud.
     requirements:
-        - python >= 3.5
-        - hcloud-python >= 1.0.0
+      - python-dateutil >= 2.7.5
+      - requests >=2.20
     description:
         - Reads inventories from the Hetzner Cloud API.
         - Uses a YAML configuration file that ends with hcloud.(yml|yaml).

--- a/plugins/modules/hcloud_floating_ip.py
+++ b/plugins/modules/hcloud_floating_ip.py
@@ -67,12 +67,8 @@ options:
         choices: [ absent, present ]
         type: str
 
-requirements:
-  - hcloud-python >= 1.6.0
-
 extends_documentation_fragment:
 - hetzner.hcloud.hcloud
-
 """
 
 EXAMPLES = """

--- a/plugins/modules/hcloud_load_balancer.py
+++ b/plugins/modules/hcloud_load_balancer.py
@@ -69,9 +69,6 @@ options:
         type: str
 extends_documentation_fragment:
 - hetzner.hcloud.hcloud
-
-requirements:
-  - hcloud-python >= 1.8.0
 """
 
 EXAMPLES = """

--- a/plugins/modules/hcloud_load_balancer_network.py
+++ b/plugins/modules/hcloud_load_balancer_network.py
@@ -39,12 +39,8 @@ options:
         choices: [ absent, present ]
         type: str
 
-requirements:
-  - hcloud-python >= 1.8.1
-
 extends_documentation_fragment:
 - hetzner.hcloud.hcloud
-
 """
 
 EXAMPLES = """

--- a/plugins/modules/hcloud_load_balancer_service.py
+++ b/plugins/modules/hcloud_load_balancer_service.py
@@ -133,9 +133,6 @@ options:
         type: str
 extends_documentation_fragment:
 - hetzner.hcloud.hcloud
-
-requirements:
-  - hcloud-python >= 1.8.1
 """
 
 EXAMPLES = """

--- a/plugins/modules/hcloud_load_balancer_target.py
+++ b/plugins/modules/hcloud_load_balancer_target.py
@@ -57,12 +57,8 @@ options:
         choices: [ absent, present ]
         type: str
 
-requirements:
-  - hcloud-python >= 1.8.1
-
 extends_documentation_fragment:
 - hetzner.hcloud.hcloud
-
 """
 
 EXAMPLES = """

--- a/plugins/modules/hcloud_network.py
+++ b/plugins/modules/hcloud_network.py
@@ -54,12 +54,8 @@ options:
         choices: [ absent, present ]
         type: str
 
-requirements:
-  - hcloud-python >= 1.3.0
-
 extends_documentation_fragment:
 - hetzner.hcloud.hcloud
-
 """
 
 EXAMPLES = """

--- a/plugins/modules/hcloud_placement_group.py
+++ b/plugins/modules/hcloud_placement_group.py
@@ -43,9 +43,6 @@ options:
         choices: [ absent, present ]
         type: str
 
-requirements:
-  - hcloud-python >= 1.15.0
-
 extends_documentation_fragment:
 - hetzner.hcloud.hcloud
 """

--- a/plugins/modules/hcloud_primary_ip.py
+++ b/plugins/modules/hcloud_primary_ip.py
@@ -59,12 +59,8 @@ options:
         choices: [ absent, present ]
         type: str
 
-requirements:
-  - hcloud-python >= 1.9.0
-
 extends_documentation_fragment:
 - hetzner.hcloud.hcloud
-
 """
 
 EXAMPLES = """

--- a/plugins/modules/hcloud_rdns.py
+++ b/plugins/modules/hcloud_rdns.py
@@ -51,12 +51,8 @@ options:
         choices: [ absent, present ]
         type: str
 
-requirements:
-  - hcloud-python >= 1.3.0
-
 extends_documentation_fragment:
 - hetzner.hcloud.hcloud
-
 """
 
 EXAMPLES = """

--- a/plugins/modules/hcloud_route.py
+++ b/plugins/modules/hcloud_route.py
@@ -40,12 +40,8 @@ options:
         choices: [ absent, present ]
         type: str
 
-requirements:
-  - hcloud-python >= 1.3.0
-
 extends_documentation_fragment:
 - hetzner.hcloud.hcloud
-
 """
 
 EXAMPLES = """

--- a/plugins/modules/hcloud_server_network.py
+++ b/plugins/modules/hcloud_server_network.py
@@ -44,12 +44,8 @@ options:
         choices: [ absent, present ]
         type: str
 
-requirements:
-  - hcloud-python >= 1.3.0
-
 extends_documentation_fragment:
 - hetzner.hcloud.hcloud
-
 """
 
 EXAMPLES = """

--- a/plugins/modules/hcloud_subnetwork.py
+++ b/plugins/modules/hcloud_subnetwork.py
@@ -51,12 +51,8 @@ options:
         choices: [ absent, present ]
         type: str
 
-requirements:
-  - hcloud-python >= 1.10.0
-
 extends_documentation_fragment:
 - hetzner.hcloud.hcloud
-
 """
 
 EXAMPLES = """


### PR DESCRIPTION
##### SUMMARY

Since we vendored the hcloud-python library, those requirements are not needed anymore.


##### ISSUE TYPE

- Docs Pull Request
