### PR TITLE
feat: replace `ansible.netcommon` utils with python3 `ipaddress` module

### DIFF
--- a/changelogs/fragments/replace-deprecated-ansible.netcommon-with-python-ipaddress.yml
+++ b/changelogs/fragments/replace-deprecated-ansible.netcommon-with-python-ipaddress.yml
@@ -1,0 +1,4 @@
+minor_changes:
+  - >
+    Replace deprecated `ansible.netcommon` ip utils with python `ipaddress` module. The
+    `ansible.netcommon` collection is no longer required by the collections.

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -10,8 +10,6 @@ tags:
   - hetzner
   - cloud
   - hcloud
-dependencies:
-  ansible.netcommon: ">=0.0.1"
 repository: https://github.com/ansible-collections/hetzner.hcloud
 documentation: https://docs.ansible.com/ansible/latest/collections/hetzner/hcloud
 homepage: https://github.com/ansible-collections/hetzner.hcloud

--- a/tests/integration/targets/rdns/tasks/test.yml
+++ b/tests/integration/targets/rdns/tasks/test.yml
@@ -37,7 +37,7 @@
     that:
       - result is changed
       - result.hcloud_rdns.server == "{{ hcloud_server_name }}"
-      - result.hcloud_rdns.ip_address == "{{ test_server.hcloud_server.ipv6 | ansible.utils.ipaddr('next_usable') }}"
+      - result.hcloud_rdns.ip_address == test_server.hcloud_server.ipv6 | ansible.utils.ipaddr('next_usable')
       - result.hcloud_rdns.dns_ptr == "example.com"
 
 - name: Test create idempotency
@@ -77,7 +77,7 @@
   ansible.builtin.assert:
     that:
       - result is changed
-      - result.hcloud_rdns.ip_address == "{{ test_server.hcloud_server.ipv4_address }}"
+      - result.hcloud_rdns.ip_address == test_server.hcloud_server.ipv4_address
 
 - name: Test update reset
   hetzner.hcloud.rdns:
@@ -113,8 +113,8 @@
   ansible.builtin.assert:
     that:
       - result is changed
-      - result.hcloud_rdns.primary_ip == "{{ hcloud_primary_ip_name }}"
-      - result.hcloud_rdns.ip_address == "{{ test_primary_ip.hcloud_primary_ip.ip }}"
+      - result.hcloud_rdns.primary_ip == hcloud_primary_ip_name
+      - result.hcloud_rdns.ip_address == test_primary_ip.hcloud_primary_ip.ip
       - result.hcloud_rdns.dns_ptr == "example.com"
 
 - name: Test create with floating ip
@@ -128,8 +128,8 @@
   ansible.builtin.assert:
     that:
       - result is changed
-      - result.hcloud_rdns.floating_ip == "{{ hcloud_floating_ip_name }}"
-      - result.hcloud_rdns.ip_address == "{{ test_floating_ip.hcloud_floating_ip.ip }}"
+      - result.hcloud_rdns.floating_ip == hcloud_floating_ip_name
+      - result.hcloud_rdns.ip_address == test_floating_ip.hcloud_floating_ip.ip
       - result.hcloud_rdns.dns_ptr == "example.com"
 
 - name: Test create with load balancer
@@ -143,6 +143,6 @@
   ansible.builtin.assert:
     that:
       - result is changed
-      - result.hcloud_rdns.load_balancer == "{{ hcloud_load_balancer_name }}"
-      - result.hcloud_rdns.ip_address == "{{ test_load_balancer.hcloud_load_balancer.ipv4_address }}"
+      - result.hcloud_rdns.load_balancer == hcloud_load_balancer_name
+      - result.hcloud_rdns.ip_address == test_load_balancer.hcloud_load_balancer.ipv4_address
       - result.hcloud_rdns.dns_ptr == "example.com"

--- a/tests/integration/targets/rdns/tasks/test.yml
+++ b/tests/integration/targets/rdns/tasks/test.yml
@@ -15,7 +15,7 @@
 - name: Test create with checkmode
   hetzner.hcloud.rdns:
     server: "{{ hcloud_server_name }}"
-    ip_address: "{{ test_server.hcloud_server.ipv6 | ansible.netcommon.ipaddr('next_usable') }}"
+    ip_address: "{{ test_server.hcloud_server.ipv6 | ansible.utils.ipaddr('next_usable') }}"
     dns_ptr: example.com
     state: present
   check_mode: true
@@ -28,7 +28,7 @@
 - name: Test create
   hetzner.hcloud.rdns:
     server: "{{ hcloud_server_name }}"
-    ip_address: "{{ test_server.hcloud_server.ipv6 | ansible.netcommon.ipaddr('next_usable') }}"
+    ip_address: "{{ test_server.hcloud_server.ipv6 | ansible.utils.ipaddr('next_usable') }}"
     dns_ptr: example.com
     state: present
   register: result
@@ -37,13 +37,13 @@
     that:
       - result is changed
       - result.hcloud_rdns.server == "{{ hcloud_server_name }}"
-      - result.hcloud_rdns.ip_address == "{{ test_server.hcloud_server.ipv6 | ansible.netcommon.ipaddr('next_usable') }}"
+      - result.hcloud_rdns.ip_address == "{{ test_server.hcloud_server.ipv6 | ansible.utils.ipaddr('next_usable') }}"
       - result.hcloud_rdns.dns_ptr == "example.com"
 
 - name: Test create idempotency
   hetzner.hcloud.rdns:
     server: "{{ hcloud_server_name }}"
-    ip_address: "{{ test_server.hcloud_server.ipv6 | ansible.netcommon.ipaddr('next_usable') }}"
+    ip_address: "{{ test_server.hcloud_server.ipv6 | ansible.utils.ipaddr('next_usable') }}"
     dns_ptr: example.com
     state: present
   register: result
@@ -94,7 +94,7 @@
 - name: Test delete
   hetzner.hcloud.rdns:
     server: "{{ hcloud_server_name }}"
-    ip_address: "{{ test_server.hcloud_server.ipv6 | ansible.netcommon.ipaddr('next_usable') }}"
+    ip_address: "{{ test_server.hcloud_server.ipv6 | ansible.utils.ipaddr('next_usable') }}"
     state: absent
   register: result
 - name: Verify delete

--- a/tests/requirements.yml
+++ b/tests/requirements.yml
@@ -1,5 +1,5 @@
 ---
 collections:
-  - ansible.netcommon
+  - ansible.utils
   - community.crypto
   - community.general


### PR DESCRIPTION
##### SUMMARY

Replace `ansible.netcommon` deprecated ipaddr utils with python `ipaddress` module. The  `ansible.netcommon` collection is no longer required by the collections. We still use the `ansible.utils` collections for testing
