### PR TITLE
feat!: remove inventory `api_token_env` option

### DIFF
--- a/changelogs/fragments/remove-inventory-api_token_env-option.yml
+++ b/changelogs/fragments/remove-inventory-api_token_env-option.yml
@@ -1,0 +1,2 @@
+breaking_changes:
+  - inventory - Remove the deprecated `api_token_env` option, you may use the `ansible.builtin.env` lookup as alternative.


### PR DESCRIPTION
##### SUMMARY

Remove the previously deprecated `api_token_env` to fully leverage the ansible inventory options loader.

##### ISSUE TYPE

- Feature Pull Request


##### COMPONENT NAME

inventory
