### PR TITLE
fix!: always return iso-8601 formatted date time

### DIFF
--- a/changelogs/fragments/fix-always-return-iso-8601-formatted-datetime.yml
+++ b/changelogs/fragments/fix-always-return-iso-8601-formatted-datetime.yml
@@ -1,0 +1,4 @@
+breaking_changes:
+  - certificate_info - The `not_valid_before` and `not_valid_after` values are now returned as ISO-8601 formatted strings.
+  - certificate - The `not_valid_before` and `not_valid_after` values are now returned as ISO-8601 formatted strings.
+  - iso_info - The `deprecated` value is now returned as ISO-8601 formatted strings.

--- a/plugins/modules/certificate.py
+++ b/plugins/modules/certificate.py
@@ -165,8 +165,8 @@ class AnsibleHCloudCertificate(AnsibleHCloud):
             "type": to_native(self.hcloud_certificate.type),
             "fingerprint": to_native(self.hcloud_certificate.fingerprint),
             "certificate": to_native(self.hcloud_certificate.certificate),
-            "not_valid_before": to_native(self.hcloud_certificate.not_valid_before),
-            "not_valid_after": to_native(self.hcloud_certificate.not_valid_after),
+            "not_valid_before": to_native(self.hcloud_certificate.not_valid_before.isoformat()),
+            "not_valid_after": to_native(self.hcloud_certificate.not_valid_after.isoformat()),
             "domain_names": [to_native(domain) for domain in self.hcloud_certificate.domain_names],
             "labels": self.hcloud_certificate.labels,
         }

--- a/plugins/modules/certificate_info.py
+++ b/plugins/modules/certificate_info.py
@@ -110,8 +110,8 @@ class AnsibleHCloudCertificateInfo(AnsibleHCloud):
                         "name": to_native(certificate.name),
                         "fingerprint": to_native(certificate.fingerprint),
                         "certificate": to_native(certificate.certificate),
-                        "not_valid_before": to_native(certificate.not_valid_before),
-                        "not_valid_after": to_native(certificate.not_valid_after),
+                        "not_valid_before": to_native(certificate.not_valid_before.isoformat()),
+                        "not_valid_after": to_native(certificate.not_valid_after.isoformat()),
                         "domain_names": [to_native(domain) for domain in certificate.domain_names],
                         "labels": certificate.labels,
                     }

--- a/plugins/modules/iso_info.py
+++ b/plugins/modules/iso_info.py
@@ -149,7 +149,7 @@ class AnsibleHCloudIsoInfo(AnsibleHCloud):
                     "type": iso_info.type,
                     "architecture": iso_info.architecture,
                     "deprecated": (
-                        iso_info.deprecation.unavailable_after if iso_info.deprecation is not None else None
+                        iso_info.deprecation.unavailable_after.isoformat() if iso_info.deprecation is not None else None
                     ),
                     "deprecation": (
                         {


### PR DESCRIPTION
##### SUMMARY

Fixes #91

Always return datetime as iso-8601 formatted strings.


##### ISSUE TYPE

- Bugfix Pull Request

