### PR TITLE
feat(inventory): improve api options

### DIFF
--- a/changelogs/fragments/improve-inventory-api-options.yml
+++ b/changelogs/fragments/improve-inventory-api-options.yml
@@ -1,0 +1,7 @@
+minor_changes:
+  - hcloud inventory - Rename the `token` option to `api_token`, use aliases for backward compatibility.
+  - hcloud inventory - Rename the `token_env` option to `api_token_env`, use aliases for backward compatibility.
+  - hcloud inventory - Add the `api_endpoint` option.
+  - hcloud inventory - Deprecate the `api_token_env` option, suggest using a lookup
+    plugin (`{{ lookup('ansible.builtin.env', 'YOUR_ENV_VAR') }}`) or use the
+    well-known `HCLOUD_TOKEN` environment variable name.

--- a/plugins/inventory/hcloud.py
+++ b/plugins/inventory/hcloud.py
@@ -35,7 +35,6 @@ options:
     aliases: [token]
     env:
       - name: HCLOUD_TOKEN
-      - name: I(api_token_env) # TODO: Remove once I(api_token_env) is removed.
   api_token_env:
     description:
       - Environment variable name to load the Hetzner Cloud API Token from.

--- a/plugins/inventory/hcloud.py
+++ b/plugins/inventory/hcloud.py
@@ -29,14 +29,15 @@ options:
   token:
     description: The Hetzner Cloud API Token.
     required: false
-  group:
-    description: The group all servers are automatically added to.
-    default: hcloud
-    type: str
-    required: false
   token_env:
     description: Environment variable to load the Hetzner Cloud API Token from.
     default: HCLOUD_TOKEN
+    type: str
+    required: false
+
+  group:
+    description: The group all servers are automatically added to.
+    default: hcloud
     type: str
     required: false
   connect_with:

--- a/plugins/inventory/hcloud.py
+++ b/plugins/inventory/hcloud.py
@@ -121,6 +121,7 @@ from ansible.errors import AnsibleError
 from ansible.inventory.manager import InventoryData
 from ansible.module_utils.common.text.converters import to_native
 from ansible.plugins.inventory import BaseInventoryPlugin, Cacheable, Constructable
+from ansible.utils.display import Display
 
 from ..module_utils.hcloud import HAS_DATEUTIL, HAS_REQUESTS
 from ..module_utils.vendor import hcloud
@@ -178,6 +179,9 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
     NAME = "hetzner.hcloud.hcloud"
 
     inventory: InventoryData
+    display: Display
+
+    client: hcloud.Client
 
     def _configure_hcloud_client(self):
         self.token_env = self.get_option("token_env")

--- a/plugins/inventory/hcloud.py
+++ b/plugins/inventory/hcloud.py
@@ -2,85 +2,90 @@
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 DOCUMENTATION = r"""
-    name: hcloud
-    author:
-      - Lukas Kaemmerling (@lkaemmerling)
-    short_description: Ansible dynamic inventory plugin for the Hetzner Cloud.
-    requirements:
-      - python-dateutil >= 2.7.5
-      - requests >=2.20
-    description:
-        - Reads inventories from the Hetzner Cloud API.
-        - Uses a YAML configuration file that ends with hcloud.(yml|yaml).
-    extends_documentation_fragment:
-        - constructed
-        - inventory_cache
-    options:
-        plugin:
-            description: marks this as an instance of the "hcloud" plugin
-            required: true
-            choices: ["hcloud", "hetzner.hcloud.hcloud"]
-        token:
-            description: The Hetzner Cloud API Token.
-            required: false
-        group:
-            description: The group all servers are automatically added to.
-            default: hcloud
-            type: str
-            required: false
-        token_env:
-            description: Environment variable to load the Hetzner Cloud API Token from.
-            default: HCLOUD_TOKEN
-            type: str
-            required: false
-        connect_with:
-            description: |
-              Connect to the server using the value from this field. This sets the `ansible_host`
-              variable to the value indicated, if that value is available. If you need further
-              customization, like falling back to private ipv4 if the server has no public ipv4,
-              you can use `compose` top-level key.
-            default: public_ipv4
-            type: str
-            choices:
-                - public_ipv4
-                - public_ipv6
-                - hostname
-                - ipv4_dns_ptr
-                - private_ipv4
-        locations:
-          description: Populate inventory with instances in this location.
-          default: []
-          type: list
-          elements: str
-          required: false
-        types:
-          description: Populate inventory with instances with this type.
-          default: []
-          type: list
-          elements: str
-          required: false
-        images:
-          description: Populate inventory with instances with this image name, only available for system images.
-          default: []
-          type: list
-          elements: str
-          required: false
-        label_selector:
-          description: Populate inventory with instances with this label.
-          default: ""
-          type: str
-          required: false
-        network:
-          description: Populate inventory with instances which are attached to this network name or ID.
-          default: ""
-          type: str
-          required: false
-        status:
-          description: Populate inventory with instances with this status.
-          default: []
-          type: list
-          elements: str
-          required: false
+name: hcloud
+short_description: Ansible dynamic inventory plugin for the Hetzner Cloud.
+
+description:
+  - Reads inventories from the Hetzner Cloud API.
+  - Uses a YAML configuration file that ends with hcloud.(yml|yaml).
+
+author:
+  - Lukas Kaemmerling (@lkaemmerling)
+
+requirements:
+  - python-dateutil >= 2.7.5
+  - requests >=2.20
+
+extends_documentation_fragment:
+  - constructed
+  - inventory_cache
+
+options:
+  plugin:
+    description: marks this as an instance of the "hcloud" plugin
+    required: true
+    choices: ["hcloud", "hetzner.hcloud.hcloud"]
+  token:
+    description: The Hetzner Cloud API Token.
+    required: false
+  group:
+    description: The group all servers are automatically added to.
+    default: hcloud
+    type: str
+    required: false
+  token_env:
+    description: Environment variable to load the Hetzner Cloud API Token from.
+    default: HCLOUD_TOKEN
+    type: str
+    required: false
+  connect_with:
+    description: |
+      Connect to the server using the value from this field. This sets the `ansible_host`
+      variable to the value indicated, if that value is available. If you need further
+      customization, like falling back to private ipv4 if the server has no public ipv4,
+      you can use `compose` top-level key.
+    default: public_ipv4
+    type: str
+    choices:
+      - public_ipv4
+      - public_ipv6
+      - hostname
+      - ipv4_dns_ptr
+      - private_ipv4
+  locations:
+    description: Populate inventory with instances in this location.
+    default: []
+    type: list
+    elements: str
+    required: false
+  types:
+    description: Populate inventory with instances with this type.
+    default: []
+    type: list
+    elements: str
+    required: false
+  images:
+    description: Populate inventory with instances with this image name, only available for system images.
+    default: []
+    type: list
+    elements: str
+    required: false
+  label_selector:
+    description: Populate inventory with instances with this label.
+    default: ""
+    type: str
+    required: false
+  network:
+    description: Populate inventory with instances which are attached to this network name or ID.
+    default: ""
+    type: str
+    required: false
+  status:
+    description: Populate inventory with instances with this status.
+    default: []
+    type: list
+    elements: str
+    required: false
 """
 
 EXAMPLES = r"""

--- a/plugins/inventory/hcloud.py
+++ b/plugins/inventory/hcloud.py
@@ -47,6 +47,14 @@ options:
       collection_name: hetzner.hcloud
       version: 3.0.0
       alternatives: Use the ``{{ lookup('ansible.builtin.env', 'YOUR_ENV_VAR') }}`` lookup instead.
+  api_endpoint:
+    description:
+      - The API Endpoint for the Hetzner Cloud.
+      - You can also set this option by using the C(HCLOUD_ENDPOINT) environment variable.
+    type: str
+    default: https://api.hetzner.cloud/v1
+    env:
+      - name: HCLOUD_ENDPOINT
 
   group:
     description: The group all servers are automatically added to.
@@ -211,7 +219,7 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
                 self.set_option("api_token", os.environ.get(api_token_env))
 
         api_token = self.get_option("api_token")
-        self.endpoint = os.getenv("HCLOUD_ENDPOINT") or "https://api.hetzner.cloud/v1"
+        api_endpoint = self.get_option("api_endpoint")
 
         if api_token is None:  # TODO: Remove once I(api_token_env) is removed.
             raise AnsibleError(
@@ -226,7 +234,7 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
 
         self.client = hcloud.Client(
             token=api_token,
-            api_endpoint=self.endpoint,
+            api_endpoint=api_endpoint,
             application_name="ansible-inventory",
             application_version=version,
         )

--- a/plugins/inventory/hcloud.py
+++ b/plugins/inventory/hcloud.py
@@ -204,13 +204,11 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
             application_version=version,
         )
 
-    def _test_hcloud_token(self):
         try:
-            # We test the API Token against the location API, because this is the API with the smallest result
-            # and not controllable from the customer.
-            self.client.locations.get_all()
-        except hcloud.APIException:
-            raise AnsibleError("Invalid Hetzner Cloud API Token.")
+            # Ensure the api token is valid
+            self.client.locations.get_list()
+        except hcloud.APIException as exception:
+            raise AnsibleError("Invalid Hetzner Cloud API Token.") from exception
 
     def _get_servers(self):
         if len(self.get_option("label_selector")) > 0:
@@ -400,7 +398,6 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
 
         self._read_config_data(path)
         self._configure_hcloud_client()
-        self._test_hcloud_token()
 
         self.servers, cached = self._get_cached_result(path, cache)
         if not cached:

--- a/plugins/inventory/hcloud.py
+++ b/plugins/inventory/hcloud.py
@@ -7,7 +7,7 @@ short_description: Ansible dynamic inventory plugin for the Hetzner Cloud.
 
 description:
   - Reads inventories from the Hetzner Cloud API.
-  - Uses a YAML configuration file that ends with hcloud.(yml|yaml).
+  - Uses a YAML configuration file that ends with C(hcloud.yml) or C(hcloud.yaml).
 
 author:
   - Lukas Kaemmerling (@lkaemmerling)
@@ -22,9 +22,10 @@ extends_documentation_fragment:
 
 options:
   plugin:
-    description: marks this as an instance of the "hcloud" plugin
+    description: Mark this as an C(hetzner.hcloud.hcloud) inventory instance.
     required: true
-    choices: ["hcloud", "hetzner.hcloud.hcloud"]
+    choices: [hcloud, hetzner.hcloud.hcloud]
+
   token:
     description: The Hetzner Cloud API Token.
     required: false
@@ -52,6 +53,7 @@ options:
       - hostname
       - ipv4_dns_ptr
       - private_ipv4
+
   locations:
     description: Populate inventory with instances in this location.
     default: []


### PR DESCRIPTION
##### SUMMARY

- Rename the inventory `token` option to `api_token`, use aliases for backward compatibility.
- Rename the inventory `token_env` option to `api_token_env`, use aliases for backward compatibility.
- Deprecate the inventory `api_token_env` option, suggest using a lookup plugin (`{{ lookup('ansible.builtin.env', 'YOUR_ENV_VAR') }}`) or use the well-known `HCLOUD_TOKEN` environment variable name.
- Let ansible parse the options, remove homemade options parsing.
- Improve and document the existing `api_endpoint` option.

##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME

hcloud inventory
