### PR TITLE
chore: replace deprecated server type with cx22

### DIFF
--- a/docs/docsite/rst/guides.rst
+++ b/docs/docsite/rst/guides.rst
@@ -23,7 +23,7 @@ Alternatively, you may provide the API token directly as module argument:
       hetzner.hcloud.server:
         api_token: LRK9DAWQ1ZAEFSrCNEEzLCUwhYX1U3g7wMg4dTlkkDC96fyDuyJ39nVbVjCKSDfj
         name: my-server
-        server_type: cx11
+        server_type: cx22
         image: debian-12
         state: present
 
@@ -45,6 +45,6 @@ example if you want to store your API token in a vault:
         - name: Create server
           hetzner.hcloud.server:
             name: my-server
-            server_type: cx11
+            server_type: cx22
             image: debian-12
             state: present

--- a/examples/server-with-firewall.yml
+++ b/examples/server-with-firewall.yml
@@ -31,7 +31,7 @@
     - name: Create servers
       hetzner.hcloud.server:
         name: "{{ item.name }}"
-        server_type: cx11
+        server_type: cx22
         image: debian-12
         labels:
           kind: runners

--- a/examples/server-with-private-ip-only.yml
+++ b/examples/server-with-private-ip-only.yml
@@ -28,7 +28,7 @@
     - name: Create servers without public IPs
       hetzner.hcloud.server:
         name: "{{ item.name }}"
-        server_type: cx11
+        server_type: cx22
         image: debian-12
         enable_ipv4: false
         enable_ipv6: false

--- a/examples/use-module-defaults-group.yml
+++ b/examples/use-module-defaults-group.yml
@@ -19,7 +19,7 @@
     - name: Create a server
       hetzner.hcloud.server:
         name: my-server
-        server_type: cx11
+        server_type: cx22
         image: debian-12
         location: fsn1
         volumes:

--- a/examples/use-refresh-inventory.yml
+++ b/examples/use-refresh-inventory.yml
@@ -11,7 +11,7 @@
     - name: Create new server
       hetzner.hcloud.server:
         name: my-server
-        server_type: cx11
+        server_type: cx22
         image: debian-12
 
     - name: Refresh inventory

--- a/plugins/inventory/hcloud.py
+++ b/plugins/inventory/hcloud.py
@@ -134,7 +134,7 @@ plugin: hetzner.hcloud.hcloud
 locations:
   - nbg1
 types:
-  - cx11
+  - cx22
 status:
   - running
 
@@ -163,8 +163,8 @@ plugin: hetzner.hcloud.hcloud
 #     foo: "bar"
 #   status: "running"
 ## Server Type
-#   type: "cx11"
-#   server_type: "cx11"
+#   type: "cx22"
+#   server_type: "cx22"
 #   architecture: "x86"
 ## Image
 #   image_id: 114690387

--- a/plugins/modules/load_balancer.py
+++ b/plugins/modules/load_balancer.py
@@ -113,7 +113,7 @@ hcloud_load_balancer:
             description: Name of the Load Balancer type of the Load Balancer
             returned: always
             type: str
-            sample: cx11
+            sample: cx22
         algorithm:
             description: Algorithm of the Load Balancer.
             returned: always

--- a/plugins/modules/load_balancer_info.py
+++ b/plugins/modules/load_balancer_info.py
@@ -73,7 +73,7 @@ hcloud_load_balancer_info:
             description: Name of the Load Balancer type of the Load Balancer
             returned: always
             type: str
-            sample: cx11
+            sample: cx22
         ipv4_address:
             description: Public IPv4 address of the Load Balancer
             returned: always

--- a/plugins/modules/network_info.py
+++ b/plugins/modules/network_info.py
@@ -138,7 +138,7 @@ hcloud_network_info:
                     description: Name of the server type of the server
                     returned: always
                     type: str
-                    sample: cx11
+                    sample: cx22
                 ipv4_address:
                     description: Public IPv4 address of the server, None if not existing
                     returned: always

--- a/plugins/modules/server.py
+++ b/plugins/modules/server.py
@@ -161,14 +161,14 @@ EXAMPLES = """
 - name: Create a basic server
   hetzner.hcloud.server:
     name: my-server
-    server_type: cx11
+    server_type: cx22
     image: ubuntu-22.04
     state: present
 
 - name: Create a basic server with ssh key
   hetzner.hcloud.server:
     name: my-server
-    server_type: cx11
+    server_type: cx22
     image: ubuntu-22.04
     location: fsn1
     ssh_keys:
@@ -178,7 +178,7 @@ EXAMPLES = """
 - name: Resize an existing server
   hetzner.hcloud.server:
     name: my-server
-    server_type: cx21
+    server_type: cx32
     upgrade_disk: true
     state: present
 
@@ -268,7 +268,7 @@ hcloud_server:
             description: Name of the server type of the server
             returned: always
             type: str
-            sample: cx11
+            sample: cx22
         ipv4_address:
             description: Public IPv4 address of the server
             returned: always

--- a/plugins/modules/server_info.py
+++ b/plugins/modules/server_info.py
@@ -78,7 +78,7 @@ hcloud_server_info:
             description: Name of the server type of the server
             returned: always
             type: str
-            sample: cx11
+            sample: cx22
         ipv4_address:
             description: Public IPv4 address of the server
             returned: always

--- a/tests/integration/targets/firewall/tasks/prepare.yml
+++ b/tests/integration/targets/firewall/tasks/prepare.yml
@@ -2,7 +2,7 @@
 - name: Create test_server
   hetzner.hcloud.server:
     name: "{{ hcloud_server_name }}"
-    server_type: cx11
+    server_type: cax11
     image: ubuntu-22.04
     state: stopped
   register: test_server

--- a/tests/integration/targets/firewall_info/tasks/prepare.yml
+++ b/tests/integration/targets/firewall_info/tasks/prepare.yml
@@ -2,7 +2,7 @@
 - name: Create test_server
   hetzner.hcloud.server:
     name: "{{ hcloud_server_name }}"
-    server_type: cx11
+    server_type: cax11
     image: ubuntu-22.04
     labels:
       firewall: "{{ hcloud_firewall_name }}"

--- a/tests/integration/targets/firewall_resource/tasks/prepare.yml
+++ b/tests/integration/targets/firewall_resource/tasks/prepare.yml
@@ -2,7 +2,7 @@
 - name: Create test_server
   hetzner.hcloud.server:
     name: "{{ hcloud_server_name }}"
-    server_type: cx11
+    server_type: cax11
     image: ubuntu-22.04
     labels:
       key: value

--- a/tests/integration/targets/floating_ip/tasks/test.yml
+++ b/tests/integration/targets/floating_ip/tasks/test.yml
@@ -19,7 +19,7 @@
 - name: setup server
   hetzner.hcloud.server:
     name: "{{ hcloud_server_name }}"
-    server_type: cx11
+    server_type: cax11
     image: ubuntu-22.04
     state: stopped
     location: "fsn1"
@@ -32,7 +32,7 @@
 - name: setup another server
   hetzner.hcloud.server:
     name: "{{ hcloud_server_name }}2"
-    server_type: cx11
+    server_type: cax11
     image: ubuntu-22.04
     state: stopped
   register: main_server2

--- a/tests/integration/targets/image_info/tasks/prepare.yml
+++ b/tests/integration/targets/image_info/tasks/prepare.yml
@@ -2,7 +2,7 @@
 - name: Create test_server
   hetzner.hcloud.server:
     name: "{{ hcloud_server_name }}"
-    server_type: cx11
+    server_type: cax11
     image: ubuntu-22.04
     state: stopped
   register: test_server

--- a/tests/integration/targets/load_balancer_info/tasks/prepare.yml
+++ b/tests/integration/targets/load_balancer_info/tasks/prepare.yml
@@ -2,7 +2,7 @@
 - name: Create test_server
   hetzner.hcloud.server:
     name: "{{ hcloud_server_name }}"
-    server_type: cx11
+    server_type: cax11
     image: ubuntu-22.04
     state: stopped
   register: test_server

--- a/tests/integration/targets/load_balancer_target/tasks/test.yml
+++ b/tests/integration/targets/load_balancer_target/tasks/test.yml
@@ -4,7 +4,7 @@
 - name: setup server
   hetzner.hcloud.server:
     name: "{{hcloud_server_name}}"
-    server_type: cx11
+    server_type: cax11
     image: ubuntu-22.04
     state: stopped
     location: "fsn1"

--- a/tests/integration/targets/primary_ip/tasks/prepare.yml
+++ b/tests/integration/targets/primary_ip/tasks/prepare.yml
@@ -2,7 +2,7 @@
 - name: Create test_server
   hetzner.hcloud.server:
     name: "{{ hcloud_server_name }}"
-    server_type: cx11
+    server_type: cax11
     image: ubuntu-22.04
     state: stopped
     enable_ipv4: false

--- a/tests/integration/targets/rdns/tasks/prepare.yml
+++ b/tests/integration/targets/rdns/tasks/prepare.yml
@@ -2,7 +2,7 @@
 - name: Create test_server
   hetzner.hcloud.server:
     name: "{{ hcloud_server_name }}"
-    server_type: cx11
+    server_type: cax11
     image: ubuntu-22.04
     state: present
   register: test_server

--- a/tests/integration/targets/server/tasks/test_basic.yml
+++ b/tests/integration/targets/server/tasks/test_basic.yml
@@ -1,7 +1,7 @@
 - name: test create server with check mode
   hetzner.hcloud.server:
     name: "{{ hcloud_server_name }}"
-    server_type: cx11
+    server_type: cax11
     image: ubuntu-22.04
     state: present
   register: result
@@ -14,7 +14,7 @@
 - name: test create server
   hetzner.hcloud.server:
     name: "{{ hcloud_server_name}}"
-    server_type: cx11
+    server_type: cax11
     image: ubuntu-22.04
     enable_ipv6: False
     state: started
@@ -24,7 +24,7 @@
     that:
       - main_server is changed
       - main_server.hcloud_server.name == hcloud_server_name
-      - main_server.hcloud_server.server_type == "cx11"
+      - main_server.hcloud_server.server_type == "cax11"
       - main_server.hcloud_server.status == "running"
       - main_server.root_password != ""
 
@@ -108,7 +108,7 @@
 - name: test resize server running without force
   hetzner.hcloud.server:
     name: "{{ hcloud_server_name }}"
-    server_type: "cx21"
+    server_type: "cax21"
     state: present
   register: result
   check_mode: true
@@ -116,12 +116,12 @@
   assert:
     that:
       - result is changed
-      - result.hcloud_server.server_type == "cx11"
+      - result.hcloud_server.server_type == "cax11"
 
 - name: test resize server with check mode
   hetzner.hcloud.server:
     name: "{{ hcloud_server_name }}"
-    server_type: "cx21"
+    server_type: "cax21"
     state: stopped
   register: result
   check_mode: true
@@ -133,19 +133,19 @@
 - name: test resize server without disk
   hetzner.hcloud.server:
     name: "{{ hcloud_server_name }}"
-    server_type: "cx21"
+    server_type: "cax21"
     state: stopped
   register: result
 - name: verify resize server without disk
   assert:
     that:
       - result is changed
-      - result.hcloud_server.server_type == "cx21"
+      - result.hcloud_server.server_type == "cax21"
 
 - name: test resize server idempotence
   hetzner.hcloud.server:
     name: "{{ hcloud_server_name }}"
-    server_type: "cx21"
+    server_type: "cax21"
     state: stopped
   register: result
 - name: verify resize server idempotence
@@ -156,19 +156,19 @@
 - name: test resize server to smaller plan
   hetzner.hcloud.server:
     name: "{{ hcloud_server_name }}"
-    server_type: "cx11"
+    server_type: "cax11"
     state: stopped
   register: result
 - name: verify resize server to smaller plan
   assert:
     that:
       - result is changed
-      - result.hcloud_server.server_type == "cx11"
+      - result.hcloud_server.server_type == "cax11"
 
 - name: test resize server with disk
   hetzner.hcloud.server:
     name: "{{ hcloud_server_name }}"
-    server_type: "cx21"
+    server_type: "cax21"
     upgrade_disk: true
     state: stopped
   register: result
@@ -176,7 +176,7 @@
   assert:
     that:
       - result is changed
-      - result.hcloud_server.server_type == "cx21"
+      - result.hcloud_server.server_type == "cax21"
 
 - name: test enable backups with check mode
   hetzner.hcloud.server:
@@ -360,7 +360,7 @@
 - name: test create server with ssh key
   hetzner.hcloud.server:
     name: "{{ hcloud_server_name}}"
-    server_type: cx11
+    server_type: cax11
     image: "ubuntu-22.04"
     ssh_keys:
       - "{{ hcloud_ssh_key_name }}"
@@ -371,7 +371,7 @@
     that:
       - main_server is changed
       - main_server.hcloud_server.name == hcloud_server_name
-      - main_server.hcloud_server.server_type == "cx11"
+      - main_server.hcloud_server.server_type == "cax11"
       - main_server.hcloud_server.status == "running"
       - main_server.root_password != ""
 
@@ -441,7 +441,7 @@
 - name: test create server with rescue_mode
   hetzner.hcloud.server:
     name: "{{ hcloud_server_name}}"
-    server_type: cx11
+    server_type: cax11
     image: "ubuntu-22.04"
     ssh_keys:
       - "{{ hcloud_ssh_key_name }}"
@@ -453,7 +453,7 @@
     that:
       - main_server is changed
       - main_server.hcloud_server.name == hcloud_server_name
-      - main_server.hcloud_server.server_type == "cx11"
+      - main_server.hcloud_server.server_type == "cax11"
       - main_server.hcloud_server.status == "running"
       - main_server.root_password != ""
       - main_server.hcloud_server.rescue_enabled is sameas true
@@ -470,7 +470,7 @@
 - name: test create server with labels
   hetzner.hcloud.server:
     name: "{{ hcloud_server_name}}"
-    server_type: cx11
+    server_type: cax11
     image: "ubuntu-22.04"
     ssh_keys:
       - "{{ hcloud_ssh_key_name }}"
@@ -489,7 +489,7 @@
 - name: test update server with labels
   hetzner.hcloud.server:
     name: "{{ hcloud_server_name}}"
-    server_type: cx11
+    server_type: cax11
     image: "ubuntu-22.04"
     ssh_keys:
       - "{{ hcloud_ssh_key_name }}"
@@ -508,7 +508,7 @@
 - name: test update server with labels in other order
   hetzner.hcloud.server:
     name: "{{ hcloud_server_name}}"
-    server_type: cx11
+    server_type: cax11
     image: "ubuntu-22.04"
     ssh_keys:
       - "{{ hcloud_ssh_key_name }}"

--- a/tests/integration/targets/server/tasks/test_validation.yml
+++ b/tests/integration/targets/server/tasks/test_validation.yml
@@ -40,7 +40,7 @@
 - name: test create server with not existing image
   hetzner.hcloud.server:
     name: "{{ hcloud_server_name }}"
-    server_type: cx11
+    server_type: cax11
     image: my-not-existing-image-20.04
     state: present
   register: result

--- a/tests/integration/targets/server_info/tasks/prepare.yml
+++ b/tests/integration/targets/server_info/tasks/prepare.yml
@@ -2,7 +2,7 @@
 - name: Create test_server
   hetzner.hcloud.server:
     name: "{{ hcloud_server_name }}"
-    server_type: cx11
+    server_type: cax11
     image: ubuntu-22.04
     state: stopped
     labels:
@@ -12,7 +12,7 @@
 - name: Create test_server2 (stopped + without ip)
   hetzner.hcloud.server:
     name: "{{ hcloud_server_name }}2"
-    server_type: cx11
+    server_type: cax11
     image: ubuntu-22.04
     state: stopped
     labels:

--- a/tests/integration/targets/server_network/tasks/prepare.yml
+++ b/tests/integration/targets/server_network/tasks/prepare.yml
@@ -18,7 +18,7 @@
 - name: Create test_server
   hetzner.hcloud.server:
     name: "{{ hcloud_server_name }}"
-    server_type: cx11
+    server_type: cax11
     image: ubuntu-22.04
     state: stopped
   register: test_server

--- a/tests/integration/targets/server_type_info/defaults/main/main.yml
+++ b/tests/integration/targets/server_type_info/defaults/main/main.yml
@@ -1,7 +1,7 @@
 # Copyright: (c) 2019, Hetzner Cloud GmbH <info@hetzner-cloud.de>
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 ---
-hcloud_server_type_name: cx11
-hcloud_server_type_id: 1
+hcloud_server_type_name: cax11
+hcloud_server_type_id: 45
 
 hcloud_server_type_id_deprecated: 2 # cx11-ceph

--- a/tests/integration/targets/server_type_info/tasks/test.yml
+++ b/tests/integration/targets/server_type_info/tasks/test.yml
@@ -26,7 +26,7 @@
   ansible.builtin.assert:
     that:
       - result.hcloud_server_type_info | list | count == 1
-      - result.hcloud_server_type_info[0].deprecation is none # fails if cx11 is ever deprecated
+      - result.hcloud_server_type_info[0].deprecation is none # fails if cax11 is ever deprecated
 
 - name: Gather hcloud_server_type_info with wrong id
   hetzner.hcloud.server_type_info:

--- a/tests/integration/targets/ssh_key/tasks/test.yml
+++ b/tests/integration/targets/ssh_key/tasks/test.yml
@@ -112,7 +112,7 @@
 - name: test create server with ssh key
   hetzner.hcloud.server:
     name: "{{ hcloud_server_name }}"
-    server_type: cx11
+    server_type: cax11
     image: "ubuntu-22.04"
     ssh_keys:
       - "{{ hcloud_ssh_key_name }}"

--- a/tests/integration/targets/volume/tasks/test.yml
+++ b/tests/integration/targets/volume/tasks/test.yml
@@ -4,7 +4,7 @@
 - name: setup server
   hetzner.hcloud.server:
     name: "{{hcloud_server_name}}"
-    server_type: cx11
+    server_type: cax11
     image: ubuntu-22.04
     state: stopped
     location: "fsn1"


### PR DESCRIPTION
Learn more: https://docs.hetzner.cloud/changelog#2024-06-06-old-server-types-with-shared-intel-vcpus-are-deprecated

- Updated docs with newer server types
- Use ARM server type for tests