### PR TITLE
feat: add `hostvars_prefix` and `hostvars_suffix` options to inventory hostvars

### DIFF
--- a/changelogs/fragments/add-inventory-hostvars-prefix-and-suffix-option.yml
+++ b/changelogs/fragments/add-inventory-hostvars-prefix-and-suffix-option.yml
@@ -1,0 +1,4 @@
+minor_changes:
+  - >
+    inventory - Add `hostvars_prefix` and hostvars_suffix` options to customize the
+    inventory host variables keys.

--- a/plugins/inventory/hcloud.py
+++ b/plugins/inventory/hcloud.py
@@ -462,11 +462,12 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
             self.inventory.add_host(server["name"], group=self.get_option("group"))
             for key, value in server.items():
                 # Add hostvars prefix and suffix for variables coming from the Hetzner Cloud.
-                if hostvars_prefix or hostvars_suffix and key not in ("ansible_host",):
-                    if hostvars_prefix:
-                        key = hostvars_prefix + key
-                    if hostvars_suffix:
-                        key = key + hostvars_suffix
+                if hostvars_prefix or hostvars_suffix:
+                    if key not in ("ansible_host",):
+                        if hostvars_prefix:
+                            key = hostvars_prefix + key
+                        if hostvars_suffix:
+                            key = key + hostvars_suffix
 
                 self.inventory.set_variable(server["name"], key, value)
 

--- a/plugins/inventory/hcloud.py
+++ b/plugins/inventory/hcloud.py
@@ -111,6 +111,17 @@ options:
     type: list
     elements: str
     required: false
+
+  hostvars_prefix:
+    description:
+      - The prefix for host variables names coming from Hetzner Cloud.
+    type: str
+    version_added: 2.5.0
+  hostvars_suffix:
+    description:
+      - The suffix for host variables names coming from Hetzner Cloud.
+    type: str
+    version_added: 2.5.0
 """
 
 EXAMPLES = r"""
@@ -444,9 +455,17 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
         # Add a top group
         self.inventory.add_group(group=self.get_option("group"))
 
+        hostvars_prefix = self.get_option("hostvars_prefix")
+        hostvars_suffix = self.get_option("hostvars_suffix")
+
         for server in servers:
             self.inventory.add_host(server["name"], group=self.get_option("group"))
             for key, value in server.items():
+                if hostvars_prefix:
+                    key = hostvars_prefix + key
+                if hostvars_suffix:
+                    key = key + hostvars_suffix
+
                 self.inventory.set_variable(server["name"], key, value)
 
             # Use constructed if applicable

--- a/plugins/inventory/hcloud.py
+++ b/plugins/inventory/hcloud.py
@@ -461,10 +461,12 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
         for server in servers:
             self.inventory.add_host(server["name"], group=self.get_option("group"))
             for key, value in server.items():
-                if hostvars_prefix:
-                    key = hostvars_prefix + key
-                if hostvars_suffix:
-                    key = key + hostvars_suffix
+                # Add hostvars prefix and suffix for variables coming from the Hetzner Cloud.
+                if hostvars_prefix or hostvars_suffix and key not in ("ansible_host",):
+                    if hostvars_prefix:
+                        key = hostvars_prefix + key
+                    if hostvars_suffix:
+                        key = key + hostvars_suffix
 
                 self.inventory.set_variable(server["name"], key, value)
 


### PR DESCRIPTION
##### SUMMARY

Add `hostvars_prefix` and `hostvars_suffix` options to customize the inventory host variables keys.

For example, with `hostvars_prefix: hcloud_ `, the host vars will be stored as follows:
```json
{
    "_meta": {
        "hostvars": {
            "tmp": {
                "ansible_host": "65.109.169.27",
                "hcloud_architecture": "x86",
                "hcloud_datacenter": "hel1-dc2",
                "hcloud_id": 40573407,
                "hcloud_image_id": 114690387,
                "hcloud_image_name": "debian-12",
                "hcloud_image_os_flavor": "debian",
                "hcloud_ipv4": "65.109.169.27",
                "hcloud_ipv6_network_mask": "64",
                "hcloud_ipv6_network": "2a01:4f9:c012:4377::",
                "hcloud_ipv6": "2a01:4f9:c012:4377::1",
                "hcloud_labels": {},
                "hcloud_location": "hel1",
                "hcloud_name": "tmp",
                "hcloud_private_networks": [],
                "hcloud_server_type": "cx11",
                "hcloud_status": "running",
                "hcloud_type": "cx11"
            }
        }
    }
}
``` 

Related to #116
