### PR TITLE
feat: add `hetzner.hcloud.all` action group

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -21,3 +21,6 @@ exclude_paths:
   - tests/integration/targets/volume
   - tests/integration/targets/setup_selfsigned_certificate
   - tests/integration/targets/setup_ssh_keypair
+
+warn_list:
+  - internal-error

--- a/changelogs/fragments/add-module-defaults-group-for-all-modules.yml
+++ b/changelogs/fragments/add-module-defaults-group-for-all-modules.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - Add the `hetzner.hcloud.all` group to configure all the modules using `module_defaults`.

--- a/docs/docsite/rst/authentification.rst
+++ b/docs/docsite/rst/authentification.rst
@@ -24,3 +24,25 @@ Alternatively, you may provide the API token directly as module argument:
         server_type: cx11
         image: debian-12
         state: present
+
+To reduce the duplication of the above solution, you may configure the
+``hetzner.hcloud.*`` modules using the ``hetzner.hcloud.all`` action group, for
+example if you want to store your API token in a vault:
+
+.. code-block:: yaml
+
+    - name: Demonstrate the usage of the 'hetzner.hcloud.all' module_defaults group
+      hosts: localhost
+      connection: local
+
+      module_defaults:
+        group/hetzner.hcloud.all:
+          api_token: "{{ _vault_hcloud_api_token }}"
+
+      tasks:
+        - name: Create server
+          hetzner.hcloud.server:
+            name: my-server
+            server_type: cx11
+            image: debian-12
+            state: present

--- a/examples/use-module-defaults-group.yml
+++ b/examples/use-module-defaults-group.yml
@@ -1,0 +1,27 @@
+---
+- name: Demonstrate the usage of the 'hetzner.hcloud.all' module_defaults group
+  hosts: localhost
+  connection: local
+
+  module_defaults:
+    group/hetzner.hcloud.all:
+      api_token: LRK9DAWQ1ZAEFSrCNEEzLCUwhYX1U3g7wMg4dTlkkDC96fyDuyJ39nVbVjCKSDfj
+
+  tasks:
+    - name: Create a volume
+      hetzner.hcloud.volume:
+        name: my-volume
+        location: fsn1
+        size: 100
+        state: present
+      register: volume
+
+    - name: Create a server
+      hetzner.hcloud.server:
+        name: my-server
+        server_type: cx11
+        image: debian-12
+        location: fsn1
+        volumes:
+          - "{{ volume.hcloud_volume.id }}"
+        state: present

--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -1,5 +1,39 @@
 requires_ansible: ">=2.13.0"
 
+action_groups:
+  all:
+    - certificate
+    - certificate_info
+    - datacenter_info
+    - firewall
+    - floating_ip
+    - floating_ip_info
+    - image_info
+    - iso_info
+    - load_balancer
+    - load_balancer_info
+    - load_balancer_network
+    - load_balancer_service
+    - load_balancer_target
+    - load_balancer_type_info
+    - location_info
+    - network
+    - network_info
+    - placement_group
+    - primary_ip
+    - primary_ip_info
+    - rdns
+    - route
+    - server
+    - server_info
+    - server_network
+    - server_type_info
+    - ssh_key
+    - ssh_key_info
+    - subnetwork
+    - volume
+    - volume_info
+
 plugin_routing:
   modules:
     hcloud_certificate_info:


### PR DESCRIPTION
##### SUMMARY

This allows to use `module_defaults` against all the modules at once using the new `hetzner.hcloud.all` `action_group`.

You can now pass the `api_token` argument using module_defaults:

```yaml
- name: Demonstrate the usage of the 'hetzner.hcloud.all' module_defaults group
  hosts: localhost
  connection: local

  module_defaults:
    group/hetzner.hcloud.all:
      api_token: "{{ _vault_hcloud_api_token }}"

  tasks:
    - name: Create a volume
      hetzner.hcloud.volume:
        name: my-volume
        location: fsn1
        size: 100
        state: present
      register: volume
```   

See the documentation and examples for more details.

##### ISSUE TYPE

- Feature Pull Request

