### PR TITLE
chore: enable docs rstcheck

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,6 @@ lint-docs: venv
 	venv/bin/antsibull-docs lint-collection-docs \
 		--plugin-docs \
 		--validate-collection-refs self \
-		--skip-rstcheck \
 		.
 
 clean:


### PR DESCRIPTION
This should catch more RST errors.