### PR TITLE
chore: add makefile ansible-test targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,3 +24,20 @@ lint-docs: venv
 clean:
 	git clean -xdf \
 		-e tests/integration/cloud-config-hcloud.ini
+
+sanity:
+	ansible-test sanity --color --truncate 0 -v \
+		--exclude plugins/module_utils/vendor/ \
+		--exclude scripts/ \
+		--exclude tests/utils/ \
+		--docker default \
+		--allow-disabled
+
+units:
+	ansible-test units --color --truncate 0 -v \
+		--docker default
+
+integration:
+	ansible-test integration --color --truncate 0 -v \
+		--docker default \
+		--allow-disabled


### PR DESCRIPTION
##### SUMMARY

This helps to run sanity/units/integrations tests locally.
