### PR TITLE
feat: allow forcing the deletion of firewalls that are still in use

### DIFF
--- a/changelogs/fragments/fix-firewall-deletion.yml
+++ b/changelogs/fragments/fix-firewall-deletion.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - firewall - Do not silence 'firewall still in use' deletions errors.

--- a/changelogs/fragments/fix-firewall-deletion.yml
+++ b/changelogs/fragments/fix-firewall-deletion.yml
@@ -1,3 +1,3 @@
 minor_changes:
-  - firewall - Do not silence 'firewall still in use' deletions errors.
-  - firewall - Allow forcing the deletion of a firewall that is still in use.
+  - firewall - Do not silence 'firewall still in use' delete failures.
+  - firewall - Allow forcing the deletion of firewalls that are still in use.

--- a/changelogs/fragments/fix-firewall-deletion.yml
+++ b/changelogs/fragments/fix-firewall-deletion.yml
@@ -1,2 +1,3 @@
 minor_changes:
   - firewall - Do not silence 'firewall still in use' deletions errors.
+  - firewall - Allow forcing the deletion of a firewall that is still in use.

--- a/plugins/modules/firewall.py
+++ b/plugins/modules/firewall.py
@@ -351,18 +351,19 @@ class AnsibleHCloudFirewall(AnsibleHCloud):
         if self.hcloud_firewall is not None:
             if not self.module.check_mode:
                 retry_count = 0
-                while retry_count < 10:
+                while True:
                     try:
-                        self.client.firewalls.delete(self.hcloud_firewall)
+                        self.hcloud_firewall.delete()
                         break
                     except APIException as exception:
-                        if "is still in use" in exception.message:
-                            retry_count = retry_count + 1
+                        if "is still in use" in exception.message and retry_count < 10:
+                            retry_count += 1
                             time.sleep(0.5 * retry_count)
-                        else:
-                            self.fail_json_hcloud(exception)
+                            continue
+                        self.fail_json_hcloud(exception)
                     except HCloudException as exception:
                         self.fail_json_hcloud(exception)
+
             self._mark_as_changed()
         self.hcloud_firewall = None
 

--- a/tests/integration/targets/firewall/defaults/main/main.yml
+++ b/tests/integration/targets/firewall/defaults/main/main.yml
@@ -2,3 +2,4 @@
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 ---
 hcloud_firewall_name: "{{ hcloud_ns }}"
+hcloud_server_name: "{{ hcloud_ns }}"

--- a/tests/integration/targets/firewall/tasks/cleanup.yml
+++ b/tests/integration/targets/firewall/tasks/cleanup.yml
@@ -1,4 +1,9 @@
 ---
+- name: Cleanup test_server
+  hetzner.hcloud.server:
+    name: "{{ hcloud_server_name }}"
+    state: absent
+
 - name: Cleanup test_firewall
   hetzner.hcloud.firewall:
     name: "{{ hcloud_firewall_name }}"

--- a/tests/integration/targets/firewall/tasks/prepare.yml
+++ b/tests/integration/targets/firewall/tasks/prepare.yml
@@ -1,0 +1,8 @@
+---
+- name: Create test_server
+  hetzner.hcloud.server:
+    name: "{{ hcloud_server_name }}"
+    server_type: cx11
+    image: ubuntu-22.04
+    state: stopped
+  register: test_server

--- a/tests/integration/targets/firewall/tasks/test.yml
+++ b/tests/integration/targets/firewall/tasks/test.yml
@@ -156,7 +156,7 @@
   ansible.builtin.assert:
     that:
       - result is changed
-      - result.hcloud_firewall.name == "changed-{{ hcloud_firewall_name }}"
+      - result.hcloud_firewall.name == "changed-" + hcloud_firewall_name
 
 - name: Test update name and labels
   hetzner.hcloud.firewall:

--- a/tests/integration/targets/firewall/tasks/test.yml
+++ b/tests/integration/targets/firewall/tasks/test.yml
@@ -184,3 +184,14 @@
     that:
       - result is failed
       - '"is still in use" in result.msg'
+
+- name: Test delete with force
+  hetzner.hcloud.firewall:
+    name: "{{ hcloud_firewall_name }}"
+    force: true
+    state: absent
+  register: result
+- name: Verify delete with force
+  ansible.builtin.assert:
+    that:
+      - result is changed

--- a/tests/integration/targets/firewall/tasks/test.yml
+++ b/tests/integration/targets/firewall/tasks/test.yml
@@ -69,6 +69,12 @@
     that:
       - result is not changed
 
+- name: Assign firewall to test_server
+  hetzner.hcloud.firewall_resource:
+    firewall: "{{ hcloud_firewall_name }}"
+    servers: ["{{ test_server.hcloud_server.name }}"]
+    state: present
+
 - name: Test update
   hetzner.hcloud.firewall:
     name: "{{ hcloud_firewall_name }}"
@@ -171,8 +177,10 @@
   hetzner.hcloud.firewall:
     name: "{{ hcloud_firewall_name }}"
     state: absent
+  ignore_errors: true
   register: result
 - name: Verify delete
   ansible.builtin.assert:
     that:
-      - result is changed
+      - result is failed
+      - '"is still in use" in result.msg'


### PR DESCRIPTION
##### SUMMARY

  - Do not silence 'firewall still in use' deletions errors.
  - Allow forcing the deletion of a firewall that is still in use.

Fixes #380

##### ISSUE TYPE

- Feature Pull Request


##### COMPONENT NAME

firewall

