### PR TITLE
refactor: remove unneeded `to_native` calls

### DIFF
--- a/plugins/inventory/hcloud.py
+++ b/plugins/inventory/hcloud.py
@@ -336,43 +336,43 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
     def _build_inventory_server(self, server: Server) -> InventoryServer:
         server_dict: InventoryServer = {}
         server_dict["id"] = server.id
-        server_dict["name"] = to_native(server.name)
-        server_dict["status"] = to_native(server.status)
+        server_dict["name"] = server.name
+        server_dict["status"] = server.status
 
         # Server Type
-        server_dict["type"] = to_native(server.server_type.name)
-        server_dict["server_type"] = to_native(server.server_type.name)
-        server_dict["architecture"] = to_native(server.server_type.architecture)
+        server_dict["type"] = server.server_type.name
+        server_dict["server_type"] = server.server_type.name
+        server_dict["architecture"] = server.server_type.architecture
 
         # Network
         if server.public_net.ipv4:
-            server_dict["ipv4"] = to_native(server.public_net.ipv4.ip)
+            server_dict["ipv4"] = server.public_net.ipv4.ip
 
         if server.public_net.ipv6:
-            server_dict["ipv6"] = to_native(first_ipv6_address(server.public_net.ipv6.ip))
-            server_dict["ipv6_network"] = to_native(server.public_net.ipv6.network)
-            server_dict["ipv6_network_mask"] = to_native(server.public_net.ipv6.network_mask)
+            server_dict["ipv6"] = first_ipv6_address(server.public_net.ipv6.ip)
+            server_dict["ipv6_network"] = server.public_net.ipv6.network
+            server_dict["ipv6_network_mask"] = server.public_net.ipv6.network_mask
 
         server_dict["private_networks"] = [
-            {"id": v.network.id, "name": to_native(v.network.name), "ip": to_native(v.ip)} for v in server.private_net
+            {"id": v.network.id, "name": v.network.name, "ip": v.ip} for v in server.private_net
         ]
 
         if self.get_option("network"):
             for private_net in server.private_net:
                 # Set private_ipv4 if user filtered for one network
                 if private_net.network.id == self.network.id:
-                    server_dict["private_ipv4"] = to_native(private_net.ip)
+                    server_dict["private_ipv4"] = private_net.ip
                     break
 
         # Datacenter
-        server_dict["datacenter"] = to_native(server.datacenter.name)
-        server_dict["location"] = to_native(server.datacenter.location.name)
+        server_dict["datacenter"] = server.datacenter.name
+        server_dict["location"] = server.datacenter.location.name
 
         # Image
         if server.image is not None:
             server_dict["image_id"] = server.image.id
-            server_dict["image_os_flavor"] = to_native(server.image.os_flavor)
-            server_dict["image_name"] = to_native(server.image.name or server.image.description)
+            server_dict["image_os_flavor"] = server.image.os_flavor
+            server_dict["image_name"] = server.image.name or server.image.description
 
         # Labels
         server_dict["labels"] = dict(server.labels)
@@ -391,28 +391,28 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
     def _get_server_ansible_host(self, server: Server):
         if self.get_option("connect_with") == "public_ipv4":
             if server.public_net.ipv4:
-                return to_native(server.public_net.ipv4.ip)
+                return server.public_net.ipv4.ip
             raise AnsibleError("Server has no public ipv4, but connect_with=public_ipv4 was specified")
 
         if self.get_option("connect_with") == "public_ipv6":
             if server.public_net.ipv6:
-                return to_native(first_ipv6_address(server.public_net.ipv6.ip))
+                return first_ipv6_address(server.public_net.ipv6.ip)
             raise AnsibleError("Server has no public ipv6, but connect_with=public_ipv6 was specified")
 
         if self.get_option("connect_with") == "hostname":
             # every server has a name, no need to guard this
-            return to_native(server.name)
+            return server.name
 
         if self.get_option("connect_with") == "ipv4_dns_ptr":
             if server.public_net.ipv4:
-                return to_native(server.public_net.ipv4.dns_ptr)
+                return server.public_net.ipv4.dns_ptr
             raise AnsibleError("Server has no public ipv4, but connect_with=ipv4_dns_ptr was specified")
 
         if self.get_option("connect_with") == "private_ipv4":
             if self.get_option("network"):
                 for private_net in server.private_net:
                     if private_net.network.id == self.network.id:
-                        return to_native(private_net.ip)
+                        return private_net.ip
 
             else:
                 raise AnsibleError("You can only connect via private IPv4 if you specify a network")

--- a/plugins/modules/certificate.py
+++ b/plugins/modules/certificate.py
@@ -160,14 +160,14 @@ class AnsibleHCloudCertificate(AnsibleHCloud):
 
     def _prepare_result(self):
         return {
-            "id": to_native(self.hcloud_certificate.id),
-            "name": to_native(self.hcloud_certificate.name),
-            "type": to_native(self.hcloud_certificate.type),
-            "fingerprint": to_native(self.hcloud_certificate.fingerprint),
-            "certificate": to_native(self.hcloud_certificate.certificate),
-            "not_valid_before": to_native(self.hcloud_certificate.not_valid_before.isoformat()),
-            "not_valid_after": to_native(self.hcloud_certificate.not_valid_after.isoformat()),
-            "domain_names": [to_native(domain) for domain in self.hcloud_certificate.domain_names],
+            "id": str(self.hcloud_certificate.id),
+            "name": self.hcloud_certificate.name,
+            "type": self.hcloud_certificate.type,
+            "fingerprint": self.hcloud_certificate.fingerprint,
+            "certificate": self.hcloud_certificate.certificate,
+            "not_valid_before": self.hcloud_certificate.not_valid_before.isoformat(),
+            "not_valid_after": self.hcloud_certificate.not_valid_after.isoformat(),
+            "domain_names": [domain for domain in self.hcloud_certificate.domain_names],
             "labels": self.hcloud_certificate.labels,
         }
 

--- a/plugins/modules/certificate.py
+++ b/plugins/modules/certificate.py
@@ -167,7 +167,7 @@ class AnsibleHCloudCertificate(AnsibleHCloud):
             "certificate": self.hcloud_certificate.certificate,
             "not_valid_before": self.hcloud_certificate.not_valid_before.isoformat(),
             "not_valid_after": self.hcloud_certificate.not_valid_after.isoformat(),
-            "domain_names": [domain for domain in self.hcloud_certificate.domain_names],
+            "domain_names": self.hcloud_certificate.domain_names,
             "labels": self.hcloud_certificate.labels,
         }
 

--- a/plugins/modules/certificate.py
+++ b/plugins/modules/certificate.py
@@ -146,7 +146,6 @@ hcloud_certificate:
 """
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils.common.text.converters import to_native
 
 from ..module_utils.hcloud import AnsibleHCloud
 from ..module_utils.vendor.hcloud import HCloudException

--- a/plugins/modules/certificate_info.py
+++ b/plugins/modules/certificate_info.py
@@ -100,23 +100,25 @@ class AnsibleHCloudCertificateInfo(AnsibleHCloud):
     hcloud_certificate_info: list[BoundCertificate] | None = None
 
     def _prepare_result(self):
-        certificates = []
+        tmp = []
 
         for certificate in self.hcloud_certificate_info:
-            if certificate:
-                certificates.append(
-                    {
-                        "id": str(certificate.id),
-                        "name": certificate.name,
-                        "fingerprint": certificate.fingerprint,
-                        "certificate": certificate.certificate,
-                        "not_valid_before": certificate.not_valid_before.isoformat(),
-                        "not_valid_after": certificate.not_valid_after.isoformat(),
-                        "domain_names": [domain for domain in certificate.domain_names],
-                        "labels": certificate.labels,
-                    }
-                )
-        return certificates
+            if certificate is None:
+                continue
+
+            tmp.append(
+                {
+                    "id": str(certificate.id),
+                    "name": certificate.name,
+                    "fingerprint": certificate.fingerprint,
+                    "certificate": certificate.certificate,
+                    "not_valid_before": certificate.not_valid_before.isoformat(),
+                    "not_valid_after": certificate.not_valid_after.isoformat(),
+                    "domain_names": certificate.domain_names,
+                    "labels": certificate.labels,
+                }
+            )
+        return tmp
 
     def get_certificates(self):
         try:

--- a/plugins/modules/certificate_info.py
+++ b/plugins/modules/certificate_info.py
@@ -87,7 +87,6 @@ hcloud_certificate_info:
 """
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils.common.text.converters import to_native
 
 from ..module_utils.hcloud import AnsibleHCloud
 from ..module_utils.vendor.hcloud import HCloudException

--- a/plugins/modules/certificate_info.py
+++ b/plugins/modules/certificate_info.py
@@ -106,13 +106,13 @@ class AnsibleHCloudCertificateInfo(AnsibleHCloud):
             if certificate:
                 certificates.append(
                     {
-                        "id": to_native(certificate.id),
-                        "name": to_native(certificate.name),
-                        "fingerprint": to_native(certificate.fingerprint),
-                        "certificate": to_native(certificate.certificate),
-                        "not_valid_before": to_native(certificate.not_valid_before.isoformat()),
-                        "not_valid_after": to_native(certificate.not_valid_after.isoformat()),
-                        "domain_names": [to_native(domain) for domain in certificate.domain_names],
+                        "id": str(certificate.id),
+                        "name": certificate.name,
+                        "fingerprint": certificate.fingerprint,
+                        "certificate": certificate.certificate,
+                        "not_valid_before": certificate.not_valid_before.isoformat(),
+                        "not_valid_after": certificate.not_valid_after.isoformat(),
+                        "domain_names": [domain for domain in certificate.domain_names],
                         "labels": certificate.labels,
                     }
                 )

--- a/plugins/modules/datacenter_info.py
+++ b/plugins/modules/datacenter_info.py
@@ -118,7 +118,6 @@ hcloud_datacenter_info:
 """
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils.common.text.converters import to_native
 
 from ..module_utils.hcloud import AnsibleHCloud
 from ..module_utils.vendor.hcloud import HCloudException

--- a/plugins/modules/datacenter_info.py
+++ b/plugins/modules/datacenter_info.py
@@ -139,10 +139,10 @@ class AnsibleHCloudDatacenterInfo(AnsibleHCloud):
 
             tmp.append(
                 {
-                    "id": to_native(datacenter.id),
-                    "name": to_native(datacenter.name),
-                    "description": to_native(datacenter.description),
-                    "location": to_native(datacenter.location.name),
+                    "id": str(datacenter.id),
+                    "name": datacenter.name,
+                    "description": datacenter.description,
+                    "location": datacenter.location.name,
                     "server_types": {
                         "available": [o.id for o in datacenter.server_types.available],
                         "available_for_migration": [o.id for o in datacenter.server_types.available_for_migration],

--- a/plugins/modules/firewall.py
+++ b/plugins/modules/firewall.py
@@ -219,7 +219,6 @@ hcloud_firewall:
 import time
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils.common.text.converters import to_native
 
 from ..module_utils.hcloud import AnsibleHCloud
 from ..module_utils.vendor.hcloud import APIException, HCloudException

--- a/plugins/modules/firewall.py
+++ b/plugins/modules/firewall.py
@@ -237,8 +237,8 @@ class AnsibleHCloudFirewall(AnsibleHCloud):
 
     def _prepare_result(self):
         return {
-            "id": to_native(self.hcloud_firewall.id),
-            "name": to_native(self.hcloud_firewall.name),
+            "id": str(self.hcloud_firewall.id),
+            "name": self.hcloud_firewall.name,
             "rules": [self._prepare_result_rule(rule) for rule in self.hcloud_firewall.rules],
             "labels": self.hcloud_firewall.labels,
             "applied_to": [self._prepare_result_applied_to(resource) for resource in self.hcloud_firewall.applied_to],
@@ -246,27 +246,25 @@ class AnsibleHCloudFirewall(AnsibleHCloud):
 
     def _prepare_result_rule(self, rule: FirewallRule):
         return {
-            "direction": to_native(rule.direction),
-            "protocol": to_native(rule.protocol),
-            "port": to_native(rule.port) if rule.port is not None else None,
-            "source_ips": [to_native(cidr) for cidr in rule.source_ips],
-            "destination_ips": [to_native(cidr) for cidr in rule.destination_ips],
-            "description": to_native(rule.description) if rule.description is not None else None,
+            "direction": rule.direction,
+            "protocol": rule.protocol,
+            "port": rule.port if rule.port is not None else None,
+            "source_ips": [cidr for cidr in rule.source_ips],
+            "destination_ips": [cidr for cidr in rule.destination_ips],
+            "description": rule.description if rule.description is not None else None,
         }
 
     def _prepare_result_applied_to(self, resource: FirewallResource):
         result = {
-            "type": to_native(resource.type),
-            "server": to_native(resource.server.id) if resource.server is not None else None,
-            "label_selector": (
-                to_native(resource.label_selector.selector) if resource.label_selector is not None else None
-            ),
+            "type": resource.type,
+            "server": str(resource.server.id) if resource.server is not None else None,
+            "label_selector": (resource.label_selector.selector if resource.label_selector is not None else None),
         }
         if resource.applied_to_resources is not None:
             result["applied_to_resources"] = [
                 {
-                    "type": to_native(item.type),
-                    "server": to_native(item.server.id) if item.server is not None else None,
+                    "type": item.type,
+                    "server": str(item.server.id) if item.server is not None else None,
                 }
                 for item in resource.applied_to_resources
             ]

--- a/plugins/modules/firewall.py
+++ b/plugins/modules/firewall.py
@@ -248,17 +248,17 @@ class AnsibleHCloudFirewall(AnsibleHCloud):
         return {
             "direction": rule.direction,
             "protocol": rule.protocol,
-            "port": rule.port if rule.port is not None else None,
-            "source_ips": [cidr for cidr in rule.source_ips],
-            "destination_ips": [cidr for cidr in rule.destination_ips],
-            "description": rule.description if rule.description is not None else None,
+            "port": rule.port,
+            "source_ips": rule.source_ips,
+            "destination_ips": rule.destination_ips,
+            "description": rule.description,
         }
 
     def _prepare_result_applied_to(self, resource: FirewallResource):
         result = {
             "type": resource.type,
             "server": str(resource.server.id) if resource.server is not None else None,
-            "label_selector": (resource.label_selector.selector if resource.label_selector is not None else None),
+            "label_selector": resource.label_selector.selector if resource.label_selector is not None else None,
         }
         if resource.applied_to_resources is not None:
             result["applied_to_resources"] = [

--- a/plugins/modules/firewall_info.py
+++ b/plugins/modules/firewall_info.py
@@ -179,12 +179,12 @@ class AnsibleHCloudFirewallInfo(AnsibleHCloud):
 
     def _prepare_result_rule(self, rule: FirewallRule):
         return {
-            "description": rule.description if rule.description is not None else None,
+            "description": rule.description,
             "direction": rule.direction,
             "protocol": rule.protocol,
-            "port": rule.port if rule.port is not None else None,
-            "source_ips": [cidr for cidr in rule.source_ips],
-            "destination_ips": [cidr for cidr in rule.destination_ips],
+            "port": rule.port,
+            "source_ips": rule.source_ips,
+            "destination_ips": rule.destination_ips,
         }
 
     def _prepare_result_applied_to(self, resource: FirewallResource):

--- a/plugins/modules/firewall_info.py
+++ b/plugins/modules/firewall_info.py
@@ -167,8 +167,8 @@ class AnsibleHCloudFirewallInfo(AnsibleHCloud):
 
             tmp.append(
                 {
-                    "id": to_native(firewall.id),
-                    "name": to_native(firewall.name),
+                    "id": str(firewall.id),
+                    "name": firewall.name,
                     "labels": firewall.labels,
                     "rules": [self._prepare_result_rule(rule) for rule in firewall.rules],
                     "applied_to": [self._prepare_result_applied_to(resource) for resource in firewall.applied_to],
@@ -179,27 +179,25 @@ class AnsibleHCloudFirewallInfo(AnsibleHCloud):
 
     def _prepare_result_rule(self, rule: FirewallRule):
         return {
-            "description": to_native(rule.description) if rule.description is not None else None,
-            "direction": to_native(rule.direction),
-            "protocol": to_native(rule.protocol),
-            "port": to_native(rule.port) if rule.port is not None else None,
-            "source_ips": [to_native(cidr) for cidr in rule.source_ips],
-            "destination_ips": [to_native(cidr) for cidr in rule.destination_ips],
+            "description": rule.description if rule.description is not None else None,
+            "direction": rule.direction,
+            "protocol": rule.protocol,
+            "port": rule.port if rule.port is not None else None,
+            "source_ips": [cidr for cidr in rule.source_ips],
+            "destination_ips": [cidr for cidr in rule.destination_ips],
         }
 
     def _prepare_result_applied_to(self, resource: FirewallResource):
         result = {
-            "type": to_native(resource.type),
-            "server": to_native(resource.server.id) if resource.server is not None else None,
-            "label_selector": (
-                to_native(resource.label_selector.selector) if resource.label_selector is not None else None
-            ),
+            "type": resource.type,
+            "server": str(resource.server.id) if resource.server is not None else None,
+            "label_selector": resource.label_selector.selector if resource.label_selector is not None else None,
         }
         if resource.applied_to_resources is not None:
             result["applied_to_resources"] = [
                 {
-                    "type": to_native(item.type),
-                    "server": to_native(item.server.id) if item.server is not None else None,
+                    "type": item.type,
+                    "server": str(item.server.id) if item.server is not None else None,
                 }
                 for item in resource.applied_to_resources
             ]

--- a/plugins/modules/firewall_info.py
+++ b/plugins/modules/firewall_info.py
@@ -142,7 +142,6 @@ hcloud_firewall_info:
 """
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils.common.text.converters import to_native
 
 from ..module_utils.hcloud import AnsibleHCloud
 from ..module_utils.vendor.hcloud import HCloudException

--- a/plugins/modules/firewall_resource.py
+++ b/plugins/modules/firewall_resource.py
@@ -125,12 +125,12 @@ class AnsibleHCloudFirewallResource(AnsibleHCloud):
         label_selectors = []
         for resource in self.hcloud_firewall_resource.applied_to:
             if resource.type == FirewallResource.TYPE_SERVER:
-                servers.append(to_native(resource.server.name))
+                servers.append(resource.server.name)
             elif resource.type == FirewallResource.TYPE_LABEL_SELECTOR:
-                label_selectors.append(to_native(resource.label_selector.selector))
+                label_selectors.append(resource.label_selector.selector)
 
         return {
-            "firewall": to_native(self.hcloud_firewall_resource.name),
+            "firewall": self.hcloud_firewall_resource.name,
             "servers": servers,
             "label_selectors": label_selectors,
         }

--- a/plugins/modules/firewall_resource.py
+++ b/plugins/modules/firewall_resource.py
@@ -103,7 +103,6 @@ hcloud_firewall_resource:
 """
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils.common.text.converters import to_native
 
 from ..module_utils.hcloud import AnsibleHCloud
 from ..module_utils.vendor.hcloud import HCloudException

--- a/plugins/modules/floating_ip.py
+++ b/plugins/modules/floating_ip.py
@@ -176,14 +176,14 @@ class AnsibleHCloudFloatingIP(AnsibleHCloud):
         server = None
 
         if self.hcloud_floating_ip.server is not None:
-            server = to_native(self.hcloud_floating_ip.server.name)
+            server = self.hcloud_floating_ip.server.name
         return {
-            "id": to_native(self.hcloud_floating_ip.id),
-            "name": to_native(self.hcloud_floating_ip.name),
-            "description": to_native(self.hcloud_floating_ip.description),
-            "ip": to_native(self.hcloud_floating_ip.ip),
-            "type": to_native(self.hcloud_floating_ip.type),
-            "home_location": to_native(self.hcloud_floating_ip.home_location.name),
+            "id": str(self.hcloud_floating_ip.id),
+            "name": self.hcloud_floating_ip.name,
+            "description": self.hcloud_floating_ip.description,
+            "ip": self.hcloud_floating_ip.ip,
+            "type": self.hcloud_floating_ip.type,
+            "home_location": self.hcloud_floating_ip.home_location.name,
             "labels": self.hcloud_floating_ip.labels,
             "server": server,
             "delete_protection": self.hcloud_floating_ip.protection["delete"],

--- a/plugins/modules/floating_ip.py
+++ b/plugins/modules/floating_ip.py
@@ -160,7 +160,6 @@ hcloud_floating_ip:
 """
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils.common.text.converters import to_native
 
 from ..module_utils.hcloud import AnsibleHCloud
 from ..module_utils.vendor.hcloud import HCloudException

--- a/plugins/modules/floating_ip.py
+++ b/plugins/modules/floating_ip.py
@@ -173,10 +173,6 @@ class AnsibleHCloudFloatingIP(AnsibleHCloud):
     hcloud_floating_ip: BoundFloatingIP | None = None
 
     def _prepare_result(self):
-        server = None
-
-        if self.hcloud_floating_ip.server is not None:
-            server = self.hcloud_floating_ip.server.name
         return {
             "id": str(self.hcloud_floating_ip.id),
             "name": self.hcloud_floating_ip.name,
@@ -185,7 +181,7 @@ class AnsibleHCloudFloatingIP(AnsibleHCloud):
             "type": self.hcloud_floating_ip.type,
             "home_location": self.hcloud_floating_ip.home_location.name,
             "labels": self.hcloud_floating_ip.labels,
-            "server": server,
+            "server": self.hcloud_floating_ip.server.name if self.hcloud_floating_ip.server is not None else None,
             "delete_protection": self.hcloud_floating_ip.protection["delete"],
         }
 

--- a/plugins/modules/floating_ip_info.py
+++ b/plugins/modules/floating_ip_info.py
@@ -122,13 +122,13 @@ class AnsibleHCloudFloatingIPInfo(AnsibleHCloud):
                     server_name = floating_ip.server.name
                 tmp.append(
                     {
-                        "id": to_native(floating_ip.id),
-                        "name": to_native(floating_ip.name),
-                        "description": to_native(floating_ip.description),
-                        "ip": to_native(floating_ip.ip),
-                        "type": to_native(floating_ip.type),
-                        "server": to_native(server_name),
-                        "home_location": to_native(floating_ip.home_location.name),
+                        "id": str(floating_ip.id),
+                        "name": floating_ip.name,
+                        "description": floating_ip.description,
+                        "ip": floating_ip.ip,
+                        "type": floating_ip.type,
+                        "server": server_name,
+                        "home_location": floating_ip.home_location.name,
                         "labels": floating_ip.labels,
                         "delete_protection": floating_ip.protection["delete"],
                     }

--- a/plugins/modules/floating_ip_info.py
+++ b/plugins/modules/floating_ip_info.py
@@ -100,7 +100,6 @@ hcloud_floating_ip_info:
 """
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils.common.text.converters import to_native
 
 from ..module_utils.hcloud import AnsibleHCloud
 from ..module_utils.vendor.hcloud import HCloudException

--- a/plugins/modules/floating_ip_info.py
+++ b/plugins/modules/floating_ip_info.py
@@ -116,23 +116,22 @@ class AnsibleHCloudFloatingIPInfo(AnsibleHCloud):
         tmp = []
 
         for floating_ip in self.hcloud_floating_ip_info:
-            if floating_ip is not None:
-                server_name = None
-                if floating_ip.server is not None:
-                    server_name = floating_ip.server.name
-                tmp.append(
-                    {
-                        "id": str(floating_ip.id),
-                        "name": floating_ip.name,
-                        "description": floating_ip.description,
-                        "ip": floating_ip.ip,
-                        "type": floating_ip.type,
-                        "server": server_name,
-                        "home_location": floating_ip.home_location.name,
-                        "labels": floating_ip.labels,
-                        "delete_protection": floating_ip.protection["delete"],
-                    }
-                )
+            if floating_ip is None:
+                continue
+
+            tmp.append(
+                {
+                    "id": str(floating_ip.id),
+                    "name": floating_ip.name,
+                    "description": floating_ip.description,
+                    "ip": floating_ip.ip,
+                    "type": floating_ip.type,
+                    "server": floating_ip.server.name if floating_ip.server is not None else None,
+                    "home_location": floating_ip.home_location.name,
+                    "labels": floating_ip.labels,
+                    "delete_protection": floating_ip.protection["delete"],
+                }
+            )
 
         return tmp
 

--- a/plugins/modules/image_info.py
+++ b/plugins/modules/image_info.py
@@ -128,20 +128,22 @@ class AnsibleHCloudImageInfo(AnsibleHCloud):
         tmp = []
 
         for image in self.hcloud_image_info:
-            if image is not None:
-                tmp.append(
-                    {
-                        "id": str(image.id),
-                        "status": image.status,
-                        "type": image.type,
-                        "name": image.name,
-                        "description": image.description,
-                        "os_flavor": image.os_flavor,
-                        "os_version": image.os_version,
-                        "architecture": image.architecture,
-                        "labels": image.labels,
-                    }
-                )
+            if image is None:
+                continue
+
+            tmp.append(
+                {
+                    "id": str(image.id),
+                    "status": image.status,
+                    "type": image.type,
+                    "name": image.name,
+                    "description": image.description,
+                    "os_flavor": image.os_flavor,
+                    "os_version": image.os_version,
+                    "architecture": image.architecture,
+                    "labels": image.labels,
+                }
+            )
         return tmp
 
     def get_images(self):

--- a/plugins/modules/image_info.py
+++ b/plugins/modules/image_info.py
@@ -112,7 +112,6 @@ hcloud_image_info:
 """
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils.common.text.converters import to_native
 
 from ..module_utils.hcloud import AnsibleHCloud
 from ..module_utils.vendor.hcloud import HCloudException

--- a/plugins/modules/image_info.py
+++ b/plugins/modules/image_info.py
@@ -131,14 +131,14 @@ class AnsibleHCloudImageInfo(AnsibleHCloud):
             if image is not None:
                 tmp.append(
                     {
-                        "id": to_native(image.id),
-                        "status": to_native(image.status),
-                        "type": to_native(image.type),
-                        "name": to_native(image.name),
-                        "description": to_native(image.description),
-                        "os_flavor": to_native(image.os_flavor),
-                        "os_version": to_native(image.os_version),
-                        "architecture": to_native(image.architecture),
+                        "id": str(image.id),
+                        "status": image.status,
+                        "type": image.type,
+                        "name": image.name,
+                        "description": image.description,
+                        "os_flavor": image.os_flavor,
+                        "os_version": image.os_version,
+                        "architecture": image.architecture,
                         "labels": image.labels,
                     }
                 )

--- a/plugins/modules/iso_info.py
+++ b/plugins/modules/iso_info.py
@@ -143,9 +143,9 @@ class AnsibleHCloudIsoInfo(AnsibleHCloud):
 
             tmp.append(
                 {
-                    "id": to_native(iso_info.id),
-                    "name": to_native(iso_info.name),
-                    "description": to_native(iso_info.description),
+                    "id": str(iso_info.id),
+                    "name": iso_info.name,
+                    "description": iso_info.description,
                     "type": iso_info.type,
                     "architecture": iso_info.architecture,
                     "deprecated": (

--- a/plugins/modules/iso_info.py
+++ b/plugins/modules/iso_info.py
@@ -122,7 +122,6 @@ hcloud_iso_info:
 """
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils.common.text.converters import to_native
 
 from ..module_utils.hcloud import AnsibleHCloud
 from ..module_utils.vendor.hcloud import HCloudException

--- a/plugins/modules/load_balancer.py
+++ b/plugins/modules/load_balancer.py
@@ -152,7 +152,6 @@ hcloud_load_balancer:
 """
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils.common.text.converters import to_native
 
 from ..module_utils.hcloud import AnsibleHCloud
 from ..module_utils.vendor.hcloud import HCloudException

--- a/plugins/modules/load_balancer.py
+++ b/plugins/modules/load_balancer.py
@@ -169,19 +169,17 @@ class AnsibleHCloudLoadBalancer(AnsibleHCloud):
 
     def _prepare_result(self):
         private_ipv4_address = (
-            None
-            if len(self.hcloud_load_balancer.private_net) == 0
-            else to_native(self.hcloud_load_balancer.private_net[0].ip)
+            None if len(self.hcloud_load_balancer.private_net) == 0 else self.hcloud_load_balancer.private_net[0].ip
         )
         return {
-            "id": to_native(self.hcloud_load_balancer.id),
-            "name": to_native(self.hcloud_load_balancer.name),
-            "ipv4_address": to_native(self.hcloud_load_balancer.public_net.ipv4.ip),
-            "ipv6_address": to_native(self.hcloud_load_balancer.public_net.ipv6.ip),
+            "id": str(self.hcloud_load_balancer.id),
+            "name": self.hcloud_load_balancer.name,
+            "ipv4_address": self.hcloud_load_balancer.public_net.ipv4.ip,
+            "ipv6_address": self.hcloud_load_balancer.public_net.ipv6.ip,
             "private_ipv4_address": private_ipv4_address,
-            "load_balancer_type": to_native(self.hcloud_load_balancer.load_balancer_type.name),
-            "algorithm": to_native(self.hcloud_load_balancer.algorithm.type),
-            "location": to_native(self.hcloud_load_balancer.location.name),
+            "load_balancer_type": self.hcloud_load_balancer.load_balancer_type.name,
+            "algorithm": self.hcloud_load_balancer.algorithm.type,
+            "location": self.hcloud_load_balancer.location.name,
             "labels": self.hcloud_load_balancer.labels,
             "delete_protection": self.hcloud_load_balancer.protection["delete"],
             "disable_public_interface": False if self.hcloud_load_balancer.public_net.enabled else True,

--- a/plugins/modules/load_balancer.py
+++ b/plugins/modules/load_balancer.py
@@ -168,21 +168,20 @@ class AnsibleHCloudLoadBalancer(AnsibleHCloud):
     hcloud_load_balancer: BoundLoadBalancer | None = None
 
     def _prepare_result(self):
-        private_ipv4_address = (
-            None if len(self.hcloud_load_balancer.private_net) == 0 else self.hcloud_load_balancer.private_net[0].ip
-        )
         return {
             "id": str(self.hcloud_load_balancer.id),
             "name": self.hcloud_load_balancer.name,
             "ipv4_address": self.hcloud_load_balancer.public_net.ipv4.ip,
             "ipv6_address": self.hcloud_load_balancer.public_net.ipv6.ip,
-            "private_ipv4_address": private_ipv4_address,
+            "private_ipv4_address": (
+                self.hcloud_load_balancer.private_net[0].ip if len(self.hcloud_load_balancer.private_net) else None
+            ),
             "load_balancer_type": self.hcloud_load_balancer.load_balancer_type.name,
             "algorithm": self.hcloud_load_balancer.algorithm.type,
             "location": self.hcloud_load_balancer.location.name,
             "labels": self.hcloud_load_balancer.labels,
             "delete_protection": self.hcloud_load_balancer.protection["delete"],
-            "disable_public_interface": False if self.hcloud_load_balancer.public_net.enabled else True,
+            "disable_public_interface": not self.hcloud_load_balancer.public_net.enabled,
         }
 
     def _get_load_balancer(self):

--- a/plugins/modules/load_balancer_info.py
+++ b/plugins/modules/load_balancer_info.py
@@ -301,18 +301,16 @@ class AnsibleHCloudLoadBalancerInfo(AnsibleHCloud):
                 services = [self._prepare_service_result(service) for service in load_balancer.services]
                 targets = [self._prepare_target_result(target) for target in load_balancer.targets]
 
-                private_ipv4_address = (
-                    None if len(load_balancer.private_net) == 0 else to_native(load_balancer.private_net[0].ip)
-                )
+                private_ipv4_address = None if len(load_balancer.private_net) == 0 else load_balancer.private_net[0].ip
                 tmp.append(
                     {
-                        "id": to_native(load_balancer.id),
-                        "name": to_native(load_balancer.name),
-                        "ipv4_address": to_native(load_balancer.public_net.ipv4.ip),
-                        "ipv6_address": to_native(load_balancer.public_net.ipv6.ip),
+                        "id": str(load_balancer.id),
+                        "name": load_balancer.name,
+                        "ipv4_address": load_balancer.public_net.ipv4.ip,
+                        "ipv6_address": load_balancer.public_net.ipv6.ip,
                         "private_ipv4_address": private_ipv4_address,
-                        "load_balancer_type": to_native(load_balancer.load_balancer_type.name),
-                        "location": to_native(load_balancer.location.name),
+                        "load_balancer_type": load_balancer.load_balancer_type.name,
+                        "location": load_balancer.location.name,
                         "labels": load_balancer.labels,
                         "delete_protection": load_balancer.protection["delete"],
                         "disable_public_interface": False if load_balancer.public_net.enabled else True,
@@ -327,14 +325,14 @@ class AnsibleHCloudLoadBalancerInfo(AnsibleHCloud):
         http = None
         if service.protocol != "tcp":
             http = {
-                "cookie_name": to_native(service.http.cookie_name),
+                "cookie_name": service.http.cookie_name,
                 "cookie_lifetime": service.http.cookie_lifetime,
                 "redirect_http": service.http.redirect_http,
                 "sticky_sessions": service.http.sticky_sessions,
-                "certificates": [to_native(certificate.name) for certificate in service.http.certificates],
+                "certificates": [certificate.name for certificate in service.http.certificates],
             }
         health_check = {
-            "protocol": to_native(service.health_check.protocol),
+            "protocol": service.health_check.protocol,
             "port": service.health_check.port,
             "interval": service.health_check.interval,
             "timeout": service.health_check.timeout,
@@ -342,14 +340,14 @@ class AnsibleHCloudLoadBalancerInfo(AnsibleHCloud):
         }
         if service.health_check.protocol != "tcp":
             health_check["http"] = {
-                "domain": to_native(service.health_check.http.domain),
-                "path": to_native(service.health_check.http.path),
-                "response": to_native(service.health_check.http.response),
-                "certificates": [to_native(status_code) for status_code in service.health_check.http.status_codes],
+                "domain": service.health_check.http.domain,
+                "path": service.health_check.http.path,
+                "response": service.health_check.http.response,
+                "certificates": [status_code for status_code in service.health_check.http.status_codes],
                 "tls": service.health_check.http.tls,
             }
         return {
-            "protocol": to_native(service.protocol),
+            "protocol": service.protocol,
             "listen_port": service.listen_port,
             "destination_port": service.destination_port,
             "proxyprotocol": service.proxyprotocol,
@@ -360,15 +358,15 @@ class AnsibleHCloudLoadBalancerInfo(AnsibleHCloud):
     @staticmethod
     def _prepare_target_result(target: LoadBalancerTarget):
         result = {
-            "type": to_native(target.type),
+            "type": target.type,
             "use_private_ip": target.use_private_ip,
         }
         if target.type == "server":
-            result["server"] = to_native(target.server.name)
+            result["server"] = target.server.name
         elif target.type == "label_selector":
-            result["label_selector"] = to_native(target.label_selector.selector)
+            result["label_selector"] = target.label_selector.selector
         elif target.type == "ip":
-            result["ip"] = to_native(target.ip.ip)
+            result["ip"] = target.ip.ip
 
         if target.health_status is not None:
             result["health_status"] = [

--- a/plugins/modules/load_balancer_info.py
+++ b/plugins/modules/load_balancer_info.py
@@ -297,27 +297,25 @@ class AnsibleHCloudLoadBalancerInfo(AnsibleHCloud):
         tmp = []
 
         for load_balancer in self.hcloud_load_balancer_info:
-            if load_balancer is not None:
-                services = [self._prepare_service_result(service) for service in load_balancer.services]
-                targets = [self._prepare_target_result(target) for target in load_balancer.targets]
+            if load_balancer is None:
+                continue
 
-                private_ipv4_address = None if len(load_balancer.private_net) == 0 else load_balancer.private_net[0].ip
-                tmp.append(
-                    {
-                        "id": str(load_balancer.id),
-                        "name": load_balancer.name,
-                        "ipv4_address": load_balancer.public_net.ipv4.ip,
-                        "ipv6_address": load_balancer.public_net.ipv6.ip,
-                        "private_ipv4_address": private_ipv4_address,
-                        "load_balancer_type": load_balancer.load_balancer_type.name,
-                        "location": load_balancer.location.name,
-                        "labels": load_balancer.labels,
-                        "delete_protection": load_balancer.protection["delete"],
-                        "disable_public_interface": False if load_balancer.public_net.enabled else True,
-                        "targets": targets,
-                        "services": services,
-                    }
-                )
+            tmp.append(
+                {
+                    "id": str(load_balancer.id),
+                    "name": load_balancer.name,
+                    "ipv4_address": load_balancer.public_net.ipv4.ip,
+                    "ipv6_address": load_balancer.public_net.ipv6.ip,
+                    "private_ipv4_address": load_balancer.private_net[0].ip if len(load_balancer.private_net) else None,
+                    "load_balancer_type": load_balancer.load_balancer_type.name,
+                    "location": load_balancer.location.name,
+                    "labels": load_balancer.labels,
+                    "delete_protection": load_balancer.protection["delete"],
+                    "disable_public_interface": False if load_balancer.public_net.enabled else True,
+                    "targets": [self._prepare_target_result(target) for target in load_balancer.targets],
+                    "services": [self._prepare_service_result(service) for service in load_balancer.services],
+                }
+            )
         return tmp
 
     @staticmethod
@@ -343,7 +341,7 @@ class AnsibleHCloudLoadBalancerInfo(AnsibleHCloud):
                 "domain": service.health_check.http.domain,
                 "path": service.health_check.http.path,
                 "response": service.health_check.http.response,
-                "certificates": [status_code for status_code in service.health_check.http.status_codes],
+                "certificates": service.health_check.http.status_codes,
                 "tls": service.health_check.http.tls,
             }
         return {

--- a/plugins/modules/load_balancer_info.py
+++ b/plugins/modules/load_balancer_info.py
@@ -277,7 +277,6 @@ hcloud_load_balancer_info:
 """
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils.common.text.converters import to_native
 
 from ..module_utils.hcloud import AnsibleHCloud
 from ..module_utils.vendor.hcloud import HCloudException

--- a/plugins/modules/load_balancer_network.py
+++ b/plugins/modules/load_balancer_network.py
@@ -90,7 +90,6 @@ hcloud_load_balancer_network:
 """
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils.common.text.converters import to_native
 
 from ..module_utils.hcloud import AnsibleHCloud
 from ..module_utils.vendor.hcloud import HCloudException

--- a/plugins/modules/load_balancer_network.py
+++ b/plugins/modules/load_balancer_network.py
@@ -107,9 +107,9 @@ class AnsibleHCloudLoadBalancerNetwork(AnsibleHCloud):
 
     def _prepare_result(self):
         return {
-            "network": to_native(self.hcloud_network.name),
-            "load_balancer": to_native(self.hcloud_load_balancer.name),
-            "ip": to_native(self.hcloud_load_balancer_network.ip),
+            "network": self.hcloud_network.name,
+            "load_balancer": self.hcloud_load_balancer.name,
+            "ip": self.hcloud_load_balancer_network.ip,
         }
 
     def _get_load_balancer_and_network(self):

--- a/plugins/modules/load_balancer_service.py
+++ b/plugins/modules/load_balancer_service.py
@@ -279,7 +279,6 @@ hcloud_load_balancer_service:
 """
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils.common.text.converters import to_native
 
 from ..module_utils.hcloud import AnsibleHCloud
 from ..module_utils.vendor.hcloud import APIException, HCloudException

--- a/plugins/modules/load_balancer_service.py
+++ b/plugins/modules/load_balancer_service.py
@@ -302,16 +302,16 @@ class AnsibleHCloudLoadBalancerService(AnsibleHCloud):
         http = None
         if self.hcloud_load_balancer_service.protocol != "tcp":
             http = {
-                "cookie_name": to_native(self.hcloud_load_balancer_service.http.cookie_name),
+                "cookie_name": self.hcloud_load_balancer_service.http.cookie_name,
                 "cookie_lifetime": self.hcloud_load_balancer_service.http.cookie_lifetime,
                 "redirect_http": self.hcloud_load_balancer_service.http.redirect_http,
                 "sticky_sessions": self.hcloud_load_balancer_service.http.sticky_sessions,
                 "certificates": [
-                    to_native(certificate.name) for certificate in self.hcloud_load_balancer_service.http.certificates
+                    certificate.name for certificate in self.hcloud_load_balancer_service.http.certificates
                 ],
             }
         health_check = {
-            "protocol": to_native(self.hcloud_load_balancer_service.health_check.protocol),
+            "protocol": self.hcloud_load_balancer_service.health_check.protocol,
             "port": self.hcloud_load_balancer_service.health_check.port,
             "interval": self.hcloud_load_balancer_service.health_check.interval,
             "timeout": self.hcloud_load_balancer_service.health_check.timeout,
@@ -319,18 +319,17 @@ class AnsibleHCloudLoadBalancerService(AnsibleHCloud):
         }
         if self.hcloud_load_balancer_service.health_check.protocol != "tcp":
             health_check["http"] = {
-                "domain": to_native(self.hcloud_load_balancer_service.health_check.http.domain),
-                "path": to_native(self.hcloud_load_balancer_service.health_check.http.path),
-                "response": to_native(self.hcloud_load_balancer_service.health_check.http.response),
+                "domain": self.hcloud_load_balancer_service.health_check.http.domain,
+                "path": self.hcloud_load_balancer_service.health_check.http.path,
+                "response": self.hcloud_load_balancer_service.health_check.http.response,
                 "status_codes": [
-                    to_native(status_code)
-                    for status_code in self.hcloud_load_balancer_service.health_check.http.status_codes
+                    status_code for status_code in self.hcloud_load_balancer_service.health_check.http.status_codes
                 ],
                 "tls": self.hcloud_load_balancer_service.health_check.http.tls,
             }
         return {
-            "load_balancer": to_native(self.hcloud_load_balancer.name),
-            "protocol": to_native(self.hcloud_load_balancer_service.protocol),
+            "load_balancer": self.hcloud_load_balancer.name,
+            "protocol": self.hcloud_load_balancer_service.protocol,
             "listen_port": self.hcloud_load_balancer_service.listen_port,
             "destination_port": self.hcloud_load_balancer_service.destination_port,
             "proxyprotocol": self.hcloud_load_balancer_service.proxyprotocol,

--- a/plugins/modules/load_balancer_service.py
+++ b/plugins/modules/load_balancer_service.py
@@ -322,9 +322,7 @@ class AnsibleHCloudLoadBalancerService(AnsibleHCloud):
                 "domain": self.hcloud_load_balancer_service.health_check.http.domain,
                 "path": self.hcloud_load_balancer_service.health_check.http.path,
                 "response": self.hcloud_load_balancer_service.health_check.http.response,
-                "status_codes": [
-                    status_code for status_code in self.hcloud_load_balancer_service.health_check.http.status_codes
-                ],
+                "status_codes": self.hcloud_load_balancer_service.health_check.http.status_codes,
                 "tls": self.hcloud_load_balancer_service.health_check.http.tls,
             }
         return {

--- a/plugins/modules/load_balancer_target.py
+++ b/plugins/modules/load_balancer_target.py
@@ -156,17 +156,17 @@ class AnsibleHCloudLoadBalancerTarget(AnsibleHCloud):
 
     def _prepare_result(self):
         result = {
-            "type": to_native(self.hcloud_load_balancer_target.type),
-            "load_balancer": to_native(self.hcloud_load_balancer.name),
+            "type": self.hcloud_load_balancer_target.type,
+            "load_balancer": self.hcloud_load_balancer.name,
             "use_private_ip": self.hcloud_load_balancer_target.use_private_ip,
         }
 
         if self.hcloud_load_balancer_target.type == "server":
-            result["server"] = to_native(self.hcloud_load_balancer_target.server.name)
+            result["server"] = self.hcloud_load_balancer_target.server.name
         elif self.hcloud_load_balancer_target.type == "label_selector":
-            result["label_selector"] = to_native(self.hcloud_load_balancer_target.label_selector.selector)
+            result["label_selector"] = self.hcloud_load_balancer_target.label_selector.selector
         elif self.hcloud_load_balancer_target.type == "ip":
-            result["ip"] = to_native(self.hcloud_load_balancer_target.ip.ip)
+            result["ip"] = self.hcloud_load_balancer_target.ip.ip
         return result
 
     def _get_load_balancer_and_target(self):

--- a/plugins/modules/load_balancer_target.py
+++ b/plugins/modules/load_balancer_target.py
@@ -134,7 +134,6 @@ hcloud_load_balancer_target:
 """
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils.common.text.converters import to_native
 
 from ..module_utils.hcloud import AnsibleHCloud
 from ..module_utils.vendor.hcloud import APIException, HCloudException

--- a/plugins/modules/load_balancer_type_info.py
+++ b/plugins/modules/load_balancer_type_info.py
@@ -104,18 +104,20 @@ class AnsibleHCloudLoadBalancerTypeInfo(AnsibleHCloud):
         tmp = []
 
         for load_balancer_type in self.hcloud_load_balancer_type_info:
-            if load_balancer_type is not None:
-                tmp.append(
-                    {
-                        "id": str(load_balancer_type.id),
-                        "name": load_balancer_type.name,
-                        "description": load_balancer_type.description,
-                        "max_connections": load_balancer_type.max_connections,
-                        "max_services": load_balancer_type.max_services,
-                        "max_targets": load_balancer_type.max_targets,
-                        "max_assigned_certificates": load_balancer_type.max_assigned_certificates,
-                    }
-                )
+            if load_balancer_type is None:
+                continue
+
+            tmp.append(
+                {
+                    "id": str(load_balancer_type.id),
+                    "name": load_balancer_type.name,
+                    "description": load_balancer_type.description,
+                    "max_connections": load_balancer_type.max_connections,
+                    "max_services": load_balancer_type.max_services,
+                    "max_targets": load_balancer_type.max_targets,
+                    "max_assigned_certificates": load_balancer_type.max_assigned_certificates,
+                }
+            )
         return tmp
 
     def get_load_balancer_types(self):

--- a/plugins/modules/load_balancer_type_info.py
+++ b/plugins/modules/load_balancer_type_info.py
@@ -88,7 +88,6 @@ hcloud_load_balancer_type_info:
 """
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils.common.text.converters import to_native
 
 from ..module_utils.hcloud import AnsibleHCloud
 from ..module_utils.vendor.hcloud import HCloudException

--- a/plugins/modules/load_balancer_type_info.py
+++ b/plugins/modules/load_balancer_type_info.py
@@ -107,9 +107,9 @@ class AnsibleHCloudLoadBalancerTypeInfo(AnsibleHCloud):
             if load_balancer_type is not None:
                 tmp.append(
                     {
-                        "id": to_native(load_balancer_type.id),
-                        "name": to_native(load_balancer_type.name),
-                        "description": to_native(load_balancer_type.description),
+                        "id": str(load_balancer_type.id),
+                        "name": load_balancer_type.name,
+                        "description": load_balancer_type.description,
                         "max_connections": load_balancer_type.max_connections,
                         "max_services": load_balancer_type.max_services,
                         "max_targets": load_balancer_type.max_targets,

--- a/plugins/modules/location_info.py
+++ b/plugins/modules/location_info.py
@@ -94,16 +94,18 @@ class AnsibleHCloudLocationInfo(AnsibleHCloud):
         tmp = []
 
         for location in self.hcloud_location_info:
-            if location is not None:
-                tmp.append(
-                    {
-                        "id": str(location.id),
-                        "name": location.name,
-                        "description": location.description,
-                        "city": location.city,
-                        "country": location.country,
-                    }
-                )
+            if location is None:
+                continue
+
+            tmp.append(
+                {
+                    "id": str(location.id),
+                    "name": location.name,
+                    "description": location.description,
+                    "city": location.city,
+                    "country": location.country,
+                }
+            )
         return tmp
 
     def get_locations(self):

--- a/plugins/modules/location_info.py
+++ b/plugins/modules/location_info.py
@@ -97,11 +97,11 @@ class AnsibleHCloudLocationInfo(AnsibleHCloud):
             if location is not None:
                 tmp.append(
                     {
-                        "id": to_native(location.id),
-                        "name": to_native(location.name),
-                        "description": to_native(location.description),
-                        "city": to_native(location.city),
-                        "country": to_native(location.country),
+                        "id": str(location.id),
+                        "name": location.name,
+                        "description": location.description,
+                        "city": location.city,
+                        "country": location.country,
                     }
                 )
         return tmp

--- a/plugins/modules/location_info.py
+++ b/plugins/modules/location_info.py
@@ -78,7 +78,6 @@ hcloud_location_info:
 """
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils.common.text.converters import to_native
 
 from ..module_utils.hcloud import AnsibleHCloud
 from ..module_utils.vendor.hcloud import HCloudException

--- a/plugins/modules/network.py
+++ b/plugins/modules/network.py
@@ -129,9 +129,9 @@ class AnsibleHCloudNetwork(AnsibleHCloud):
 
     def _prepare_result(self):
         return {
-            "id": to_native(self.hcloud_network.id),
-            "name": to_native(self.hcloud_network.name),
-            "ip_range": to_native(self.hcloud_network.ip_range),
+            "id": str(self.hcloud_network.id),
+            "name": self.hcloud_network.name,
+            "ip_range": self.hcloud_network.ip_range,
             "expose_routes_to_vswitch": self.hcloud_network.expose_routes_to_vswitch,
             "delete_protection": self.hcloud_network.protection["delete"],
             "labels": self.hcloud_network.labels,

--- a/plugins/modules/network.py
+++ b/plugins/modules/network.py
@@ -115,7 +115,6 @@ hcloud_network:
 """
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils.common.text.converters import to_native
 
 from ..module_utils.hcloud import AnsibleHCloud
 from ..module_utils.vendor.hcloud import HCloudException

--- a/plugins/modules/network_info.py
+++ b/plugins/modules/network_info.py
@@ -218,30 +218,30 @@ class AnsibleHCloudNetworkInfo(AnsibleHCloud):
 
                 servers = []
                 for server in network.servers:
-                    image = None if server.image is None else to_native(server.image.name)
-                    ipv4_address = None if server.public_net.ipv4 is None else to_native(server.public_net.ipv4.ip)
-                    ipv6 = None if server.public_net.ipv6 is None else to_native(server.public_net.ipv6.ip)
+                    image = None if server.image is None else server.image.name
+                    ipv4_address = None if server.public_net.ipv4 is None else server.public_net.ipv4.ip
+                    ipv6 = None if server.public_net.ipv6 is None else server.public_net.ipv6.ip
                     prepared_server = {
-                        "id": to_native(server.id),
-                        "name": to_native(server.name),
+                        "id": str(server.id),
+                        "name": server.name,
                         "ipv4_address": ipv4_address,
                         "ipv6": ipv6,
                         "image": image,
-                        "server_type": to_native(server.server_type.name),
-                        "datacenter": to_native(server.datacenter.name),
-                        "location": to_native(server.datacenter.location.name),
+                        "server_type": server.server_type.name,
+                        "datacenter": server.datacenter.name,
+                        "location": server.datacenter.location.name,
                         "rescue_enabled": server.rescue_enabled,
-                        "backup_window": to_native(server.backup_window),
+                        "backup_window": server.backup_window,
                         "labels": server.labels,
-                        "status": to_native(server.status),
+                        "status": server.status,
                     }
                     servers.append(prepared_server)
 
                 tmp.append(
                     {
-                        "id": to_native(network.id),
-                        "name": to_native(network.name),
-                        "ip_range": to_native(network.ip_range),
+                        "id": str(network.id),
+                        "name": network.name,
+                        "ip_range": network.ip_range,
                         "subnetworks": subnets,
                         "routes": routes,
                         "expose_routes_to_vswitch": network.expose_routes_to_vswitch,

--- a/plugins/modules/network_info.py
+++ b/plugins/modules/network_info.py
@@ -201,55 +201,55 @@ class AnsibleHCloudNetworkInfo(AnsibleHCloud):
         tmp = []
 
         for network in self.hcloud_network_info:
-            if network is not None:
-                subnets = []
-                for subnet in network.subnets:
-                    prepared_subnet = {
-                        "type": subnet.type,
-                        "ip_range": subnet.ip_range,
-                        "network_zone": subnet.network_zone,
-                        "gateway": subnet.gateway,
-                    }
-                    subnets.append(prepared_subnet)
-                routes = []
-                for route in network.routes:
-                    prepared_route = {"destination": route.destination, "gateway": route.gateway}
-                    routes.append(prepared_route)
+            if network is None:
+                continue
 
-                servers = []
-                for server in network.servers:
-                    image = None if server.image is None else server.image.name
-                    ipv4_address = None if server.public_net.ipv4 is None else server.public_net.ipv4.ip
-                    ipv6 = None if server.public_net.ipv6 is None else server.public_net.ipv6.ip
-                    prepared_server = {
-                        "id": str(server.id),
-                        "name": server.name,
-                        "ipv4_address": ipv4_address,
-                        "ipv6": ipv6,
-                        "image": image,
-                        "server_type": server.server_type.name,
-                        "datacenter": server.datacenter.name,
-                        "location": server.datacenter.location.name,
-                        "rescue_enabled": server.rescue_enabled,
-                        "backup_window": server.backup_window,
-                        "labels": server.labels,
-                        "status": server.status,
-                    }
-                    servers.append(prepared_server)
+            subnets = []
+            for subnet in network.subnets:
+                prepared_subnet = {
+                    "type": subnet.type,
+                    "ip_range": subnet.ip_range,
+                    "network_zone": subnet.network_zone,
+                    "gateway": subnet.gateway,
+                }
+                subnets.append(prepared_subnet)
 
-                tmp.append(
-                    {
-                        "id": str(network.id),
-                        "name": network.name,
-                        "ip_range": network.ip_range,
-                        "subnetworks": subnets,
-                        "routes": routes,
-                        "expose_routes_to_vswitch": network.expose_routes_to_vswitch,
-                        "servers": servers,
-                        "labels": network.labels,
-                        "delete_protection": network.protection["delete"],
-                    }
-                )
+            routes = []
+            for route in network.routes:
+                prepared_route = {"destination": route.destination, "gateway": route.gateway}
+                routes.append(prepared_route)
+
+            servers = []
+            for server in network.servers:
+                prepared_server = {
+                    "id": str(server.id),
+                    "name": server.name,
+                    "ipv4_address": server.public_net.ipv4.ip if server.public_net.ipv4 is not None else None,
+                    "ipv6": server.public_net.ipv6.ip if server.public_net.ipv6 is not None else None,
+                    "image": server.image.name if server.image is not None else None,
+                    "server_type": server.server_type.name,
+                    "datacenter": server.datacenter.name,
+                    "location": server.datacenter.location.name,
+                    "rescue_enabled": server.rescue_enabled,
+                    "backup_window": server.backup_window,
+                    "labels": server.labels,
+                    "status": server.status,
+                }
+                servers.append(prepared_server)
+
+            tmp.append(
+                {
+                    "id": str(network.id),
+                    "name": network.name,
+                    "ip_range": network.ip_range,
+                    "subnetworks": subnets,
+                    "routes": routes,
+                    "expose_routes_to_vswitch": network.expose_routes_to_vswitch,
+                    "servers": servers,
+                    "labels": network.labels,
+                    "delete_protection": network.protection["delete"],
+                }
+            )
         return tmp
 
     def get_networks(self):

--- a/plugins/modules/network_info.py
+++ b/plugins/modules/network_info.py
@@ -185,7 +185,6 @@ hcloud_network_info:
 """
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils.common.text.converters import to_native
 
 from ..module_utils.hcloud import AnsibleHCloud
 from ..module_utils.vendor.hcloud import HCloudException

--- a/plugins/modules/placement_group.py
+++ b/plugins/modules/placement_group.py
@@ -107,7 +107,6 @@ hcloud_placement_group:
 """
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils.common.text.converters import to_native
 
 from ..module_utils.hcloud import AnsibleHCloud
 from ..module_utils.vendor.hcloud import HCloudException

--- a/plugins/modules/placement_group.py
+++ b/plugins/modules/placement_group.py
@@ -121,10 +121,10 @@ class AnsibleHCloudPlacementGroup(AnsibleHCloud):
 
     def _prepare_result(self):
         return {
-            "id": to_native(self.hcloud_placement_group.id),
-            "name": to_native(self.hcloud_placement_group.name),
+            "id": str(self.hcloud_placement_group.id),
+            "name": self.hcloud_placement_group.name,
             "labels": self.hcloud_placement_group.labels,
-            "type": to_native(self.hcloud_placement_group.type),
+            "type": self.hcloud_placement_group.type,
             "servers": self.hcloud_placement_group.servers,
         }
 

--- a/plugins/modules/primary_ip.py
+++ b/plugins/modules/primary_ip.py
@@ -168,7 +168,6 @@ hcloud_primary_ip:
 """
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils.common.text.converters import to_native
 
 from ..module_utils.hcloud import AnsibleHCloud
 from ..module_utils.vendor.hcloud import HCloudException

--- a/plugins/modules/primary_ip.py
+++ b/plugins/modules/primary_ip.py
@@ -182,19 +182,17 @@ class AnsibleHCloudPrimaryIP(AnsibleHCloud):
 
     def _prepare_result(self):
         return {
-            "id": to_native(self.hcloud_primary_ip.id),
-            "name": to_native(self.hcloud_primary_ip.name),
-            "ip": to_native(self.hcloud_primary_ip.ip),
-            "type": to_native(self.hcloud_primary_ip.type),
-            "datacenter": to_native(self.hcloud_primary_ip.datacenter.name),
+            "id": str(self.hcloud_primary_ip.id),
+            "name": self.hcloud_primary_ip.name,
+            "ip": self.hcloud_primary_ip.ip,
+            "type": self.hcloud_primary_ip.type,
+            "datacenter": self.hcloud_primary_ip.datacenter.name,
             "labels": self.hcloud_primary_ip.labels,
             "delete_protection": self.hcloud_primary_ip.protection["delete"],
             "assignee_id": (
-                to_native(self.hcloud_primary_ip.assignee_id)
-                if self.hcloud_primary_ip.assignee_id is not None
-                else None
+                str(self.hcloud_primary_ip.assignee_id) if self.hcloud_primary_ip.assignee_id is not None else None
             ),
-            "assignee_type": to_native(self.hcloud_primary_ip.assignee_type),
+            "assignee_type": self.hcloud_primary_ip.assignee_type,
             "auto_delete": self.hcloud_primary_ip.auto_delete,
         }
 

--- a/plugins/modules/primary_ip_info.py
+++ b/plugins/modules/primary_ip_info.py
@@ -146,15 +146,15 @@ class AnsibleHCloudPrimaryIPInfo(AnsibleHCloud):
 
             tmp.append(
                 {
-                    "id": to_native(primary_ip.id),
-                    "name": to_native(primary_ip.name),
-                    "ip": to_native(primary_ip.ip),
-                    "type": to_native(primary_ip.type),
-                    "assignee_id": (to_native(primary_ip.assignee_id) if primary_ip.assignee_id is not None else None),
-                    "assignee_type": to_native(primary_ip.assignee_type),
+                    "id": str(primary_ip.id),
+                    "name": primary_ip.name,
+                    "ip": primary_ip.ip,
+                    "type": primary_ip.type,
+                    "assignee_id": (str(primary_ip.assignee_id) if primary_ip.assignee_id is not None else None),
+                    "assignee_type": primary_ip.assignee_type,
                     "auto_delete": primary_ip.auto_delete,
-                    "home_location": to_native(primary_ip.datacenter.name),
-                    "dns_ptr": to_native(primary_ip.dns_ptr[0]["dns_ptr"]) if len(primary_ip.dns_ptr) > 0 else None,
+                    "home_location": primary_ip.datacenter.name,
+                    "dns_ptr": primary_ip.dns_ptr[0]["dns_ptr"] if len(primary_ip.dns_ptr) > 0 else None,
                     "labels": primary_ip.labels,
                     "delete_protection": primary_ip.protection["delete"],
                 }

--- a/plugins/modules/primary_ip_info.py
+++ b/plugins/modules/primary_ip_info.py
@@ -125,7 +125,6 @@ hcloud_primary_ip_info:
 """
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils.common.text.converters import to_native
 
 from ..module_utils.hcloud import AnsibleHCloud
 from ..module_utils.vendor.hcloud import HCloudException

--- a/plugins/modules/primary_ip_info.py
+++ b/plugins/modules/primary_ip_info.py
@@ -150,11 +150,11 @@ class AnsibleHCloudPrimaryIPInfo(AnsibleHCloud):
                     "name": primary_ip.name,
                     "ip": primary_ip.ip,
                     "type": primary_ip.type,
-                    "assignee_id": (str(primary_ip.assignee_id) if primary_ip.assignee_id is not None else None),
+                    "assignee_id": str(primary_ip.assignee_id) if primary_ip.assignee_id is not None else None,
                     "assignee_type": primary_ip.assignee_type,
                     "auto_delete": primary_ip.auto_delete,
                     "home_location": primary_ip.datacenter.name,
-                    "dns_ptr": primary_ip.dns_ptr[0]["dns_ptr"] if len(primary_ip.dns_ptr) > 0 else None,
+                    "dns_ptr": primary_ip.dns_ptr[0]["dns_ptr"] if len(primary_ip.dns_ptr) else None,
                     "labels": primary_ip.labels,
                     "delete_protection": primary_ip.protection["delete"],
                 }

--- a/plugins/modules/rdns.py
+++ b/plugins/modules/rdns.py
@@ -157,18 +157,18 @@ class AnsibleHCloudReverseDNS(AnsibleHCloud):
             "server": None,
             "floating_ip": None,
             "load_balancer": None,
-            "ip_address": to_native(self.hcloud_rdns["ip_address"]),
-            "dns_ptr": to_native(self.hcloud_rdns["dns_ptr"]),
+            "ip_address": self.hcloud_rdns["ip_address"],
+            "dns_ptr": self.hcloud_rdns["dns_ptr"],
         }
 
         if self.module.params.get("server"):
-            result["server"] = to_native(self.hcloud_resource.name)
+            result["server"] = self.hcloud_resource.name
         elif self.module.params.get("floating_ip"):
-            result["floating_ip"] = to_native(self.hcloud_resource.name)
+            result["floating_ip"] = self.hcloud_resource.name
         elif self.module.params.get("load_balancer"):
-            result["load_balancer"] = to_native(self.hcloud_resource.name)
+            result["load_balancer"] = self.hcloud_resource.name
         elif self.module.params.get("primary_ip"):
-            result["primary_ip"] = to_native(self.hcloud_resource.name)
+            result["primary_ip"] = self.hcloud_resource.name
         return result
 
     def _get_resource(self):

--- a/plugins/modules/rdns.py
+++ b/plugins/modules/rdns.py
@@ -136,7 +136,6 @@ import ipaddress
 from typing import Any
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils.common.text.converters import to_native
 
 from ..module_utils.hcloud import AnsibleHCloud
 from ..module_utils.vendor.hcloud import HCloudException

--- a/plugins/modules/route.py
+++ b/plugins/modules/route.py
@@ -101,8 +101,8 @@ class AnsibleHCloudRoute(AnsibleHCloud):
 
     def _prepare_result(self):
         return {
-            "network": to_native(self.hcloud_network.name),
-            "destination": to_native(self.hcloud_route.destination),
+            "network": self.hcloud_network.name,
+            "destination": self.hcloud_route.destination,
             "gateway": self.hcloud_route.gateway,
         }
 

--- a/plugins/modules/route.py
+++ b/plugins/modules/route.py
@@ -86,7 +86,6 @@ hcloud_route:
 """
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils.common.text.converters import to_native
 
 from ..module_utils.hcloud import AnsibleHCloud
 from ..module_utils.vendor.hcloud import HCloudException

--- a/plugins/modules/server.py
+++ b/plugins/modules/server.py
@@ -338,7 +338,6 @@ hcloud_server:
 from datetime import datetime, timedelta, timezone
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils.common.text.converters import to_native
 
 from ..module_utils.hcloud import AnsibleHCloud
 from ..module_utils.vendor.hcloud import HCloudException

--- a/plugins/modules/server.py
+++ b/plugins/modules/server.py
@@ -358,38 +358,34 @@ class AnsibleHCloudServer(AnsibleHCloud):
     hcloud_server: BoundServer | None = None
 
     def _prepare_result(self):
-        image = None if self.hcloud_server.image is None else to_native(self.hcloud_server.image.name)
+        image = None if self.hcloud_server.image is None else self.hcloud_server.image.name
         placement_group = (
-            None if self.hcloud_server.placement_group is None else to_native(self.hcloud_server.placement_group.name)
+            None if self.hcloud_server.placement_group is None else self.hcloud_server.placement_group.name
         )
-        ipv4_address = (
-            None if self.hcloud_server.public_net.ipv4 is None else to_native(self.hcloud_server.public_net.ipv4.ip)
-        )
-        ipv6 = None if self.hcloud_server.public_net.ipv6 is None else to_native(self.hcloud_server.public_net.ipv6.ip)
-        backup_window = (
-            None if self.hcloud_server.backup_window is None else to_native(self.hcloud_server.backup_window)
-        )
+        ipv4_address = None if self.hcloud_server.public_net.ipv4 is None else self.hcloud_server.public_net.ipv4.ip
+        ipv6 = None if self.hcloud_server.public_net.ipv6 is None else self.hcloud_server.public_net.ipv6.ip
+        backup_window = None if self.hcloud_server.backup_window is None else self.hcloud_server.backup_window
         return {
-            "id": to_native(self.hcloud_server.id),
-            "name": to_native(self.hcloud_server.name),
-            "created": to_native(self.hcloud_server.created.isoformat()),
+            "id": str(self.hcloud_server.id),
+            "name": self.hcloud_server.name,
+            "created": self.hcloud_server.created.isoformat(),
             "ipv4_address": ipv4_address,
             "ipv6": ipv6,
-            "private_networks": [to_native(net.network.name) for net in self.hcloud_server.private_net],
+            "private_networks": [net.network.name for net in self.hcloud_server.private_net],
             "private_networks_info": [
-                {"name": to_native(net.network.name), "ip": net.ip} for net in self.hcloud_server.private_net
+                {"name": net.network.name, "ip": net.ip} for net in self.hcloud_server.private_net
             ],
             "image": image,
-            "server_type": to_native(self.hcloud_server.server_type.name),
-            "datacenter": to_native(self.hcloud_server.datacenter.name),
-            "location": to_native(self.hcloud_server.datacenter.location.name),
+            "server_type": self.hcloud_server.server_type.name,
+            "datacenter": self.hcloud_server.datacenter.name,
+            "location": self.hcloud_server.datacenter.location.name,
             "placement_group": placement_group,
             "rescue_enabled": self.hcloud_server.rescue_enabled,
             "backup_window": backup_window,
             "labels": self.hcloud_server.labels,
             "delete_protection": self.hcloud_server.protection["delete"],
             "rebuild_protection": self.hcloud_server.protection["rebuild"],
-            "status": to_native(self.hcloud_server.status),
+            "status": self.hcloud_server.status,
         }
 
     def _get_server(self):

--- a/plugins/modules/server.py
+++ b/plugins/modules/server.py
@@ -358,30 +358,27 @@ class AnsibleHCloudServer(AnsibleHCloud):
     hcloud_server: BoundServer | None = None
 
     def _prepare_result(self):
-        image = None if self.hcloud_server.image is None else self.hcloud_server.image.name
-        placement_group = (
-            None if self.hcloud_server.placement_group is None else self.hcloud_server.placement_group.name
-        )
-        ipv4_address = None if self.hcloud_server.public_net.ipv4 is None else self.hcloud_server.public_net.ipv4.ip
-        ipv6 = None if self.hcloud_server.public_net.ipv6 is None else self.hcloud_server.public_net.ipv6.ip
-        backup_window = None if self.hcloud_server.backup_window is None else self.hcloud_server.backup_window
         return {
             "id": str(self.hcloud_server.id),
             "name": self.hcloud_server.name,
             "created": self.hcloud_server.created.isoformat(),
-            "ipv4_address": ipv4_address,
-            "ipv6": ipv6,
+            "ipv4_address": (
+                self.hcloud_server.public_net.ipv4.ip if self.hcloud_server.public_net.ipv4 is not None else None
+            ),
+            "ipv6": self.hcloud_server.public_net.ipv6.ip if self.hcloud_server.public_net.ipv6 is not None else None,
             "private_networks": [net.network.name for net in self.hcloud_server.private_net],
             "private_networks_info": [
                 {"name": net.network.name, "ip": net.ip} for net in self.hcloud_server.private_net
             ],
-            "image": image,
+            "image": self.hcloud_server.image.name if self.hcloud_server.image is not None else None,
             "server_type": self.hcloud_server.server_type.name,
             "datacenter": self.hcloud_server.datacenter.name,
             "location": self.hcloud_server.datacenter.location.name,
-            "placement_group": placement_group,
+            "placement_group": (
+                self.hcloud_server.placement_group.name if self.hcloud_server.placement_group is not None else None
+            ),
             "rescue_enabled": self.hcloud_server.rescue_enabled,
-            "backup_window": backup_window,
+            "backup_window": self.hcloud_server.backup_window,
             "labels": self.hcloud_server.labels,
             "delete_protection": self.hcloud_server.protection["delete"],
             "rebuild_protection": self.hcloud_server.protection["rebuild"],

--- a/plugins/modules/server_info.py
+++ b/plugins/modules/server_info.py
@@ -146,7 +146,6 @@ hcloud_server_info:
 """
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils.common.text.converters import to_native
 
 from ..module_utils.hcloud import AnsibleHCloud
 from ..module_utils.vendor.hcloud import HCloudException

--- a/plugins/modules/server_info.py
+++ b/plugins/modules/server_info.py
@@ -162,36 +162,31 @@ class AnsibleHCloudServerInfo(AnsibleHCloud):
         tmp = []
 
         for server in self.hcloud_server_info:
-            if server is not None:
-                image = None if server.image is None else server.image.name
-                placement_group = None if server.placement_group is None else server.placement_group.name
-                ipv4_address = None if server.public_net.ipv4 is None else server.public_net.ipv4.ip
-                ipv6 = None if server.public_net.ipv6 is None else server.public_net.ipv6.ip
-                backup_window = None if server.backup_window is None else server.backup_window
-                tmp.append(
-                    {
-                        "id": str(server.id),
-                        "name": server.name,
-                        "created": server.created.isoformat(),
-                        "ipv4_address": ipv4_address,
-                        "ipv6": ipv6,
-                        "private_networks": [net.network.name for net in server.private_net],
-                        "private_networks_info": [
-                            {"name": net.network.name, "ip": net.ip} for net in server.private_net
-                        ],
-                        "image": image,
-                        "server_type": server.server_type.name,
-                        "datacenter": server.datacenter.name,
-                        "location": server.datacenter.location.name,
-                        "placement_group": placement_group,
-                        "rescue_enabled": server.rescue_enabled,
-                        "backup_window": backup_window,
-                        "labels": server.labels,
-                        "status": server.status,
-                        "delete_protection": server.protection["delete"],
-                        "rebuild_protection": server.protection["rebuild"],
-                    }
-                )
+            if server is None:
+                continue
+
+            tmp.append(
+                {
+                    "id": str(server.id),
+                    "name": server.name,
+                    "created": server.created.isoformat(),
+                    "ipv4_address": server.public_net.ipv4.ip if server.public_net.ipv4 is not None else None,
+                    "ipv6": server.public_net.ipv6.ip if server.public_net.ipv6 is not None else None,
+                    "private_networks": [net.network.name for net in server.private_net],
+                    "private_networks_info": [{"name": net.network.name, "ip": net.ip} for net in server.private_net],
+                    "image": server.image.name if server.image is not None else None,
+                    "server_type": server.server_type.name,
+                    "datacenter": server.datacenter.name,
+                    "location": server.datacenter.location.name,
+                    "placement_group": server.placement_group.name if server.placement_group is not None else None,
+                    "rescue_enabled": server.rescue_enabled,
+                    "backup_window": server.backup_window,
+                    "labels": server.labels,
+                    "status": server.status,
+                    "delete_protection": server.protection["delete"],
+                    "rebuild_protection": server.protection["rebuild"],
+                }
+            )
         return tmp
 
     def get_servers(self):

--- a/plugins/modules/server_info.py
+++ b/plugins/modules/server_info.py
@@ -163,31 +163,31 @@ class AnsibleHCloudServerInfo(AnsibleHCloud):
 
         for server in self.hcloud_server_info:
             if server is not None:
-                image = None if server.image is None else to_native(server.image.name)
-                placement_group = None if server.placement_group is None else to_native(server.placement_group.name)
-                ipv4_address = None if server.public_net.ipv4 is None else to_native(server.public_net.ipv4.ip)
-                ipv6 = None if server.public_net.ipv6 is None else to_native(server.public_net.ipv6.ip)
-                backup_window = None if server.backup_window is None else to_native(server.backup_window)
+                image = None if server.image is None else server.image.name
+                placement_group = None if server.placement_group is None else server.placement_group.name
+                ipv4_address = None if server.public_net.ipv4 is None else server.public_net.ipv4.ip
+                ipv6 = None if server.public_net.ipv6 is None else server.public_net.ipv6.ip
+                backup_window = None if server.backup_window is None else server.backup_window
                 tmp.append(
                     {
-                        "id": to_native(server.id),
-                        "name": to_native(server.name),
-                        "created": to_native(server.created.isoformat()),
+                        "id": str(server.id),
+                        "name": server.name,
+                        "created": server.created.isoformat(),
                         "ipv4_address": ipv4_address,
                         "ipv6": ipv6,
-                        "private_networks": [to_native(net.network.name) for net in server.private_net],
+                        "private_networks": [net.network.name for net in server.private_net],
                         "private_networks_info": [
-                            {"name": to_native(net.network.name), "ip": net.ip} for net in server.private_net
+                            {"name": net.network.name, "ip": net.ip} for net in server.private_net
                         ],
                         "image": image,
-                        "server_type": to_native(server.server_type.name),
-                        "datacenter": to_native(server.datacenter.name),
-                        "location": to_native(server.datacenter.location.name),
+                        "server_type": server.server_type.name,
+                        "datacenter": server.datacenter.name,
+                        "location": server.datacenter.location.name,
                         "placement_group": placement_group,
                         "rescue_enabled": server.rescue_enabled,
                         "backup_window": backup_window,
                         "labels": server.labels,
-                        "status": to_native(server.status),
+                        "status": server.status,
                         "delete_protection": server.protection["delete"],
                         "rebuild_protection": server.protection["rebuild"],
                     }

--- a/plugins/modules/server_network.py
+++ b/plugins/modules/server_network.py
@@ -128,10 +128,10 @@ class AnsibleHCloudServerNetwork(AnsibleHCloud):
 
     def _prepare_result(self):
         return {
-            "network": to_native(self.hcloud_network.name),
-            "server": to_native(self.hcloud_server.name),
-            "ip": to_native(self.hcloud_server_network.ip),
-            "alias_ips": [to_native(ip) for ip in sorted(self.hcloud_server_network.alias_ips)],
+            "network": self.hcloud_network.name,
+            "server": self.hcloud_server.name,
+            "ip": self.hcloud_server_network.ip,
+            "alias_ips": [ip for ip in sorted(self.hcloud_server_network.alias_ips)],
         }
 
     def _get_server_and_network(self):

--- a/plugins/modules/server_network.py
+++ b/plugins/modules/server_network.py
@@ -131,7 +131,7 @@ class AnsibleHCloudServerNetwork(AnsibleHCloud):
             "network": self.hcloud_network.name,
             "server": self.hcloud_server.name,
             "ip": self.hcloud_server_network.ip,
-            "alias_ips": [ip for ip in sorted(self.hcloud_server_network.alias_ips)],
+            "alias_ips": list(sorted(self.hcloud_server_network.alias_ips)),
         }
 
     def _get_server_and_network(self):

--- a/plugins/modules/server_network.py
+++ b/plugins/modules/server_network.py
@@ -111,7 +111,6 @@ hcloud_server_network:
 """
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils.common.text.converters import to_native
 
 from ..module_utils.hcloud import AnsibleHCloud
 from ..module_utils.vendor.hcloud import APIException, HCloudException

--- a/plugins/modules/server_type_info.py
+++ b/plugins/modules/server_type_info.py
@@ -143,15 +143,15 @@ class AnsibleHCloudServerTypeInfo(AnsibleHCloud):
             if server_type is not None:
                 tmp.append(
                     {
-                        "id": to_native(server_type.id),
-                        "name": to_native(server_type.name),
-                        "description": to_native(server_type.description),
+                        "id": str(server_type.id),
+                        "name": server_type.name,
+                        "description": server_type.description,
                         "cores": server_type.cores,
                         "memory": server_type.memory,
                         "disk": server_type.disk,
-                        "storage_type": to_native(server_type.storage_type),
-                        "cpu_type": to_native(server_type.cpu_type),
-                        "architecture": to_native(server_type.architecture),
+                        "storage_type": server_type.storage_type,
+                        "cpu_type": server_type.cpu_type,
+                        "architecture": server_type.architecture,
                         "included_traffic": server_type.included_traffic,
                         "deprecation": (
                             {

--- a/plugins/modules/server_type_info.py
+++ b/plugins/modules/server_type_info.py
@@ -124,7 +124,6 @@ hcloud_server_type_info:
 """
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils.common.text.converters import to_native
 
 from ..module_utils.hcloud import AnsibleHCloud
 from ..module_utils.vendor.hcloud import HCloudException

--- a/plugins/modules/server_type_info.py
+++ b/plugins/modules/server_type_info.py
@@ -140,29 +140,31 @@ class AnsibleHCloudServerTypeInfo(AnsibleHCloud):
         tmp = []
 
         for server_type in self.hcloud_server_type_info:
-            if server_type is not None:
-                tmp.append(
-                    {
-                        "id": str(server_type.id),
-                        "name": server_type.name,
-                        "description": server_type.description,
-                        "cores": server_type.cores,
-                        "memory": server_type.memory,
-                        "disk": server_type.disk,
-                        "storage_type": server_type.storage_type,
-                        "cpu_type": server_type.cpu_type,
-                        "architecture": server_type.architecture,
-                        "included_traffic": server_type.included_traffic,
-                        "deprecation": (
-                            {
-                                "announced": server_type.deprecation.announced.isoformat(),
-                                "unavailable_after": server_type.deprecation.unavailable_after.isoformat(),
-                            }
-                            if server_type.deprecation is not None
-                            else None
-                        ),
-                    }
-                )
+            if server_type is None:
+                continue
+
+            tmp.append(
+                {
+                    "id": str(server_type.id),
+                    "name": server_type.name,
+                    "description": server_type.description,
+                    "cores": server_type.cores,
+                    "memory": server_type.memory,
+                    "disk": server_type.disk,
+                    "storage_type": server_type.storage_type,
+                    "cpu_type": server_type.cpu_type,
+                    "architecture": server_type.architecture,
+                    "included_traffic": server_type.included_traffic,
+                    "deprecation": (
+                        {
+                            "announced": server_type.deprecation.announced.isoformat(),
+                            "unavailable_after": server_type.deprecation.unavailable_after.isoformat(),
+                        }
+                        if server_type.deprecation is not None
+                        else None
+                    ),
+                }
+            )
         return tmp
 
     def get_server_types(self):

--- a/plugins/modules/ssh_key.py
+++ b/plugins/modules/ssh_key.py
@@ -127,10 +127,10 @@ class AnsibleHCloudSSHKey(AnsibleHCloud):
 
     def _prepare_result(self):
         return {
-            "id": to_native(self.hcloud_ssh_key.id),
-            "name": to_native(self.hcloud_ssh_key.name),
-            "fingerprint": to_native(self.hcloud_ssh_key.fingerprint),
-            "public_key": to_native(self.hcloud_ssh_key.public_key),
+            "id": str(self.hcloud_ssh_key.id),
+            "name": self.hcloud_ssh_key.name,
+            "fingerprint": self.hcloud_ssh_key.fingerprint,
+            "public_key": self.hcloud_ssh_key.public_key,
             "labels": self.hcloud_ssh_key.labels,
         }
 

--- a/plugins/modules/ssh_key.py
+++ b/plugins/modules/ssh_key.py
@@ -113,7 +113,6 @@ hcloud_ssh_key:
 """
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils.common.text.converters import to_native
 
 from ..module_utils.hcloud import AnsibleHCloud
 from ..module_utils.vendor.hcloud import HCloudException

--- a/plugins/modules/ssh_key_info.py
+++ b/plugins/modules/ssh_key_info.py
@@ -98,10 +98,10 @@ class AnsibleHCloudSSHKeyInfo(AnsibleHCloud):
             if ssh_key:
                 ssh_keys.append(
                     {
-                        "id": to_native(ssh_key.id),
-                        "name": to_native(ssh_key.name),
-                        "fingerprint": to_native(ssh_key.fingerprint),
-                        "public_key": to_native(ssh_key.public_key),
+                        "id": str(ssh_key.id),
+                        "name": ssh_key.name,
+                        "fingerprint": ssh_key.fingerprint,
+                        "public_key": ssh_key.public_key,
                         "labels": ssh_key.labels,
                     }
                 )

--- a/plugins/modules/ssh_key_info.py
+++ b/plugins/modules/ssh_key_info.py
@@ -92,20 +92,22 @@ class AnsibleHCloudSSHKeyInfo(AnsibleHCloud):
     hcloud_ssh_key_info: list[BoundSSHKey] | None = None
 
     def _prepare_result(self):
-        ssh_keys = []
+        tmp = []
 
         for ssh_key in self.hcloud_ssh_key_info:
-            if ssh_key:
-                ssh_keys.append(
-                    {
-                        "id": str(ssh_key.id),
-                        "name": ssh_key.name,
-                        "fingerprint": ssh_key.fingerprint,
-                        "public_key": ssh_key.public_key,
-                        "labels": ssh_key.labels,
-                    }
-                )
-        return ssh_keys
+            if ssh_key is None:
+                continue
+
+            tmp.append(
+                {
+                    "id": str(ssh_key.id),
+                    "name": ssh_key.name,
+                    "fingerprint": ssh_key.fingerprint,
+                    "public_key": ssh_key.public_key,
+                    "labels": ssh_key.labels,
+                }
+            )
+        return tmp
 
     def get_ssh_keys(self):
         try:

--- a/plugins/modules/ssh_key_info.py
+++ b/plugins/modules/ssh_key_info.py
@@ -79,7 +79,6 @@ hcloud_ssh_key_info:
 """
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils.common.text.converters import to_native
 
 from ..module_utils.hcloud import AnsibleHCloud
 from ..module_utils.vendor.hcloud import HCloudException

--- a/plugins/modules/subnetwork.py
+++ b/plugins/modules/subnetwork.py
@@ -123,7 +123,6 @@ hcloud_subnetwork:
 """
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils.common.text.converters import to_native
 
 from ..module_utils.hcloud import AnsibleHCloud
 from ..module_utils.vendor.hcloud import HCloudException

--- a/plugins/modules/subnetwork.py
+++ b/plugins/modules/subnetwork.py
@@ -138,10 +138,10 @@ class AnsibleHCloudSubnetwork(AnsibleHCloud):
 
     def _prepare_result(self):
         return {
-            "network": to_native(self.hcloud_network.name),
-            "ip_range": to_native(self.hcloud_subnetwork.ip_range),
-            "type": to_native(self.hcloud_subnetwork.type),
-            "network_zone": to_native(self.hcloud_subnetwork.network_zone),
+            "network": self.hcloud_network.name,
+            "ip_range": self.hcloud_subnetwork.ip_range,
+            "type": self.hcloud_subnetwork.type,
+            "network_zone": self.hcloud_subnetwork.network_zone,
             "gateway": self.hcloud_subnetwork.gateway,
             "vswitch_id": self.hcloud_subnetwork.vswitch_id,
         }

--- a/plugins/modules/volume.py
+++ b/plugins/modules/volume.py
@@ -175,16 +175,16 @@ class AnsibleHCloudVolume(AnsibleHCloud):
     def _prepare_result(self):
         server_name = None
         if self.hcloud_volume.server is not None:
-            server_name = to_native(self.hcloud_volume.server.name)
+            server_name = self.hcloud_volume.server.name
 
         return {
-            "id": to_native(self.hcloud_volume.id),
-            "name": to_native(self.hcloud_volume.name),
+            "id": str(self.hcloud_volume.id),
+            "name": self.hcloud_volume.name,
             "size": self.hcloud_volume.size,
-            "location": to_native(self.hcloud_volume.location.name),
+            "location": self.hcloud_volume.location.name,
             "labels": self.hcloud_volume.labels,
             "server": server_name,
-            "linux_device": to_native(self.hcloud_volume.linux_device),
+            "linux_device": self.hcloud_volume.linux_device,
             "delete_protection": self.hcloud_volume.protection["delete"],
         }
 

--- a/plugins/modules/volume.py
+++ b/plugins/modules/volume.py
@@ -160,7 +160,6 @@ hcloud_volume:
 """
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils.common.text.converters import to_native
 
 from ..module_utils.hcloud import AnsibleHCloud
 from ..module_utils.vendor.hcloud import HCloudException

--- a/plugins/modules/volume.py
+++ b/plugins/modules/volume.py
@@ -173,17 +173,13 @@ class AnsibleHCloudVolume(AnsibleHCloud):
     hcloud_volume: BoundVolume | None = None
 
     def _prepare_result(self):
-        server_name = None
-        if self.hcloud_volume.server is not None:
-            server_name = self.hcloud_volume.server.name
-
         return {
             "id": str(self.hcloud_volume.id),
             "name": self.hcloud_volume.name,
             "size": self.hcloud_volume.size,
             "location": self.hcloud_volume.location.name,
             "labels": self.hcloud_volume.labels,
-            "server": server_name,
+            "server": self.hcloud_volume.server.name if self.hcloud_volume.server is not None else None,
             "linux_device": self.hcloud_volume.linux_device,
             "delete_protection": self.hcloud_volume.protection["delete"],
         }

--- a/plugins/modules/volume_info.py
+++ b/plugins/modules/volume_info.py
@@ -114,16 +114,16 @@ class AnsibleHCloudVolumeInfo(AnsibleHCloud):
             if volume is not None:
                 server_name = None
                 if volume.server is not None:
-                    server_name = to_native(volume.server.name)
+                    server_name = volume.server.name
                 tmp.append(
                     {
-                        "id": to_native(volume.id),
-                        "name": to_native(volume.name),
+                        "id": str(volume.id),
+                        "name": volume.name,
                         "size": volume.size,
-                        "location": to_native(volume.location.name),
+                        "location": volume.location.name,
                         "labels": volume.labels,
                         "server": server_name,
-                        "linux_device": to_native(volume.linux_device),
+                        "linux_device": volume.linux_device,
                         "delete_protection": volume.protection["delete"],
                     }
                 )

--- a/plugins/modules/volume_info.py
+++ b/plugins/modules/volume_info.py
@@ -111,22 +111,21 @@ class AnsibleHCloudVolumeInfo(AnsibleHCloud):
         tmp = []
 
         for volume in self.hcloud_volume_info:
-            if volume is not None:
-                server_name = None
-                if volume.server is not None:
-                    server_name = volume.server.name
-                tmp.append(
-                    {
-                        "id": str(volume.id),
-                        "name": volume.name,
-                        "size": volume.size,
-                        "location": volume.location.name,
-                        "labels": volume.labels,
-                        "server": server_name,
-                        "linux_device": volume.linux_device,
-                        "delete_protection": volume.protection["delete"],
-                    }
-                )
+            if volume is None:
+                continue
+
+            tmp.append(
+                {
+                    "id": str(volume.id),
+                    "name": volume.name,
+                    "size": volume.size,
+                    "location": volume.location.name,
+                    "labels": volume.labels,
+                    "server": volume.server.name if volume.server is not None else None,
+                    "linux_device": volume.linux_device,
+                    "delete_protection": volume.protection["delete"],
+                }
+            )
 
         return tmp
 

--- a/plugins/modules/volume_info.py
+++ b/plugins/modules/volume_info.py
@@ -95,7 +95,6 @@ hcloud_volume_info:
 """
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils.common.text.converters import to_native
 
 from ..module_utils.hcloud import AnsibleHCloud
 from ..module_utils.vendor.hcloud import HCloudException


### PR DESCRIPTION
##### SUMMARY

Since we only support python >=3.8, the `to_native` python2/3 compatibility function is not needed anymore. We only keep it for printing a traceback free exception message. Where a type conversion is needed, we use the built-in `str()` function.
