### PR TITLE
fix: use empty string to remove server from its placement group

### DIFF
--- a/changelogs/fragments/server-empty-string-arguments.yml
+++ b/changelogs/fragments/server-empty-string-arguments.yml
@@ -1,0 +1,3 @@
+bugfixes:
+  - server - Do not remove the server from its placement group when the `placement_group` argument is not specified.
+  - server - Pass an empty string to the `placement_group` argument to remove a server from its placement group.

--- a/tests/integration/targets/placement_group/tasks/test.yml
+++ b/tests/integration/targets/placement_group/tasks/test.yml
@@ -80,7 +80,7 @@
 - name: test remove server from placement group
   hetzner.hcloud.server:
     name: "{{ hcloud_server_name }}"
-    placement_group: null
+    placement_group: ""
     state: present
   register: result
 - name: verify remove server from placement group


### PR DESCRIPTION
##### SUMMARY
- Do not remove the server from its placement group when the `placement_group` argument is not specified.
- Pass an empty string to the `placement_group` argument to remove a server from its placement group.
