### PR TITLE
test: fix linting error for integrations setup roles

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -20,8 +20,6 @@ exclude_paths:
   - tests/integration/targets/server_network
   - tests/integration/targets/ssh_key
   - tests/integration/targets/volume
-  - tests/integration/targets/setup_selfsigned_certificate
-  - tests/integration/targets/setup_ssh_keypair
 
 warn_list:
   - internal-error

--- a/tests/integration/targets/setup_selfsigned_certificate/tasks/main.yml
+++ b/tests/integration/targets/setup_selfsigned_certificate/tasks/main.yml
@@ -30,6 +30,6 @@
   register: _certificate_file
 
 - name: Save certificate files content
-  set_fact:
+  ansible.builtin.set_fact:
     test_certificate_privatekey_content: "{{ _certificate_privatekey_file.privatekey }}"
     test_certificate_content: "{{ _certificate_file.certificate }}"

--- a/tests/integration/targets/setup_ssh_keypair/tasks/main.yml
+++ b/tests/integration/targets/setup_ssh_keypair/tasks/main.yml
@@ -4,6 +4,7 @@
   ansible.builtin.file:
     state: directory
     path: ~/tmp
+    mode: "0755"
 
 - name: Create temporary file for test_ssh_keypair
   ansible.builtin.tempfile:


### PR DESCRIPTION
##### SUMMARY

Fix ansible lint error for the integrations setup roles.
