### PR TITLE
test: force firewall cleanup before running server cleanup

### DIFF
--- a/tests/integration/targets/firewall/tasks/cleanup.yml
+++ b/tests/integration/targets/firewall/tasks/cleanup.yml
@@ -1,10 +1,11 @@
 ---
-- name: Cleanup test_server
-  hetzner.hcloud.server:
-    name: "{{ hcloud_server_name }}"
-    state: absent
-
 - name: Cleanup test_firewall
   hetzner.hcloud.firewall:
     name: "{{ hcloud_firewall_name }}"
+    state: absent
+    force: true
+
+- name: Cleanup test_server
+  hetzner.hcloud.server:
+    name: "{{ hcloud_server_name }}"
     state: absent

--- a/tests/integration/targets/firewall_info/tasks/cleanup.yml
+++ b/tests/integration/targets/firewall_info/tasks/cleanup.yml
@@ -1,10 +1,11 @@
 ---
-- name: Cleanup test_server
-  hetzner.hcloud.server:
-    name: "{{ hcloud_server_name }}"
-    state: absent
-
 - name: Cleanup test_firewall
   hetzner.hcloud.firewall:
     name: "{{ hcloud_firewall_name }}"
+    state: absent
+    force: true
+
+- name: Cleanup test_server
+  hetzner.hcloud.server:
+    name: "{{ hcloud_server_name }}"
     state: absent

--- a/tests/integration/targets/firewall_resource/tasks/cleanup.yml
+++ b/tests/integration/targets/firewall_resource/tasks/cleanup.yml
@@ -1,10 +1,11 @@
 ---
-- name: Cleanup test_server
-  hetzner.hcloud.server:
-    name: "{{ hcloud_server_name }}"
-    state: absent
-
 - name: Cleanup test_firewall
   hetzner.hcloud.firewall:
     name: "{{ hcloud_firewall_name }}"
+    state: absent
+    force: true
+
+- name: Cleanup test_server
+  hetzner.hcloud.server:
+    name: "{{ hcloud_server_name }}"
     state: absent


### PR DESCRIPTION
##### SUMMARY

Cleanup the firewall before the server to prevent a server deletion timeout.
