### PR TITLE
docs: add global docs using docsite

### DIFF
--- a/docs/docsite/extra-docs.yml
+++ b/docs/docsite/extra-docs.yml
@@ -1,0 +1,5 @@
+---
+sections:
+  - title: Authentication
+    toctree:
+      - authentication

--- a/docs/docsite/links.yml
+++ b/docs/docsite/links.yml
@@ -1,0 +1,10 @@
+---
+edit_on_github:
+  repository: ansible-collections/hetzner.hcloud
+  branch: main
+
+extra_links:
+  - description: Hetzner Cloud API Reference
+    url: https://docs.hetzner.cloud
+  - description: Hetzner Cloud API Changelog
+    url: https://docs.hetzner.cloud/changelog

--- a/docs/docsite/rst/authentification.rst
+++ b/docs/docsite/rst/authentification.rst
@@ -1,0 +1,26 @@
+Authentication
+==============
+
+To `authenticate the API call against the Hetzner Cloud API <https://docs.hetzner.cloud/#authentication>`_ when
+using the ``hetzner.hcloud`` collection, you can provide the API token by different means:
+
+You can pass the API token using an environment variable (recommended):
+
+.. code-block:: bash
+
+    export HCLOUD_TOKEN='LRK9DAWQ1ZAEFSrCNEEzLCUwhYX1U3g7wMg4dTlkkDC96fyDuyJ39nVbVjCKSDfj'
+
+    # Verify that your token is working
+    ansible -m hetzner.hcloud.location_info localhost
+
+Alternatively, you may provide the API token directly as module argument:
+
+.. code-block:: yaml
+
+    - name: Create server
+      hetzner.hcloud.server:
+        api_token: LRK9DAWQ1ZAEFSrCNEEzLCUwhYX1U3g7wMg4dTlkkDC96fyDuyJ39nVbVjCKSDfj
+        name: my-server
+        server_type: cx11
+        image: debian-12
+        state: present


### PR DESCRIPTION
##### SUMMARY

Add a global documentation for the collection. See the https://github.com/ansible-collections/collection_template and https://github.com/ansible-collections/amazon.aws/tree/main/docs/docsite for examples.

##### ISSUE TYPE

- Docs Pull Request

