### PR TITLE
test: add workaround to prevent a timeout during the server deletion

### DIFF
--- a/tests/integration/targets/primary_ip/tasks/test.yml
+++ b/tests/integration/targets/primary_ip/tasks/test.yml
@@ -179,3 +179,7 @@
   ansible.builtin.assert:
     that:
       - result is changed
+
+- name: Workaround to prevent a timeout during the server deletion
+  ansible.builtin.pause:
+    seconds: 2


### PR DESCRIPTION
When the following steps are executed, the server deletion fails with a timeout:
- delete primary IP (attached to the server)
- delete server
- timeout after 5 minutes on server delete action


Adding the 2 seconds pause will work around this timeout.