### PR TITLE
fix: keep deprecated alias for another major version

### DIFF
--- a/changelogs/fragments/keep-deprecated-alias.yml
+++ b/changelogs/fragments/keep-deprecated-alias.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - server - Keep `force_upgrade` deprecated alias for another major version.

--- a/plugins/modules/server.py
+++ b/plugins/modules/server.py
@@ -923,7 +923,7 @@ class AnsibleHCloudServer(AnsibleHCloud):
                     "default": False,
                     "aliases": ["force_upgrade"],
                     "deprecated_aliases": [
-                        {"collection_name": "hetzner.hcloud", "name": "force_upgrade", "version": "4.0.0"}
+                        {"collection_name": "hetzner.hcloud", "name": "force_upgrade", "version": "5.0.0"}
                     ],
                 },
                 rescue_mode={"type": "str"},


### PR DESCRIPTION
This was not removed during the v4.0.0 release, we must therefor reschedule it for the v5.0.0 release.