### PR TITLE
chore: disable out of scope pylint rules

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,4 +25,9 @@ good-names = ["i", "j", "k", "ex", "_", "ip", "id"]
 [tool.pylint.messages_control]
 disable = [
   "wrong-import-position",
+  "missing-module-docstring",
+  "missing-class-docstring",
+  "missing-function-docstring",
+  "duplicate-code",
+  "use-dict-literal",
 ]


### PR DESCRIPTION
##### SUMMARY

Disable some pylint rules that are out of scope for the time being, to stop polluting the pylint errors report. Those might be re-enabled at a later stage.
