### PR TITLE
ci: run vendor script on hcloud-python update

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -8,5 +8,15 @@
       "datasourceTemplate": "pypi",
       "depNameTemplate": "hcloud"
     }
+  ],
+  "packageRules": [
+    {
+      "matchDepNames": ["hcloud"],
+      "postUpgradeTasks": {
+        "commands": ["python3 scripts/vendor.py"],
+        "fileFilters": ["plugins/module_utils/vendor/**"],
+        "executionMode": "branch"
+      }
+    }
   ]
 }


### PR DESCRIPTION
##### SUMMARY

Should reduce manual action to update the hcloud-python vendor files updates, such as https://github.com/ansible-collections/hetzner.hcloud/pull/430
