### PR TITLE
fix(inventory): always use fresh cache on new cached session

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -5,6 +5,7 @@ exclude_paths:
   - .git/
   - .github/
   - changelogs/
+  - examples/
   - tests/integration/targets/certificate
   - tests/integration/targets/firewall
   - tests/integration/targets/floating_ip

--- a/changelogs/fragments/fix-inventory-fresh-cache.yaml
+++ b/changelogs/fragments/fix-inventory-fresh-cache.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - hcloud inventory - Ensure the API client use a new cache for every *cached session*.

--- a/examples/use-refresh-inventory.yml
+++ b/examples/use-refresh-inventory.yml
@@ -1,0 +1,35 @@
+---
+- name: Demonstrate the usage of 'refresh_inventory'
+  hosts: localhost
+  connection: local
+
+  tasks:
+    - name: Print hostvars
+      ansible.builtin.debug:
+        var: hostvars
+
+    - name: Create new server
+      hetzner.hcloud.server:
+        name: my-server
+        server_type: cx11
+        image: debian-12
+
+    - name: Refresh inventory
+      ansible.builtin.meta: refresh_inventory
+
+    - name: Run tests
+      block:
+        - name: Print updated inventory
+          ansible.builtin.debug:
+            var: hostvars
+
+        - name: Verify hostvars is not empty
+          ansible.builtin.assert:
+            that:
+              - hostvars != {}
+
+      always:
+        - name: Cleanup server
+          hetzner.hcloud.server:
+            name: my-server
+            state: absent


### PR DESCRIPTION
##### SUMMARY

The class scoped `cache` dict was being shared across all `cached_session`, we now make sure that the cache is instance scoped.

Fixes #403

##### ISSUE TYPE

- Bugfix Pull Request

