### PR TITLE
test: remove jinja templates where unnecessary

### DIFF
--- a/tests/integration/targets/certificate/tasks/test.yml
+++ b/tests/integration/targets/certificate/tasks/test.yml
@@ -37,7 +37,7 @@
   assert:
     that:
       - certificate is changed
-      - certificate.hcloud_certificate.name == "{{ hcloud_certificate_name }}"
+      - certificate.hcloud_certificate.name == hcloud_certificate_name
       - certificate.hcloud_certificate.domain_names[0] ==  "www.example.com"
       - certificate.hcloud_certificate.labels.key == "value"
 
@@ -110,7 +110,7 @@
   assert:
     that:
       - result is changed
-      - result.hcloud_certificate.name == "{{ hcloud_certificate_name }}"
+      - result.hcloud_certificate.name == hcloud_certificate_name
 
 - name: absent certificate
   hetzner.hcloud.certificate:
@@ -141,8 +141,8 @@
   assert:
     that:
       - result is changed
-      - result.hcloud_certificate.name == "{{ hcloud_certificate_name }}"
-      - result.hcloud_certificate.domain_names[0] == "{{ hcloud_dns_test_domain }}"
+      - result.hcloud_certificate.name == hcloud_certificate_name
+      - result.hcloud_certificate.domain_names[0] == hcloud_dns_test_domain
 
 - name: test delete certificate
   hetzner.hcloud.certificate:

--- a/tests/integration/targets/certificate_info/tasks/test.yml
+++ b/tests/integration/targets/certificate_info/tasks/test.yml
@@ -64,7 +64,7 @@
     that:
       - >
         result.hcloud_certificate_info
-        | selectattr('name', 'equalto', '{{ hcloud_certificate_name }}')
+        | selectattr('name', 'equalto', hcloud_certificate_name)
         | list | count == 1
 
 - name: Gather hcloud_certificate_info with wrong label selector

--- a/tests/integration/targets/firewall/tasks/test.yml
+++ b/tests/integration/targets/firewall/tasks/test.yml
@@ -44,7 +44,7 @@
   assert:
     that:
       - firewall is changed
-      - firewall.hcloud_firewall.name == "{{ hcloud_firewall_name }}"
+      - firewall.hcloud_firewall.name == hcloud_firewall_name
       - firewall.hcloud_firewall.rules | list | count == 1
       - firewall.hcloud_firewall.rules | selectattr('direction','equalto','in') | list | count == 1
       - firewall.hcloud_firewall.rules | selectattr('protocol','equalto','icmp') | list | count == 1
@@ -99,7 +99,7 @@
   assert:
     that:
       - firewall is changed
-      - firewall.hcloud_firewall.name == "{{ hcloud_firewall_name }}"
+      - firewall.hcloud_firewall.name == hcloud_firewall_name
       - firewall.hcloud_firewall.rules | list | count == 3
       - firewall.hcloud_firewall.rules | selectattr('direction','equalto','in') | list | count == 2
       - firewall.hcloud_firewall.rules | selectattr('direction','equalto','out') | list | count == 1
@@ -197,7 +197,7 @@
   assert:
     that:
       - result is changed
-      - result.hcloud_firewall.name == "{{ hcloud_firewall_name }}"
+      - result.hcloud_firewall.name == hcloud_firewall_name
 
 - name: absent firewall
   hetzner.hcloud.firewall:

--- a/tests/integration/targets/floating_ip/tasks/test.yml
+++ b/tests/integration/targets/floating_ip/tasks/test.yml
@@ -239,7 +239,7 @@
   assert:
     that:
       - floatingIP is changed
-      - floatingIP.hcloud_floating_ip.server != "{{ main_server.hcloud_server.name }}"
+      - floatingIP.hcloud_floating_ip.server != main_server.hcloud_server.name
 
 - name: test assign Floating IP
   hetzner.hcloud.floating_ip:
@@ -252,7 +252,7 @@
   assert:
     that:
       - floatingIP is changed
-      - floatingIP.hcloud_floating_ip.server == "{{ main_server.hcloud_server.name }}"
+      - floatingIP.hcloud_floating_ip.server == main_server.hcloud_server.name
 
 - name: test assign Floating IP idempotency
   hetzner.hcloud.floating_ip:
@@ -276,7 +276,7 @@
   assert:
     that:
       - floatingIP is changed
-      - floatingIP.hcloud_floating_ip.server != "{{ main_server.hcloud_server.name }}"
+      - floatingIP.hcloud_floating_ip.server != main_server.hcloud_server.name
 
 - name: test unassign Floating IP idempotency
   hetzner.hcloud.floating_ip:
@@ -299,7 +299,7 @@
   assert:
     that:
       - floatingIP is changed
-      - floatingIP.hcloud_floating_ip.server == "{{ main_server.hcloud_server.name }}"
+      - floatingIP.hcloud_floating_ip.server == main_server.hcloud_server.name
 
 - name: test already assigned Floating IP assign without force
   hetzner.hcloud.floating_ip:
@@ -311,7 +311,7 @@
   assert:
     that:
       - floatingIP is changed
-      - floatingIP.hcloud_floating_ip.server == "{{ main_server.hcloud_server.name }}"
+      - floatingIP.hcloud_floating_ip.server == main_server.hcloud_server.name
 
 - name: test already assigned Floating IP assign with force
   hetzner.hcloud.floating_ip:
@@ -324,7 +324,7 @@
   assert:
     that:
       - floatingIP is changed
-      - floatingIP.hcloud_floating_ip.server == "{{ main_server2.hcloud_server.name }}"
+      - floatingIP.hcloud_floating_ip.server == main_server2.hcloud_server.name
 
 - name: test update Floating IP delete protection
   hetzner.hcloud.floating_ip:

--- a/tests/integration/targets/floating_ip_info/tasks/test.yml
+++ b/tests/integration/targets/floating_ip_info/tasks/test.yml
@@ -64,7 +64,7 @@
     that:
       - >
         result.hcloud_floating_ip_info
-        | selectattr('name', 'equalto', '{{ hcloud_floating_ip_name }}')
+        | selectattr('name', 'equalto', hcloud_floating_ip_name)
         | list | count == 1
 
 - name: Gather hcloud_floating_ip_info with wrong label selector

--- a/tests/integration/targets/image_info/tasks/test.yml
+++ b/tests/integration/targets/image_info/tasks/test.yml
@@ -90,7 +90,7 @@
       # Snapshot names are stored in the description field
       - >
         result.hcloud_image_info
-        | selectattr('description', 'equalto', '{{ hcloud_snapshot_name }}')
+        | selectattr('description', 'equalto', hcloud_snapshot_name)
         | list | count == 1
 
 - name: Gather hcloud_image_info with wrong label selector

--- a/tests/integration/targets/iso_info/tasks/test.yml
+++ b/tests/integration/targets/iso_info/tasks/test.yml
@@ -26,7 +26,7 @@
   ansible.builtin.assert:
     that:
       - result.hcloud_iso_info | list | count == 1
-      - result.hcloud_iso_info[0].id == hcloud_iso_id
+      - result.hcloud_iso_info[0].id == hcloud_iso_id | string
       - result.hcloud_iso_info[0].name == hcloud_iso_name
       - result.hcloud_iso_info[0].architecture == hcloud_iso_architecture
       - result.hcloud_iso_info[0].type == hcloud_iso_type

--- a/tests/integration/targets/iso_info/tasks/test.yml
+++ b/tests/integration/targets/iso_info/tasks/test.yml
@@ -26,10 +26,10 @@
   ansible.builtin.assert:
     that:
       - result.hcloud_iso_info | list | count == 1
-      - result.hcloud_iso_info[0].id == "{{ hcloud_iso_id }}"
-      - result.hcloud_iso_info[0].name == "{{ hcloud_iso_name }}"
-      - result.hcloud_iso_info[0].architecture == "{{ hcloud_iso_architecture }}"
-      - result.hcloud_iso_info[0].type == "{{ hcloud_iso_type }}"
+      - result.hcloud_iso_info[0].id == hcloud_iso_id
+      - result.hcloud_iso_info[0].name == hcloud_iso_name
+      - result.hcloud_iso_info[0].architecture == hcloud_iso_architecture
+      - result.hcloud_iso_info[0].type == hcloud_iso_type
       - result.hcloud_iso_info[0].deprecated is none
       - result.hcloud_iso_info[0].deprecation is none
 

--- a/tests/integration/targets/load_balancer/tasks/test.yml
+++ b/tests/integration/targets/load_balancer/tasks/test.yml
@@ -40,7 +40,7 @@
   ansible.builtin.assert:
     that:
       - result is changed
-      - result.hcloud_load_balancer.name == "{{ hcloud_load_balancer_name }}"
+      - result.hcloud_load_balancer.name == hcloud_load_balancer_name
       - result.hcloud_load_balancer.load_balancer_type == "lb11"
       - result.hcloud_load_balancer.algorithm == "round_robin"
       - result.hcloud_load_balancer.labels.key == "value"

--- a/tests/integration/targets/load_balancer_info/tasks/test.yml
+++ b/tests/integration/targets/load_balancer_info/tasks/test.yml
@@ -28,7 +28,7 @@
       - result.hcloud_load_balancer_info | list | count == 1
       - result.hcloud_load_balancer_info[0].targets | list | count == 1
       - result.hcloud_load_balancer_info[0].targets | selectattr('type', 'equalto', 'server') | list | count == 1
-      - result.hcloud_load_balancer_info[0].targets | selectattr('server', 'equalto', '{{ hcloud_server_name }}') | list | count == 1
+      - result.hcloud_load_balancer_info[0].targets | selectattr('server', 'equalto', hcloud_server_name) | list | count == 1
       - result.hcloud_load_balancer_info[0].targets[0].health_status[0].listen_port == 80
       - result.hcloud_load_balancer_info[0].targets[0].health_status[0].status in ['healthy', 'unhealthy', 'unknown']
       - result.hcloud_load_balancer_info[0].services | list | count == 1
@@ -73,7 +73,7 @@
     that:
       - >
         result.hcloud_load_balancer_info
-        | selectattr('name', 'equalto', '{{ hcloud_load_balancer_name }}')
+        | selectattr('name', 'equalto', hcloud_load_balancer_name)
         | list | count == 1
 
 - name: Gather hcloud_load_balancer_info with wrong label selector

--- a/tests/integration/targets/network/tasks/test.yml
+++ b/tests/integration/targets/network/tasks/test.yml
@@ -40,7 +40,7 @@
   assert:
     that:
       - network is changed
-      - network.hcloud_network.name == "{{hcloud_network_name}}"
+      - network.hcloud_network.name == hcloud_network_name
       - network.hcloud_network.ip_range == "10.0.0.0/16"
 
 - name: test create Network idempotence
@@ -63,7 +63,7 @@
   assert:
     that:
       - network is changed
-      - network.hcloud_network.name == "{{hcloud_network_name_with_vswitch}}"
+      - network.hcloud_network.name == hcloud_network_name_with_vswitch
       - network.hcloud_network.ip_range == "10.0.0.0/16"
       - network.hcloud_network.expose_routes_to_vswitch is true
 

--- a/tests/integration/targets/network_info/tasks/test.yml
+++ b/tests/integration/targets/network_info/tasks/test.yml
@@ -66,7 +66,7 @@
     that:
       - >
         result.hcloud_network_info
-        | selectattr('name', 'equalto', '{{ hcloud_network_name }}')
+        | selectattr('name', 'equalto', hcloud_network_name)
         | list | count == 1
 
 - name: Gather hcloud_network_info with wrong label selector

--- a/tests/integration/targets/placement_group/tasks/test.yml
+++ b/tests/integration/targets/placement_group/tasks/test.yml
@@ -44,7 +44,7 @@
   assert:
     that:
       - placement_group is changed
-      - placement_group.hcloud_placement_group.name == "{{ hcloud_placement_group_name }}"
+      - placement_group.hcloud_placement_group.name == hcloud_placement_group_name
       - placement_group.hcloud_placement_group.type == "spread"
       - placement_group.hcloud_placement_group.servers | list | count == 0
 
@@ -75,7 +75,7 @@
   assert:
     that:
       - server is changed
-      - server.hcloud_server.placement_group == "{{ hcloud_placement_group_name }}"
+      - server.hcloud_server.placement_group == hcloud_placement_group_name
 
 - name: test remove server from placement group
   hetzner.hcloud.server:
@@ -100,7 +100,7 @@
   assert:
     that:
       - result is changed
-      - result.hcloud_server.placement_group == "{{ hcloud_placement_group_name }}"
+      - result.hcloud_server.placement_group == hcloud_placement_group_name
       - result.hcloud_server.status == "running"
 
 - name: test add server to placement group idempotence
@@ -114,7 +114,7 @@
   assert:
     that:
       - result is not changed
-      - result.hcloud_server.placement_group == "{{ hcloud_placement_group_name }}"
+      - result.hcloud_server.placement_group == hcloud_placement_group_name
       - result.hcloud_server.status == "running"
 
 - name: test update placement group with check mode

--- a/tests/integration/targets/primary_ip_info/tasks/test.yml
+++ b/tests/integration/targets/primary_ip_info/tasks/test.yml
@@ -64,7 +64,7 @@
     that:
       - >
         result.hcloud_primary_ip_info
-        | selectattr('name', 'equalto', '{{ hcloud_primary_ip_name }}')
+        | selectattr('name', 'equalto', hcloud_primary_ip_name)
         | list | count == 1
 
 - name: Gather hcloud_primary_ip_info with wrong label selector

--- a/tests/integration/targets/rdns/tasks/test.yml
+++ b/tests/integration/targets/rdns/tasks/test.yml
@@ -36,7 +36,7 @@
   ansible.builtin.assert:
     that:
       - result is changed
-      - result.hcloud_rdns.server == "{{ hcloud_server_name }}"
+      - result.hcloud_rdns.server == hcloud_server_name
       - result.hcloud_rdns.ip_address == test_server.hcloud_server.ipv6 | ansible.utils.ipaddr('next_usable')
       - result.hcloud_rdns.dns_ptr == "example.com"
 

--- a/tests/integration/targets/route/tasks/test.yml
+++ b/tests/integration/targets/route/tasks/test.yml
@@ -47,7 +47,7 @@
   assert:
     that:
       - route is changed
-      - route.hcloud_route.network == "{{ hcloud_network_name }}"
+      - route.hcloud_route.network == hcloud_network_name
       - route.hcloud_route.destination == "10.100.1.0/24"
       - route.hcloud_route.gateway == "10.0.1.1"
 

--- a/tests/integration/targets/server/tasks/test_basic.yml
+++ b/tests/integration/targets/server/tasks/test_basic.yml
@@ -23,7 +23,7 @@
   assert:
     that:
       - main_server is changed
-      - main_server.hcloud_server.name == "{{ hcloud_server_name }}"
+      - main_server.hcloud_server.name == hcloud_server_name
       - main_server.hcloud_server.server_type == "cx11"
       - main_server.hcloud_server.status == "running"
       - main_server.root_password != ""
@@ -368,7 +368,7 @@
   assert:
     that:
       - main_server is changed
-      - main_server.hcloud_server.name == "{{ hcloud_server_name }}"
+      - main_server.hcloud_server.name == hcloud_server_name
       - main_server.hcloud_server.server_type == "cx11"
       - main_server.hcloud_server.status == "running"
       - main_server.root_password != ""
@@ -450,7 +450,7 @@
   assert:
     that:
       - main_server is changed
-      - main_server.hcloud_server.name == "{{ hcloud_server_name }}"
+      - main_server.hcloud_server.name == hcloud_server_name
       - main_server.hcloud_server.server_type == "cx11"
       - main_server.hcloud_server.status == "running"
       - main_server.root_password != ""

--- a/tests/integration/targets/server_info/tasks/test.yml
+++ b/tests/integration/targets/server_info/tasks/test.yml
@@ -66,7 +66,7 @@
     that:
       - >
         result.hcloud_server_info
-        | selectattr('name', 'equalto', '{{ hcloud_server_name }}')
+        | selectattr('name', 'equalto', hcloud_server_name)
         | list | count == 1
 
 - name: Gather hcloud_server_info with wrong label selector

--- a/tests/integration/targets/ssh_key/tasks/test.yml
+++ b/tests/integration/targets/ssh_key/tasks/test.yml
@@ -35,8 +35,8 @@
   assert:
     that:
       - ssh_key is changed
-      - ssh_key.hcloud_ssh_key.name == "{{ hcloud_ssh_key_name }}"
-      - ssh_key.hcloud_ssh_key.public_key ==  "{{ test_ssh_keypair.public_key }}"
+      - ssh_key.hcloud_ssh_key.name == hcloud_ssh_key_name
+      - ssh_key.hcloud_ssh_key.public_key == test_ssh_keypair.public_key
       - ssh_key.hcloud_ssh_key.labels.key == "value"
 
 - name: test create ssh key idempotence
@@ -107,7 +107,7 @@
   assert:
     that:
       - result is changed
-      - result.hcloud_ssh_key.name == "{{ hcloud_ssh_key_name }}"
+      - result.hcloud_ssh_key.name == hcloud_ssh_key_name
 
 - name: test create server with ssh key
   hetzner.hcloud.server:

--- a/tests/integration/targets/ssh_key_info/tasks/test.yml
+++ b/tests/integration/targets/ssh_key_info/tasks/test.yml
@@ -64,7 +64,7 @@
     that:
       - >
         result.hcloud_ssh_key_info
-        | selectattr('name', 'equalto', '{{ hcloud_ssh_key_name }}')
+        | selectattr('name', 'equalto', hcloud_ssh_key_name)
         | list | count == 1
 
 - name: Gather hcloud_ssh_key_info with wrong label selector

--- a/tests/integration/targets/subnetwork/tasks/test.yml
+++ b/tests/integration/targets/subnetwork/tasks/test.yml
@@ -39,7 +39,7 @@
   ansible.builtin.assert:
     that:
       - result is changed
-      - result.hcloud_subnetwork.network == "{{ hcloud_network_name }}"
+      - result.hcloud_subnetwork.network == hcloud_network_name
       - result.hcloud_subnetwork.network_zone == "eu-central"
       - result.hcloud_subnetwork.type == "cloud"
       - result.hcloud_subnetwork.ip_range == "10.0.0.0/24"
@@ -83,7 +83,7 @@
   ansible.builtin.assert:
     that:
       - result is changed
-      - result.hcloud_subnetwork.network == "{{ hcloud_network_name }}"
+      - result.hcloud_subnetwork.network == hcloud_network_name
       - result.hcloud_subnetwork.network_zone == "eu-central"
       - result.hcloud_subnetwork.type == "vswitch"
       - result.hcloud_subnetwork.ip_range == "10.0.1.0/24"

--- a/tests/integration/targets/volume/tasks/test.yml
+++ b/tests/integration/targets/volume/tasks/test.yml
@@ -48,10 +48,10 @@
   assert:
     that:
       - volume is changed
-      - volume.hcloud_volume.name == "{{hcloud_volume_name}}"
+      - volume.hcloud_volume.name == hcloud_volume_name
       - volume.hcloud_volume.location == "fsn1"
       - volume.hcloud_volume.size == 10
-      - volume.hcloud_volume.server != "{{hcloud_server_name}}"
+      - volume.hcloud_volume.server != hcloud_server_name
       - volume.hcloud_volume.linux_device is defined
 
 - name: test create Volume idempotence
@@ -75,7 +75,7 @@
   assert:
     that:
       - volume is changed
-      - volume.hcloud_volume.server != "{{hcloud_server_name}}"
+      - volume.hcloud_volume.server != hcloud_server_name
 
 - name: test attach Volume
   hetzner.hcloud.volume:
@@ -86,7 +86,7 @@
   assert:
     that:
       - volume is changed
-      - volume.hcloud_volume.server == "{{hcloud_server_name}}"
+      - volume.hcloud_volume.server == hcloud_server_name
 
 - name: test attach Volume idempotence
   hetzner.hcloud.volume:
@@ -97,7 +97,7 @@
   assert:
     that:
       - volume is not changed
-      - volume.hcloud_volume.server == "{{hcloud_server_name}}"
+      - volume.hcloud_volume.server == hcloud_server_name
 
 - name: test detach Volume with checkmode
   hetzner.hcloud.volume:
@@ -108,7 +108,7 @@
   assert:
     that:
       - volume is changed
-      - volume.hcloud_volume.server == "{{hcloud_server_name}}"
+      - volume.hcloud_volume.server == hcloud_server_name
 
 - name: test detach Volume
   hetzner.hcloud.volume:
@@ -119,7 +119,7 @@
     that:
       - volume is changed
       - volume.hcloud_volume.location == "fsn1"
-      - volume.hcloud_volume.server != "{{hcloud_server_name}}"
+      - volume.hcloud_volume.server != hcloud_server_name
 
 - name: test update Volume label
   hetzner.hcloud.volume:

--- a/tests/integration/targets/volume_info/tasks/test.yml
+++ b/tests/integration/targets/volume_info/tasks/test.yml
@@ -26,7 +26,7 @@
   ansible.builtin.assert:
     that:
       - result.hcloud_volume_info | list | count == 1
-      - result.hcloud_volume_info[0].name == '{{ hcloud_volume_name }}'
+      - result.hcloud_volume_info[0].name == hcloud_volume_name
       - result.hcloud_volume_info[0].location == 'fsn1'
       - result.hcloud_volume_info[0].size == 10
       - result.hcloud_volume_info[0].linux_device is defined
@@ -68,7 +68,7 @@
     that:
       - >
         result.hcloud_volume_info
-        | selectattr('name', 'equalto', '{{ hcloud_volume_name }}')
+        | selectattr('name', 'equalto', hcloud_volume_name)
         | list | count == 1
 
 - name: Gather hcloud_volume_info with wrong label selector


### PR DESCRIPTION
Attempt to fix the unsafe condition by removing unnecessary jinja templates.

Example of failing CI: https://dev.azure.com/ansible/hetzner.hcloud/_build/results?buildId=98486&view=logs&j=86ea7956-35b6-5577-ed45-fe20f8c6b276&t=a2e51dbe-b8d9-5c65-a584-138300c332b7&l=2562