### PR TITLE
feat: rename api_endpoint module argument

### DIFF
--- a/changelogs/fragments/improve-modules-api-arguments.yml
+++ b/changelogs/fragments/improve-modules-api-arguments.yml
@@ -1,0 +1,3 @@
+minor_changes:
+  - Renamed the `endpoint` module argument to `api_endpoint`, backward compatibility is maintained using an alias.
+  - Allow to set the `api_endpoint` module argument using the `HCLOUD_ENDPOINT` environment variable.

--- a/plugins/doc_fragments/hcloud.py
+++ b/plugins/doc_fragments/hcloud.py
@@ -7,20 +7,24 @@ class ModuleDocFragment:
 options:
   api_token:
     description:
-      - This is the API Token for the Hetzner Cloud.
-      - You can also set this option by using the environment variable HCLOUD_TOKEN
+      - The API Token for the Hetzner Cloud.
+      - You can also set this option by using the C(HCLOUD_TOKEN) environment variable.
     required: True
     type: str
-  endpoint:
+  api_endpoint:
     description:
-      - This is the API Endpoint for the Hetzner Cloud.
+      - The API Endpoint for the Hetzner Cloud.
+      - You can also set this option by using the C(HCLOUD_ENDPOINT) environment variable.
     default: https://api.hetzner.cloud/v1
     type: str
+    aliases: [endpoint]
+
 requirements:
   - python-dateutil >= 2.7.5
   - requests >=2.20
+
 seealso:
   - name: Documentation for Hetzner Cloud API
     description: Complete reference for the Hetzner Cloud API.
-    link: https://docs.hetzner.cloud/
+    link: https://docs.hetzner.cloud
 """

--- a/plugins/doc_fragments/hcloud.py
+++ b/plugins/doc_fragments/hcloud.py
@@ -5,22 +5,22 @@
 class ModuleDocFragment:
     DOCUMENTATION = """
 options:
-    api_token:
-        description:
-            - This is the API Token for the Hetzner Cloud.
-            - You can also set this option by using the environment variable HCLOUD_TOKEN
-        required: True
-        type: str
-    endpoint:
-        description:
-            - This is the API Endpoint for the Hetzner Cloud.
-        default: https://api.hetzner.cloud/v1
-        type: str
+  api_token:
+    description:
+      - This is the API Token for the Hetzner Cloud.
+      - You can also set this option by using the environment variable HCLOUD_TOKEN
+    required: True
+    type: str
+  endpoint:
+    description:
+      - This is the API Endpoint for the Hetzner Cloud.
+    default: https://api.hetzner.cloud/v1
+    type: str
 requirements:
   - python-dateutil >= 2.7.5
   - requests >=2.20
 seealso:
-- name: Documentation for Hetzner Cloud API
-  description: Complete reference for the Hetzner Cloud API.
-  link: https://docs.hetzner.cloud/
+  - name: Documentation for Hetzner Cloud API
+    description: Complete reference for the Hetzner Cloud API.
+    link: https://docs.hetzner.cloud/
 """

--- a/plugins/module_utils/hcloud.py
+++ b/plugins/module_utils/hcloud.py
@@ -86,7 +86,7 @@ class AnsibleHCloud:
     def _build_client(self) -> None:
         self.client = Client(
             token=self.module.params["api_token"],
-            api_endpoint=self.module.params["endpoint"],
+            api_endpoint=self.module.params["api_endpoint"],
             application_name="ansible-module",
             application_version=version,
         )
@@ -124,9 +124,11 @@ class AnsibleHCloud:
                 "fallback": (env_fallback, ["HCLOUD_TOKEN"]),
                 "no_log": True,
             },
-            "endpoint": {
+            "api_endpoint": {
                 "type": "str",
+                "fallback": (env_fallback, ["HCLOUD_ENDPOINT"]),
                 "default": "https://api.hetzner.cloud/v1",
+                "aliases": ["endpoint"],
             },
         }
 

--- a/tests/unit/module_utils/test_hcloud.py
+++ b/tests/unit/module_utils/test_hcloud.py
@@ -18,7 +18,7 @@ def test_hcloud_fail_json_hcloud():
     module = MagicMock()
     module.params = {
         "api_token": "fake_token",
-        "endpoint": "https://api.hetzner.cloud/v1",
+        "api_endpoint": "https://api.hetzner.cloud/v1",
     }
     AnsibleHCloud.represent = "hcloud_test"
     hcloud = AnsibleHCloud(module)


### PR DESCRIPTION
##### SUMMARY

Make the api endpoint module argument consistent with the api token. 
- Renamed the `endpoint` module argument to `api_endpoint`, backward compatibility is maintained using an alias.
- Allow to configure it using the `HCLOUD_ENDPOINT` env var.

This makes the inventory config and the modules config a bit more consistent.

##### ISSUE TYPE

- Feature Pull Request
