### PR TITLE
feat(inventory): allow templating instances hostname

### DIFF
--- a/changelogs/fragments/add-inventory-hostname-option.yml
+++ b/changelogs/fragments/add-inventory-hostname-option.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - inventory - Add `hostname` option used to template the hostname of the instances.


### PR DESCRIPTION
##### SUMMARY

Adds a `hostname` option that allow the user to pass a template to add a prefix or use the hostvars to build the hostname.

For example:
```yml
plugin: hetzner.hcloud.hcloud

hostname: "hcloud-{{ location }}-{{ name }}"
```

OR with a hostvars_prefix:
```yml
plugin: hetzner.hcloud.hcloud

hostvars_prefix: hcloud_
hostname: "hcloud-{{ hcloud_location }}-{{ hcloud_name }}"
```

Fixes #115

##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME

inventory

