### PR TITLE
chore: add dev target helper

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,8 @@
 SHELL := bash
-.PHONY: vendor clean
+.PHONY: vendor clean dev
+
+dev:
+	cat tests/integration/cloud-config-hcloud.ini.in | envsubst > tests/integration/cloud-config-hcloud.ini
 
 vendor:
 	python3 scripts/vendor.py
@@ -21,8 +24,7 @@ lint-docs: venv
 		.
 
 clean:
-	git clean -xdf \
-		-e tests/integration/cloud-config-hcloud.ini
+	git clean -xdf
 
 sanity:
 	ansible-test sanity --color --truncate 0 -v \

--- a/tests/integration/cloud-config-hcloud.ini.in
+++ b/tests/integration/cloud-config-hcloud.ini.in
@@ -1,0 +1,2 @@
+[default]
+hcloud_api_token=$HCLOUD_TOKEN


### PR DESCRIPTION
##### SUMMARY

Adds a helper to configure the dev env. For example reexporting a hcloud_token and reload the integration tests configuration:
```bash
export HCLOUD_TOKEN="$(get-tmp-hcloud-token)"
make dev
```
