### PR TITLE
fix: allow renaming networks

### DIFF
--- a/changelogs/fragments/allow-renaming-networks.yml
+++ b/changelogs/fragments/allow-renaming-networks.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - network - Allow renaming networks.

--- a/plugins/modules/network.py
+++ b/plugins/modules/network.py
@@ -173,6 +173,13 @@ class AnsibleHCloudNetwork(AnsibleHCloud):
 
     def _update_network(self):
         try:
+            name = self.module.params.get("name")
+            if name is not None and self.hcloud_network.name != name:
+                self.module.fail_on_missing_params(required_params=["id"])
+                if not self.module.check_mode:
+                    self.hcloud_network.update(name=name)
+                self._mark_as_changed()
+
             labels = self.module.params.get("labels")
             if labels is not None and labels != self.hcloud_network.labels:
                 if not self.module.check_mode:


### PR DESCRIPTION
##### SUMMARY

The network could not be renamed before. This was discovered while working on #448 

##### ISSUE TYPE


- Feature Pull Request


##### COMPONENT NAME

network
