### PR TITLE
test: update server type to cax11

### DIFF
--- a/tests/integration/targets/placement_group/tasks/test.yml
+++ b/tests/integration/targets/placement_group/tasks/test.yml
@@ -64,7 +64,7 @@
 - name: test create server with placement group
   hetzner.hcloud.server:
     name: "{{ hcloud_server_name }}"
-    server_type: cpx11
+    server_type: cax11
     placement_group: "{{ hcloud_placement_group_name }}"
     image: "ubuntu-22.04"
     ssh_keys:

--- a/tests/integration/targets/server/tasks/test_basic.yml
+++ b/tests/integration/targets/server/tasks/test_basic.yml
@@ -535,7 +535,7 @@
 - name: test create server with enabled backups
   hetzner.hcloud.server:
     name: "{{ hcloud_server_name }}"
-    server_type: cpx11
+    server_type: cax11
     backups: true
     image: "ubuntu-22.04"
     ssh_keys:
@@ -563,7 +563,7 @@
     name: "{{ hcloud_server_name }}"
     delete_protection: true
     rebuild_protection: true
-    server_type: cpx11
+    server_type: cax11
     image: "ubuntu-22.04"
     ssh_keys:
       - "{{ hcloud_ssh_key_name }}"

--- a/tests/integration/targets/server/tasks/test_firewalls.yml
+++ b/tests/integration/targets/server/tasks/test_firewalls.yml
@@ -32,7 +32,7 @@
 - name: test create server with firewalls
   hetzner.hcloud.server:
     name: "{{ hcloud_server_name }}"
-    server_type: cpx11
+    server_type: cax11
     firewalls:
       - "{{ hcloud_firewall_name }}"
     image: "ubuntu-22.04"
@@ -48,7 +48,7 @@
 - name: test create server with firewalls idempotence
   hetzner.hcloud.server:
     name: "{{ hcloud_server_name }}"
-    server_type: cpx11
+    server_type: cax11
     firewalls:
       - "{{ hcloud_firewall_name }}"
     image: "ubuntu-22.04"
@@ -64,7 +64,7 @@
 - name: test update server with firewalls
   hetzner.hcloud.server:
     name: "{{ hcloud_server_name }}"
-    server_type: cpx11
+    server_type: cax11
     firewalls:
       - "{{ hcloud_firewall_name }}2"
     image: "ubuntu-22.04"
@@ -80,7 +80,7 @@
 - name: test update server with firewalls idempotence
   hetzner.hcloud.server:
     name: "{{ hcloud_server_name }}"
-    server_type: cpx11
+    server_type: cax11
     firewalls:
       - "{{ hcloud_firewall_name }}2"
     image: "ubuntu-22.04"

--- a/tests/integration/targets/server/tasks/test_primary_ips.yml
+++ b/tests/integration/targets/server/tasks/test_primary_ips.yml
@@ -25,7 +25,7 @@
 - name: test create server with primary ips
   hetzner.hcloud.server:
     name: "{{ hcloud_server_name }}"
-    server_type: cpx11
+    server_type: cax11
     datacenter: "fsn1-dc14"
     image: "ubuntu-22.04"
     ipv4: "{{primaryIPv4.hcloud_primary_ip.id}}"
@@ -42,7 +42,7 @@
 - name: test update server with primary ips
   hetzner.hcloud.server:
     name: "{{ hcloud_server_name }}"
-    server_type: cpx11
+    server_type: cax11
     datacenter: "fsn1-dc14"
     image: "ubuntu-22.04"
     ipv4: "{{secondPrimaryIPv4.hcloud_primary_ip.id}}"

--- a/tests/integration/targets/server/tasks/test_private_network_only.yml
+++ b/tests/integration/targets/server/tasks/test_private_network_only.yml
@@ -63,7 +63,7 @@
 - name: test create server with primary network and no internet
   hetzner.hcloud.server:
     name: "{{ hcloud_server_name }}"
-    server_type: cpx11
+    server_type: cax11
     datacenter: "fsn1-dc14"
     image: "ubuntu-22.04"
     enable_ipv4: false
@@ -82,7 +82,7 @@
 - name: test update server by adding secondary network
   hetzner.hcloud.server:
     name: "{{ hcloud_server_name }}"
-    server_type: cpx11
+    server_type: cax11
     datacenter: "fsn1-dc14"
     image: "ubuntu-22.04"
     enable_ipv4: false
@@ -102,7 +102,7 @@
 - name: test update server idem
   hetzner.hcloud.server:
     name: "{{ hcloud_server_name }}"
-    server_type: cpx11
+    server_type: cax11
     datacenter: "fsn1-dc14"
     image: "ubuntu-22.04"
     enable_ipv4: false


### PR DESCRIPTION
Ensure we are consistent across our tests, and updates some server types that were missing from the previous PR updating this:

https://github.com/ansible-collections/hetzner.hcloud/pull/510



