### PR TITLE
fix: load balancer invalid cookie lifetime value returned

### DIFF
--- a/changelogs/fragments/fix-load-balancer-cookie-lifetime.yml
+++ b/changelogs/fragments/fix-load-balancer-cookie-lifetime.yml
@@ -1,0 +1,3 @@
+bugfixes:
+  - load_balancer_service - Correctly return the `cookie_lifetime` value.
+  - load_balancer_info - Correctly return the `cookie_lifetime` value.

--- a/plugins/modules/load_balancer_info.py
+++ b/plugins/modules/load_balancer_info.py
@@ -281,7 +281,11 @@ from ansible.module_utils.common.text.converters import to_native
 
 from ..module_utils.hcloud import AnsibleHCloud
 from ..module_utils.vendor.hcloud import HCloudException
-from ..module_utils.vendor.hcloud.load_balancers import BoundLoadBalancer
+from ..module_utils.vendor.hcloud.load_balancers import (
+    BoundLoadBalancer,
+    LoadBalancerService,
+    LoadBalancerTarget,
+)
 
 
 class AnsibleHCloudLoadBalancerInfo(AnsibleHCloud):
@@ -319,12 +323,12 @@ class AnsibleHCloudLoadBalancerInfo(AnsibleHCloud):
         return tmp
 
     @staticmethod
-    def _prepare_service_result(service):
+    def _prepare_service_result(service: LoadBalancerService):
         http = None
         if service.protocol != "tcp":
             http = {
                 "cookie_name": to_native(service.http.cookie_name),
-                "cookie_lifetime": service.http.cookie_name,
+                "cookie_lifetime": service.http.cookie_lifetime,
                 "redirect_http": service.http.redirect_http,
                 "sticky_sessions": service.http.sticky_sessions,
                 "certificates": [to_native(certificate.name) for certificate in service.http.certificates],
@@ -354,7 +358,7 @@ class AnsibleHCloudLoadBalancerInfo(AnsibleHCloud):
         }
 
     @staticmethod
-    def _prepare_target_result(target):
+    def _prepare_target_result(target: LoadBalancerTarget):
         result = {
             "type": to_native(target.type),
             "use_private_ip": target.use_private_ip,

--- a/plugins/modules/load_balancer_service.py
+++ b/plugins/modules/load_balancer_service.py
@@ -303,7 +303,7 @@ class AnsibleHCloudLoadBalancerService(AnsibleHCloud):
         if self.hcloud_load_balancer_service.protocol != "tcp":
             http = {
                 "cookie_name": to_native(self.hcloud_load_balancer_service.http.cookie_name),
-                "cookie_lifetime": self.hcloud_load_balancer_service.http.cookie_name,
+                "cookie_lifetime": self.hcloud_load_balancer_service.http.cookie_lifetime,
                 "redirect_http": self.hcloud_load_balancer_service.http.redirect_http,
                 "sticky_sessions": self.hcloud_load_balancer_service.http.sticky_sessions,
                 "certificates": [


### PR DESCRIPTION
##### SUMMARY

The load balancer cookie lifetime field now returns the cookie lifetime value, instead of the cookie name.

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

load_balancer_info
load_balancer_service
