### PR TITLE
test: use longer role namespace to prevent collision

### DIFF
--- a/tests/integration/common/defaults/main/common.yml
+++ b/tests/integration/common/defaults/main/common.yml
@@ -5,5 +5,5 @@ hcloud_prefix: "tests"
 
 # Used to namespace resources created by concurrent test pipelines/targets
 hcloud_run_ns: "{{ hcloud_prefix | md5 }}"
-hcloud_role_ns: "{{ role_name | split('_') | map('first') | join() }}"
+hcloud_role_ns: "{{ role_name | split('_') | map('batch', 2) | map('first') | flatten() | join() }}"
 hcloud_ns: "ansible-{{ hcloud_run_ns }}-{{ hcloud_role_ns }}"

--- a/tests/integration/targets/certificate/defaults/main/common.yml
+++ b/tests/integration/targets/certificate/defaults/main/common.yml
@@ -8,5 +8,5 @@ hcloud_prefix: "tests"
 
 # Used to namespace resources created by concurrent test pipelines/targets
 hcloud_run_ns: "{{ hcloud_prefix | md5 }}"
-hcloud_role_ns: "{{ role_name | split('_') | map('first') | join() }}"
+hcloud_role_ns: "{{ role_name | split('_') | map('batch', 2) | map('first') | flatten() | join() }}"
 hcloud_ns: "ansible-{{ hcloud_run_ns }}-{{ hcloud_role_ns }}"

--- a/tests/integration/targets/certificate_info/defaults/main/common.yml
+++ b/tests/integration/targets/certificate_info/defaults/main/common.yml
@@ -8,5 +8,5 @@ hcloud_prefix: "tests"
 
 # Used to namespace resources created by concurrent test pipelines/targets
 hcloud_run_ns: "{{ hcloud_prefix | md5 }}"
-hcloud_role_ns: "{{ role_name | split('_') | map('first') | join() }}"
+hcloud_role_ns: "{{ role_name | split('_') | map('batch', 2) | map('first') | flatten() | join() }}"
 hcloud_ns: "ansible-{{ hcloud_run_ns }}-{{ hcloud_role_ns }}"

--- a/tests/integration/targets/datacenter_info/defaults/main/common.yml
+++ b/tests/integration/targets/datacenter_info/defaults/main/common.yml
@@ -8,5 +8,5 @@ hcloud_prefix: "tests"
 
 # Used to namespace resources created by concurrent test pipelines/targets
 hcloud_run_ns: "{{ hcloud_prefix | md5 }}"
-hcloud_role_ns: "{{ role_name | split('_') | map('first') | join() }}"
+hcloud_role_ns: "{{ role_name | split('_') | map('batch', 2) | map('first') | flatten() | join() }}"
 hcloud_ns: "ansible-{{ hcloud_run_ns }}-{{ hcloud_role_ns }}"

--- a/tests/integration/targets/firewall/defaults/main/common.yml
+++ b/tests/integration/targets/firewall/defaults/main/common.yml
@@ -8,5 +8,5 @@ hcloud_prefix: "tests"
 
 # Used to namespace resources created by concurrent test pipelines/targets
 hcloud_run_ns: "{{ hcloud_prefix | md5 }}"
-hcloud_role_ns: "{{ role_name | split('_') | map('first') | join() }}"
+hcloud_role_ns: "{{ role_name | split('_') | map('batch', 2) | map('first') | flatten() | join() }}"
 hcloud_ns: "ansible-{{ hcloud_run_ns }}-{{ hcloud_role_ns }}"

--- a/tests/integration/targets/firewall_info/aliases
+++ b/tests/integration/targets/firewall_info/aliases
@@ -1,2 +1,2 @@
 cloud/hcloud
-shippable/hcloud/group2
+azp/group2

--- a/tests/integration/targets/firewall_info/defaults/main/common.yml
+++ b/tests/integration/targets/firewall_info/defaults/main/common.yml
@@ -8,5 +8,5 @@ hcloud_prefix: "tests"
 
 # Used to namespace resources created by concurrent test pipelines/targets
 hcloud_run_ns: "{{ hcloud_prefix | md5 }}"
-hcloud_role_ns: "{{ role_name | split('_') | map('first') | join() }}"
+hcloud_role_ns: "{{ role_name | split('_') | map('batch', 2) | map('first') | flatten() | join() }}"
 hcloud_ns: "ansible-{{ hcloud_run_ns }}-{{ hcloud_role_ns }}"

--- a/tests/integration/targets/firewall_resource/aliases
+++ b/tests/integration/targets/firewall_resource/aliases
@@ -1,2 +1,2 @@
 cloud/hcloud
-azp/group2
+azp/group1

--- a/tests/integration/targets/firewall_resource/defaults/main/common.yml
+++ b/tests/integration/targets/firewall_resource/defaults/main/common.yml
@@ -8,5 +8,5 @@ hcloud_prefix: "tests"
 
 # Used to namespace resources created by concurrent test pipelines/targets
 hcloud_run_ns: "{{ hcloud_prefix | md5 }}"
-hcloud_role_ns: "{{ role_name | split('_') | map('first') | join() }}"
+hcloud_role_ns: "{{ role_name | split('_') | map('batch', 2) | map('first') | flatten() | join() }}"
 hcloud_ns: "ansible-{{ hcloud_run_ns }}-{{ hcloud_role_ns }}"

--- a/tests/integration/targets/floating_ip/defaults/main/common.yml
+++ b/tests/integration/targets/floating_ip/defaults/main/common.yml
@@ -8,5 +8,5 @@ hcloud_prefix: "tests"
 
 # Used to namespace resources created by concurrent test pipelines/targets
 hcloud_run_ns: "{{ hcloud_prefix | md5 }}"
-hcloud_role_ns: "{{ role_name | split('_') | map('first') | join() }}"
+hcloud_role_ns: "{{ role_name | split('_') | map('batch', 2) | map('first') | flatten() | join() }}"
 hcloud_ns: "ansible-{{ hcloud_run_ns }}-{{ hcloud_role_ns }}"

--- a/tests/integration/targets/floating_ip_info/defaults/main/common.yml
+++ b/tests/integration/targets/floating_ip_info/defaults/main/common.yml
@@ -8,5 +8,5 @@ hcloud_prefix: "tests"
 
 # Used to namespace resources created by concurrent test pipelines/targets
 hcloud_run_ns: "{{ hcloud_prefix | md5 }}"
-hcloud_role_ns: "{{ role_name | split('_') | map('first') | join() }}"
+hcloud_role_ns: "{{ role_name | split('_') | map('batch', 2) | map('first') | flatten() | join() }}"
 hcloud_ns: "ansible-{{ hcloud_run_ns }}-{{ hcloud_role_ns }}"

--- a/tests/integration/targets/image_info/defaults/main/common.yml
+++ b/tests/integration/targets/image_info/defaults/main/common.yml
@@ -8,5 +8,5 @@ hcloud_prefix: "tests"
 
 # Used to namespace resources created by concurrent test pipelines/targets
 hcloud_run_ns: "{{ hcloud_prefix | md5 }}"
-hcloud_role_ns: "{{ role_name | split('_') | map('first') | join() }}"
+hcloud_role_ns: "{{ role_name | split('_') | map('batch', 2) | map('first') | flatten() | join() }}"
 hcloud_ns: "ansible-{{ hcloud_run_ns }}-{{ hcloud_role_ns }}"

--- a/tests/integration/targets/iso_info/defaults/main/common.yml
+++ b/tests/integration/targets/iso_info/defaults/main/common.yml
@@ -8,5 +8,5 @@ hcloud_prefix: "tests"
 
 # Used to namespace resources created by concurrent test pipelines/targets
 hcloud_run_ns: "{{ hcloud_prefix | md5 }}"
-hcloud_role_ns: "{{ role_name | split('_') | map('first') | join() }}"
+hcloud_role_ns: "{{ role_name | split('_') | map('batch', 2) | map('first') | flatten() | join() }}"
 hcloud_ns: "ansible-{{ hcloud_run_ns }}-{{ hcloud_role_ns }}"

--- a/tests/integration/targets/load_balancer/defaults/main/common.yml
+++ b/tests/integration/targets/load_balancer/defaults/main/common.yml
@@ -8,5 +8,5 @@ hcloud_prefix: "tests"
 
 # Used to namespace resources created by concurrent test pipelines/targets
 hcloud_run_ns: "{{ hcloud_prefix | md5 }}"
-hcloud_role_ns: "{{ role_name | split('_') | map('first') | join() }}"
+hcloud_role_ns: "{{ role_name | split('_') | map('batch', 2) | map('first') | flatten() | join() }}"
 hcloud_ns: "ansible-{{ hcloud_run_ns }}-{{ hcloud_role_ns }}"

--- a/tests/integration/targets/load_balancer_info/defaults/main/common.yml
+++ b/tests/integration/targets/load_balancer_info/defaults/main/common.yml
@@ -8,5 +8,5 @@ hcloud_prefix: "tests"
 
 # Used to namespace resources created by concurrent test pipelines/targets
 hcloud_run_ns: "{{ hcloud_prefix | md5 }}"
-hcloud_role_ns: "{{ role_name | split('_') | map('first') | join() }}"
+hcloud_role_ns: "{{ role_name | split('_') | map('batch', 2) | map('first') | flatten() | join() }}"
 hcloud_ns: "ansible-{{ hcloud_run_ns }}-{{ hcloud_role_ns }}"

--- a/tests/integration/targets/load_balancer_network/defaults/main/common.yml
+++ b/tests/integration/targets/load_balancer_network/defaults/main/common.yml
@@ -8,5 +8,5 @@ hcloud_prefix: "tests"
 
 # Used to namespace resources created by concurrent test pipelines/targets
 hcloud_run_ns: "{{ hcloud_prefix | md5 }}"
-hcloud_role_ns: "{{ role_name | split('_') | map('first') | join() }}"
+hcloud_role_ns: "{{ role_name | split('_') | map('batch', 2) | map('first') | flatten() | join() }}"
 hcloud_ns: "ansible-{{ hcloud_run_ns }}-{{ hcloud_role_ns }}"

--- a/tests/integration/targets/load_balancer_service/defaults/main/common.yml
+++ b/tests/integration/targets/load_balancer_service/defaults/main/common.yml
@@ -8,5 +8,5 @@ hcloud_prefix: "tests"
 
 # Used to namespace resources created by concurrent test pipelines/targets
 hcloud_run_ns: "{{ hcloud_prefix | md5 }}"
-hcloud_role_ns: "{{ role_name | split('_') | map('first') | join() }}"
+hcloud_role_ns: "{{ role_name | split('_') | map('batch', 2) | map('first') | flatten() | join() }}"
 hcloud_ns: "ansible-{{ hcloud_run_ns }}-{{ hcloud_role_ns }}"

--- a/tests/integration/targets/load_balancer_target/defaults/main/common.yml
+++ b/tests/integration/targets/load_balancer_target/defaults/main/common.yml
@@ -8,5 +8,5 @@ hcloud_prefix: "tests"
 
 # Used to namespace resources created by concurrent test pipelines/targets
 hcloud_run_ns: "{{ hcloud_prefix | md5 }}"
-hcloud_role_ns: "{{ role_name | split('_') | map('first') | join() }}"
+hcloud_role_ns: "{{ role_name | split('_') | map('batch', 2) | map('first') | flatten() | join() }}"
 hcloud_ns: "ansible-{{ hcloud_run_ns }}-{{ hcloud_role_ns }}"

--- a/tests/integration/targets/load_balancer_type_info/defaults/main/common.yml
+++ b/tests/integration/targets/load_balancer_type_info/defaults/main/common.yml
@@ -8,5 +8,5 @@ hcloud_prefix: "tests"
 
 # Used to namespace resources created by concurrent test pipelines/targets
 hcloud_run_ns: "{{ hcloud_prefix | md5 }}"
-hcloud_role_ns: "{{ role_name | split('_') | map('first') | join() }}"
+hcloud_role_ns: "{{ role_name | split('_') | map('batch', 2) | map('first') | flatten() | join() }}"
 hcloud_ns: "ansible-{{ hcloud_run_ns }}-{{ hcloud_role_ns }}"

--- a/tests/integration/targets/location_info/defaults/main/common.yml
+++ b/tests/integration/targets/location_info/defaults/main/common.yml
@@ -8,5 +8,5 @@ hcloud_prefix: "tests"
 
 # Used to namespace resources created by concurrent test pipelines/targets
 hcloud_run_ns: "{{ hcloud_prefix | md5 }}"
-hcloud_role_ns: "{{ role_name | split('_') | map('first') | join() }}"
+hcloud_role_ns: "{{ role_name | split('_') | map('batch', 2) | map('first') | flatten() | join() }}"
 hcloud_ns: "ansible-{{ hcloud_run_ns }}-{{ hcloud_role_ns }}"

--- a/tests/integration/targets/network/defaults/main/common.yml
+++ b/tests/integration/targets/network/defaults/main/common.yml
@@ -8,5 +8,5 @@ hcloud_prefix: "tests"
 
 # Used to namespace resources created by concurrent test pipelines/targets
 hcloud_run_ns: "{{ hcloud_prefix | md5 }}"
-hcloud_role_ns: "{{ role_name | split('_') | map('first') | join() }}"
+hcloud_role_ns: "{{ role_name | split('_') | map('batch', 2) | map('first') | flatten() | join() }}"
 hcloud_ns: "ansible-{{ hcloud_run_ns }}-{{ hcloud_role_ns }}"

--- a/tests/integration/targets/network_info/defaults/main/common.yml
+++ b/tests/integration/targets/network_info/defaults/main/common.yml
@@ -8,5 +8,5 @@ hcloud_prefix: "tests"
 
 # Used to namespace resources created by concurrent test pipelines/targets
 hcloud_run_ns: "{{ hcloud_prefix | md5 }}"
-hcloud_role_ns: "{{ role_name | split('_') | map('first') | join() }}"
+hcloud_role_ns: "{{ role_name | split('_') | map('batch', 2) | map('first') | flatten() | join() }}"
 hcloud_ns: "ansible-{{ hcloud_run_ns }}-{{ hcloud_role_ns }}"

--- a/tests/integration/targets/placement_group/defaults/main/common.yml
+++ b/tests/integration/targets/placement_group/defaults/main/common.yml
@@ -8,5 +8,5 @@ hcloud_prefix: "tests"
 
 # Used to namespace resources created by concurrent test pipelines/targets
 hcloud_run_ns: "{{ hcloud_prefix | md5 }}"
-hcloud_role_ns: "{{ role_name | split('_') | map('first') | join() }}"
+hcloud_role_ns: "{{ role_name | split('_') | map('batch', 2) | map('first') | flatten() | join() }}"
 hcloud_ns: "ansible-{{ hcloud_run_ns }}-{{ hcloud_role_ns }}"

--- a/tests/integration/targets/primary_ip/defaults/main/common.yml
+++ b/tests/integration/targets/primary_ip/defaults/main/common.yml
@@ -8,5 +8,5 @@ hcloud_prefix: "tests"
 
 # Used to namespace resources created by concurrent test pipelines/targets
 hcloud_run_ns: "{{ hcloud_prefix | md5 }}"
-hcloud_role_ns: "{{ role_name | split('_') | map('first') | join() }}"
+hcloud_role_ns: "{{ role_name | split('_') | map('batch', 2) | map('first') | flatten() | join() }}"
 hcloud_ns: "ansible-{{ hcloud_run_ns }}-{{ hcloud_role_ns }}"

--- a/tests/integration/targets/primary_ip_info/defaults/main/common.yml
+++ b/tests/integration/targets/primary_ip_info/defaults/main/common.yml
@@ -8,5 +8,5 @@ hcloud_prefix: "tests"
 
 # Used to namespace resources created by concurrent test pipelines/targets
 hcloud_run_ns: "{{ hcloud_prefix | md5 }}"
-hcloud_role_ns: "{{ role_name | split('_') | map('first') | join() }}"
+hcloud_role_ns: "{{ role_name | split('_') | map('batch', 2) | map('first') | flatten() | join() }}"
 hcloud_ns: "ansible-{{ hcloud_run_ns }}-{{ hcloud_role_ns }}"

--- a/tests/integration/targets/rdns/defaults/main/common.yml
+++ b/tests/integration/targets/rdns/defaults/main/common.yml
@@ -8,5 +8,5 @@ hcloud_prefix: "tests"
 
 # Used to namespace resources created by concurrent test pipelines/targets
 hcloud_run_ns: "{{ hcloud_prefix | md5 }}"
-hcloud_role_ns: "{{ role_name | split('_') | map('first') | join() }}"
+hcloud_role_ns: "{{ role_name | split('_') | map('batch', 2) | map('first') | flatten() | join() }}"
 hcloud_ns: "ansible-{{ hcloud_run_ns }}-{{ hcloud_role_ns }}"

--- a/tests/integration/targets/route/defaults/main/common.yml
+++ b/tests/integration/targets/route/defaults/main/common.yml
@@ -8,5 +8,5 @@ hcloud_prefix: "tests"
 
 # Used to namespace resources created by concurrent test pipelines/targets
 hcloud_run_ns: "{{ hcloud_prefix | md5 }}"
-hcloud_role_ns: "{{ role_name | split('_') | map('first') | join() }}"
+hcloud_role_ns: "{{ role_name | split('_') | map('batch', 2) | map('first') | flatten() | join() }}"
 hcloud_ns: "ansible-{{ hcloud_run_ns }}-{{ hcloud_role_ns }}"

--- a/tests/integration/targets/server/defaults/main/common.yml
+++ b/tests/integration/targets/server/defaults/main/common.yml
@@ -8,5 +8,5 @@ hcloud_prefix: "tests"
 
 # Used to namespace resources created by concurrent test pipelines/targets
 hcloud_run_ns: "{{ hcloud_prefix | md5 }}"
-hcloud_role_ns: "{{ role_name | split('_') | map('first') | join() }}"
+hcloud_role_ns: "{{ role_name | split('_') | map('batch', 2) | map('first') | flatten() | join() }}"
 hcloud_ns: "ansible-{{ hcloud_run_ns }}-{{ hcloud_role_ns }}"

--- a/tests/integration/targets/server_info/defaults/main/common.yml
+++ b/tests/integration/targets/server_info/defaults/main/common.yml
@@ -8,5 +8,5 @@ hcloud_prefix: "tests"
 
 # Used to namespace resources created by concurrent test pipelines/targets
 hcloud_run_ns: "{{ hcloud_prefix | md5 }}"
-hcloud_role_ns: "{{ role_name | split('_') | map('first') | join() }}"
+hcloud_role_ns: "{{ role_name | split('_') | map('batch', 2) | map('first') | flatten() | join() }}"
 hcloud_ns: "ansible-{{ hcloud_run_ns }}-{{ hcloud_role_ns }}"

--- a/tests/integration/targets/server_network/defaults/main/common.yml
+++ b/tests/integration/targets/server_network/defaults/main/common.yml
@@ -8,5 +8,5 @@ hcloud_prefix: "tests"
 
 # Used to namespace resources created by concurrent test pipelines/targets
 hcloud_run_ns: "{{ hcloud_prefix | md5 }}"
-hcloud_role_ns: "{{ role_name | split('_') | map('first') | join() }}"
+hcloud_role_ns: "{{ role_name | split('_') | map('batch', 2) | map('first') | flatten() | join() }}"
 hcloud_ns: "ansible-{{ hcloud_run_ns }}-{{ hcloud_role_ns }}"

--- a/tests/integration/targets/server_type_info/defaults/main/common.yml
+++ b/tests/integration/targets/server_type_info/defaults/main/common.yml
@@ -8,5 +8,5 @@ hcloud_prefix: "tests"
 
 # Used to namespace resources created by concurrent test pipelines/targets
 hcloud_run_ns: "{{ hcloud_prefix | md5 }}"
-hcloud_role_ns: "{{ role_name | split('_') | map('first') | join() }}"
+hcloud_role_ns: "{{ role_name | split('_') | map('batch', 2) | map('first') | flatten() | join() }}"
 hcloud_ns: "ansible-{{ hcloud_run_ns }}-{{ hcloud_role_ns }}"

--- a/tests/integration/targets/ssh_key/defaults/main/common.yml
+++ b/tests/integration/targets/ssh_key/defaults/main/common.yml
@@ -8,5 +8,5 @@ hcloud_prefix: "tests"
 
 # Used to namespace resources created by concurrent test pipelines/targets
 hcloud_run_ns: "{{ hcloud_prefix | md5 }}"
-hcloud_role_ns: "{{ role_name | split('_') | map('first') | join() }}"
+hcloud_role_ns: "{{ role_name | split('_') | map('batch', 2) | map('first') | flatten() | join() }}"
 hcloud_ns: "ansible-{{ hcloud_run_ns }}-{{ hcloud_role_ns }}"

--- a/tests/integration/targets/ssh_key_info/defaults/main/common.yml
+++ b/tests/integration/targets/ssh_key_info/defaults/main/common.yml
@@ -8,5 +8,5 @@ hcloud_prefix: "tests"
 
 # Used to namespace resources created by concurrent test pipelines/targets
 hcloud_run_ns: "{{ hcloud_prefix | md5 }}"
-hcloud_role_ns: "{{ role_name | split('_') | map('first') | join() }}"
+hcloud_role_ns: "{{ role_name | split('_') | map('batch', 2) | map('first') | flatten() | join() }}"
 hcloud_ns: "ansible-{{ hcloud_run_ns }}-{{ hcloud_role_ns }}"

--- a/tests/integration/targets/subnetwork/defaults/main/common.yml
+++ b/tests/integration/targets/subnetwork/defaults/main/common.yml
@@ -8,5 +8,5 @@ hcloud_prefix: "tests"
 
 # Used to namespace resources created by concurrent test pipelines/targets
 hcloud_run_ns: "{{ hcloud_prefix | md5 }}"
-hcloud_role_ns: "{{ role_name | split('_') | map('first') | join() }}"
+hcloud_role_ns: "{{ role_name | split('_') | map('batch', 2) | map('first') | flatten() | join() }}"
 hcloud_ns: "ansible-{{ hcloud_run_ns }}-{{ hcloud_role_ns }}"

--- a/tests/integration/targets/volume/defaults/main/common.yml
+++ b/tests/integration/targets/volume/defaults/main/common.yml
@@ -8,5 +8,5 @@ hcloud_prefix: "tests"
 
 # Used to namespace resources created by concurrent test pipelines/targets
 hcloud_run_ns: "{{ hcloud_prefix | md5 }}"
-hcloud_role_ns: "{{ role_name | split('_') | map('first') | join() }}"
+hcloud_role_ns: "{{ role_name | split('_') | map('batch', 2) | map('first') | flatten() | join() }}"
 hcloud_ns: "ansible-{{ hcloud_run_ns }}-{{ hcloud_role_ns }}"

--- a/tests/integration/targets/volume_info/defaults/main/common.yml
+++ b/tests/integration/targets/volume_info/defaults/main/common.yml
@@ -8,5 +8,5 @@ hcloud_prefix: "tests"
 
 # Used to namespace resources created by concurrent test pipelines/targets
 hcloud_run_ns: "{{ hcloud_prefix | md5 }}"
-hcloud_role_ns: "{{ role_name | split('_') | map('first') | join() }}"
+hcloud_role_ns: "{{ role_name | split('_') | map('batch', 2) | map('first') | flatten() | join() }}"
 hcloud_ns: "ansible-{{ hcloud_run_ns }}-{{ hcloud_role_ns }}"


### PR DESCRIPTION
##### SUMMARY

Use bigger roles namespace, by using the first 2 chars of each word: `load_balancer_network` => `lobane`

For example, we have such cases:
- `rdns` => `r` => `rd`
- `route` => `r` => `ro`
