### PR TITLE
test: use shared variable for server type, image and location

### DIFF
--- a/tests/integration/common/defaults/main/common.yml
+++ b/tests/integration/common/defaults/main/common.yml
@@ -7,3 +7,18 @@ hcloud_prefix: "tests"
 hcloud_run_ns: "{{ hcloud_prefix | md5 }}"
 hcloud_role_ns: "{{ role_name | split('_') | map('batch', 2) | map('first') | flatten() | join() }}"
 hcloud_ns: "ansible-{{ hcloud_run_ns }}-{{ hcloud_role_ns }}"
+
+# Used to easily update the server types and images across all our tests.
+hcloud_server_type: cax11
+hcloud_server_type_id: 45
+
+hcloud_server_type_upgrade: cax21
+hcloud_server_type_upgrade_id: 93
+
+hcloud_image: debian-12
+hcloud_image_id: 114690389 # architecture=arm
+
+hcloud_location: hel1
+hcloud_location_id: 3
+hcloud_datacenter: hel1-dc2
+hcloud_datacenter_id: 3

--- a/tests/integration/common/defaults/main/common.yml
+++ b/tests/integration/common/defaults/main/common.yml
@@ -9,16 +9,16 @@ hcloud_role_ns: "{{ role_name | split('_') | map('batch', 2) | map('first') | fl
 hcloud_ns: "ansible-{{ hcloud_run_ns }}-{{ hcloud_role_ns }}"
 
 # Used to easily update the server types and images across all our tests.
-hcloud_server_type: cax11
+hcloud_server_type_name: cax11
 hcloud_server_type_id: 45
 
-hcloud_server_type_upgrade: cax21
+hcloud_server_type_upgrade_name: cax21
 hcloud_server_type_upgrade_id: 93
 
-hcloud_image: debian-12
+hcloud_image_name: debian-12
 hcloud_image_id: 114690389 # architecture=arm
 
-hcloud_location: hel1
+hcloud_location_name: hel1
 hcloud_location_id: 3
-hcloud_datacenter: hel1-dc2
+hcloud_datacenter_name: hel1-dc2
 hcloud_datacenter_id: 3

--- a/tests/integration/targets/certificate/defaults/main/common.yml
+++ b/tests/integration/targets/certificate/defaults/main/common.yml
@@ -10,3 +10,18 @@ hcloud_prefix: "tests"
 hcloud_run_ns: "{{ hcloud_prefix | md5 }}"
 hcloud_role_ns: "{{ role_name | split('_') | map('batch', 2) | map('first') | flatten() | join() }}"
 hcloud_ns: "ansible-{{ hcloud_run_ns }}-{{ hcloud_role_ns }}"
+
+# Used to easily update the server types and images across all our tests.
+hcloud_server_type: cax11
+hcloud_server_type_id: 45
+
+hcloud_server_type_upgrade: cax21
+hcloud_server_type_upgrade_id: 93
+
+hcloud_image: debian-12
+hcloud_image_id: 114690389 # architecture=arm
+
+hcloud_location: hel1
+hcloud_location_id: 3
+hcloud_datacenter: hel1-dc2
+hcloud_datacenter_id: 3

--- a/tests/integration/targets/certificate/defaults/main/common.yml
+++ b/tests/integration/targets/certificate/defaults/main/common.yml
@@ -12,16 +12,16 @@ hcloud_role_ns: "{{ role_name | split('_') | map('batch', 2) | map('first') | fl
 hcloud_ns: "ansible-{{ hcloud_run_ns }}-{{ hcloud_role_ns }}"
 
 # Used to easily update the server types and images across all our tests.
-hcloud_server_type: cax11
+hcloud_server_type_name: cax11
 hcloud_server_type_id: 45
 
-hcloud_server_type_upgrade: cax21
+hcloud_server_type_upgrade_name: cax21
 hcloud_server_type_upgrade_id: 93
 
-hcloud_image: debian-12
+hcloud_image_name: debian-12
 hcloud_image_id: 114690389 # architecture=arm
 
-hcloud_location: hel1
+hcloud_location_name: hel1
 hcloud_location_id: 3
-hcloud_datacenter: hel1-dc2
+hcloud_datacenter_name: hel1-dc2
 hcloud_datacenter_id: 3

--- a/tests/integration/targets/certificate_info/defaults/main/common.yml
+++ b/tests/integration/targets/certificate_info/defaults/main/common.yml
@@ -10,3 +10,18 @@ hcloud_prefix: "tests"
 hcloud_run_ns: "{{ hcloud_prefix | md5 }}"
 hcloud_role_ns: "{{ role_name | split('_') | map('batch', 2) | map('first') | flatten() | join() }}"
 hcloud_ns: "ansible-{{ hcloud_run_ns }}-{{ hcloud_role_ns }}"
+
+# Used to easily update the server types and images across all our tests.
+hcloud_server_type: cax11
+hcloud_server_type_id: 45
+
+hcloud_server_type_upgrade: cax21
+hcloud_server_type_upgrade_id: 93
+
+hcloud_image: debian-12
+hcloud_image_id: 114690389 # architecture=arm
+
+hcloud_location: hel1
+hcloud_location_id: 3
+hcloud_datacenter: hel1-dc2
+hcloud_datacenter_id: 3

--- a/tests/integration/targets/certificate_info/defaults/main/common.yml
+++ b/tests/integration/targets/certificate_info/defaults/main/common.yml
@@ -12,16 +12,16 @@ hcloud_role_ns: "{{ role_name | split('_') | map('batch', 2) | map('first') | fl
 hcloud_ns: "ansible-{{ hcloud_run_ns }}-{{ hcloud_role_ns }}"
 
 # Used to easily update the server types and images across all our tests.
-hcloud_server_type: cax11
+hcloud_server_type_name: cax11
 hcloud_server_type_id: 45
 
-hcloud_server_type_upgrade: cax21
+hcloud_server_type_upgrade_name: cax21
 hcloud_server_type_upgrade_id: 93
 
-hcloud_image: debian-12
+hcloud_image_name: debian-12
 hcloud_image_id: 114690389 # architecture=arm
 
-hcloud_location: hel1
+hcloud_location_name: hel1
 hcloud_location_id: 3
-hcloud_datacenter: hel1-dc2
+hcloud_datacenter_name: hel1-dc2
 hcloud_datacenter_id: 3

--- a/tests/integration/targets/datacenter_info/defaults/main/common.yml
+++ b/tests/integration/targets/datacenter_info/defaults/main/common.yml
@@ -10,3 +10,18 @@ hcloud_prefix: "tests"
 hcloud_run_ns: "{{ hcloud_prefix | md5 }}"
 hcloud_role_ns: "{{ role_name | split('_') | map('batch', 2) | map('first') | flatten() | join() }}"
 hcloud_ns: "ansible-{{ hcloud_run_ns }}-{{ hcloud_role_ns }}"
+
+# Used to easily update the server types and images across all our tests.
+hcloud_server_type: cax11
+hcloud_server_type_id: 45
+
+hcloud_server_type_upgrade: cax21
+hcloud_server_type_upgrade_id: 93
+
+hcloud_image: debian-12
+hcloud_image_id: 114690389 # architecture=arm
+
+hcloud_location: hel1
+hcloud_location_id: 3
+hcloud_datacenter: hel1-dc2
+hcloud_datacenter_id: 3

--- a/tests/integration/targets/datacenter_info/defaults/main/common.yml
+++ b/tests/integration/targets/datacenter_info/defaults/main/common.yml
@@ -12,16 +12,16 @@ hcloud_role_ns: "{{ role_name | split('_') | map('batch', 2) | map('first') | fl
 hcloud_ns: "ansible-{{ hcloud_run_ns }}-{{ hcloud_role_ns }}"
 
 # Used to easily update the server types and images across all our tests.
-hcloud_server_type: cax11
+hcloud_server_type_name: cax11
 hcloud_server_type_id: 45
 
-hcloud_server_type_upgrade: cax21
+hcloud_server_type_upgrade_name: cax21
 hcloud_server_type_upgrade_id: 93
 
-hcloud_image: debian-12
+hcloud_image_name: debian-12
 hcloud_image_id: 114690389 # architecture=arm
 
-hcloud_location: hel1
+hcloud_location_name: hel1
 hcloud_location_id: 3
-hcloud_datacenter: hel1-dc2
+hcloud_datacenter_name: hel1-dc2
 hcloud_datacenter_id: 3

--- a/tests/integration/targets/datacenter_info/defaults/main/main.yml
+++ b/tests/integration/targets/datacenter_info/defaults/main/main.yml
@@ -1,6 +1,0 @@
-# Copyright: (c) 2019, Hetzner Cloud GmbH <info@hetzner-cloud.de>
-# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
----
-hcloud_datacenter_id: 4
-hcloud_datacenter_name: fsn1-dc14
-hcloud_location_name: fsn1

--- a/tests/integration/targets/datacenter_info/tasks/test.yml
+++ b/tests/integration/targets/datacenter_info/tasks/test.yml
@@ -26,8 +26,8 @@
   ansible.builtin.assert:
     that:
       - result.hcloud_datacenter_info | list | count == 1
-      - result.hcloud_datacenter_info[0].name == hcloud_datacenter
-      - result.hcloud_datacenter_info[0].location == hcloud_location
+      - result.hcloud_datacenter_info[0].name == hcloud_datacenter_name
+      - result.hcloud_datacenter_info[0].location == hcloud_location_name
 
 - name: Gather hcloud_datacenter_info with wrong id
   hetzner.hcloud.datacenter_info:
@@ -41,7 +41,7 @@
 
 - name: Gather hcloud_datacenter_info with correct name
   hetzner.hcloud.datacenter_info:
-    name: "{{ hcloud_datacenter }}"
+    name: "{{ hcloud_datacenter_name }}"
   register: result
 - name: Verify hcloud_datacenter_info with correct name
   ansible.builtin.assert:
@@ -50,7 +50,7 @@
 
 - name: Gather hcloud_datacenter_info with wrong name
   hetzner.hcloud.datacenter_info:
-    name: "{{ hcloud_datacenter }}-invalid"
+    name: "{{ hcloud_datacenter_name }}-invalid"
   register: result
 - name: Verify hcloud_datacenter_info with wrong name
   ansible.builtin.assert:

--- a/tests/integration/targets/datacenter_info/tasks/test.yml
+++ b/tests/integration/targets/datacenter_info/tasks/test.yml
@@ -26,8 +26,8 @@
   ansible.builtin.assert:
     that:
       - result.hcloud_datacenter_info | list | count == 1
-      - result.hcloud_datacenter_info[0].name == hcloud_datacenter_name
-      - result.hcloud_datacenter_info[0].location == hcloud_location_name
+      - result.hcloud_datacenter_info[0].name == hcloud_datacenter
+      - result.hcloud_datacenter_info[0].location == hcloud_location
 
 - name: Gather hcloud_datacenter_info with wrong id
   hetzner.hcloud.datacenter_info:
@@ -41,7 +41,7 @@
 
 - name: Gather hcloud_datacenter_info with correct name
   hetzner.hcloud.datacenter_info:
-    name: "{{ hcloud_datacenter_name }}"
+    name: "{{ hcloud_datacenter }}"
   register: result
 - name: Verify hcloud_datacenter_info with correct name
   ansible.builtin.assert:
@@ -50,7 +50,7 @@
 
 - name: Gather hcloud_datacenter_info with wrong name
   hetzner.hcloud.datacenter_info:
-    name: "{{ hcloud_datacenter_name }}-invalid"
+    name: "{{ hcloud_datacenter }}-invalid"
   register: result
 - name: Verify hcloud_datacenter_info with wrong name
   ansible.builtin.assert:

--- a/tests/integration/targets/firewall/defaults/main/common.yml
+++ b/tests/integration/targets/firewall/defaults/main/common.yml
@@ -10,3 +10,18 @@ hcloud_prefix: "tests"
 hcloud_run_ns: "{{ hcloud_prefix | md5 }}"
 hcloud_role_ns: "{{ role_name | split('_') | map('batch', 2) | map('first') | flatten() | join() }}"
 hcloud_ns: "ansible-{{ hcloud_run_ns }}-{{ hcloud_role_ns }}"
+
+# Used to easily update the server types and images across all our tests.
+hcloud_server_type: cax11
+hcloud_server_type_id: 45
+
+hcloud_server_type_upgrade: cax21
+hcloud_server_type_upgrade_id: 93
+
+hcloud_image: debian-12
+hcloud_image_id: 114690389 # architecture=arm
+
+hcloud_location: hel1
+hcloud_location_id: 3
+hcloud_datacenter: hel1-dc2
+hcloud_datacenter_id: 3

--- a/tests/integration/targets/firewall/defaults/main/common.yml
+++ b/tests/integration/targets/firewall/defaults/main/common.yml
@@ -12,16 +12,16 @@ hcloud_role_ns: "{{ role_name | split('_') | map('batch', 2) | map('first') | fl
 hcloud_ns: "ansible-{{ hcloud_run_ns }}-{{ hcloud_role_ns }}"
 
 # Used to easily update the server types and images across all our tests.
-hcloud_server_type: cax11
+hcloud_server_type_name: cax11
 hcloud_server_type_id: 45
 
-hcloud_server_type_upgrade: cax21
+hcloud_server_type_upgrade_name: cax21
 hcloud_server_type_upgrade_id: 93
 
-hcloud_image: debian-12
+hcloud_image_name: debian-12
 hcloud_image_id: 114690389 # architecture=arm
 
-hcloud_location: hel1
+hcloud_location_name: hel1
 hcloud_location_id: 3
-hcloud_datacenter: hel1-dc2
+hcloud_datacenter_name: hel1-dc2
 hcloud_datacenter_id: 3

--- a/tests/integration/targets/firewall/tasks/prepare.yml
+++ b/tests/integration/targets/firewall/tasks/prepare.yml
@@ -2,7 +2,7 @@
 - name: Create test_server
   hetzner.hcloud.server:
     name: "{{ hcloud_server_name }}"
-    server_type: "{{ hcloud_server_type }}"
-    image: "{{ hcloud_image }}"
+    server_type: "{{ hcloud_server_type_name }}"
+    image: "{{ hcloud_image_name }}"
     state: stopped
   register: test_server

--- a/tests/integration/targets/firewall/tasks/prepare.yml
+++ b/tests/integration/targets/firewall/tasks/prepare.yml
@@ -2,7 +2,7 @@
 - name: Create test_server
   hetzner.hcloud.server:
     name: "{{ hcloud_server_name }}"
-    server_type: cax11
-    image: ubuntu-22.04
+    server_type: "{{ hcloud_server_type }}"
+    image: "{{ hcloud_image }}"
     state: stopped
   register: test_server

--- a/tests/integration/targets/firewall_info/defaults/main/common.yml
+++ b/tests/integration/targets/firewall_info/defaults/main/common.yml
@@ -10,3 +10,18 @@ hcloud_prefix: "tests"
 hcloud_run_ns: "{{ hcloud_prefix | md5 }}"
 hcloud_role_ns: "{{ role_name | split('_') | map('batch', 2) | map('first') | flatten() | join() }}"
 hcloud_ns: "ansible-{{ hcloud_run_ns }}-{{ hcloud_role_ns }}"
+
+# Used to easily update the server types and images across all our tests.
+hcloud_server_type: cax11
+hcloud_server_type_id: 45
+
+hcloud_server_type_upgrade: cax21
+hcloud_server_type_upgrade_id: 93
+
+hcloud_image: debian-12
+hcloud_image_id: 114690389 # architecture=arm
+
+hcloud_location: hel1
+hcloud_location_id: 3
+hcloud_datacenter: hel1-dc2
+hcloud_datacenter_id: 3

--- a/tests/integration/targets/firewall_info/defaults/main/common.yml
+++ b/tests/integration/targets/firewall_info/defaults/main/common.yml
@@ -12,16 +12,16 @@ hcloud_role_ns: "{{ role_name | split('_') | map('batch', 2) | map('first') | fl
 hcloud_ns: "ansible-{{ hcloud_run_ns }}-{{ hcloud_role_ns }}"
 
 # Used to easily update the server types and images across all our tests.
-hcloud_server_type: cax11
+hcloud_server_type_name: cax11
 hcloud_server_type_id: 45
 
-hcloud_server_type_upgrade: cax21
+hcloud_server_type_upgrade_name: cax21
 hcloud_server_type_upgrade_id: 93
 
-hcloud_image: debian-12
+hcloud_image_name: debian-12
 hcloud_image_id: 114690389 # architecture=arm
 
-hcloud_location: hel1
+hcloud_location_name: hel1
 hcloud_location_id: 3
-hcloud_datacenter: hel1-dc2
+hcloud_datacenter_name: hel1-dc2
 hcloud_datacenter_id: 3

--- a/tests/integration/targets/firewall_info/tasks/prepare.yml
+++ b/tests/integration/targets/firewall_info/tasks/prepare.yml
@@ -2,8 +2,8 @@
 - name: Create test_server
   hetzner.hcloud.server:
     name: "{{ hcloud_server_name }}"
-    server_type: cax11
-    image: ubuntu-22.04
+    server_type: "{{ hcloud_server_type }}"
+    image: "{{ hcloud_image }}"
     labels:
       firewall: "{{ hcloud_firewall_name }}"
     state: stopped

--- a/tests/integration/targets/firewall_info/tasks/prepare.yml
+++ b/tests/integration/targets/firewall_info/tasks/prepare.yml
@@ -2,8 +2,8 @@
 - name: Create test_server
   hetzner.hcloud.server:
     name: "{{ hcloud_server_name }}"
-    server_type: "{{ hcloud_server_type }}"
-    image: "{{ hcloud_image }}"
+    server_type: "{{ hcloud_server_type_name }}"
+    image: "{{ hcloud_image_name }}"
     labels:
       firewall: "{{ hcloud_firewall_name }}"
     state: stopped

--- a/tests/integration/targets/firewall_resource/defaults/main/common.yml
+++ b/tests/integration/targets/firewall_resource/defaults/main/common.yml
@@ -10,3 +10,18 @@ hcloud_prefix: "tests"
 hcloud_run_ns: "{{ hcloud_prefix | md5 }}"
 hcloud_role_ns: "{{ role_name | split('_') | map('batch', 2) | map('first') | flatten() | join() }}"
 hcloud_ns: "ansible-{{ hcloud_run_ns }}-{{ hcloud_role_ns }}"
+
+# Used to easily update the server types and images across all our tests.
+hcloud_server_type: cax11
+hcloud_server_type_id: 45
+
+hcloud_server_type_upgrade: cax21
+hcloud_server_type_upgrade_id: 93
+
+hcloud_image: debian-12
+hcloud_image_id: 114690389 # architecture=arm
+
+hcloud_location: hel1
+hcloud_location_id: 3
+hcloud_datacenter: hel1-dc2
+hcloud_datacenter_id: 3

--- a/tests/integration/targets/firewall_resource/defaults/main/common.yml
+++ b/tests/integration/targets/firewall_resource/defaults/main/common.yml
@@ -12,16 +12,16 @@ hcloud_role_ns: "{{ role_name | split('_') | map('batch', 2) | map('first') | fl
 hcloud_ns: "ansible-{{ hcloud_run_ns }}-{{ hcloud_role_ns }}"
 
 # Used to easily update the server types and images across all our tests.
-hcloud_server_type: cax11
+hcloud_server_type_name: cax11
 hcloud_server_type_id: 45
 
-hcloud_server_type_upgrade: cax21
+hcloud_server_type_upgrade_name: cax21
 hcloud_server_type_upgrade_id: 93
 
-hcloud_image: debian-12
+hcloud_image_name: debian-12
 hcloud_image_id: 114690389 # architecture=arm
 
-hcloud_location: hel1
+hcloud_location_name: hel1
 hcloud_location_id: 3
-hcloud_datacenter: hel1-dc2
+hcloud_datacenter_name: hel1-dc2
 hcloud_datacenter_id: 3

--- a/tests/integration/targets/firewall_resource/tasks/prepare.yml
+++ b/tests/integration/targets/firewall_resource/tasks/prepare.yml
@@ -2,8 +2,8 @@
 - name: Create test_server
   hetzner.hcloud.server:
     name: "{{ hcloud_server_name }}"
-    server_type: cax11
-    image: ubuntu-22.04
+    server_type: "{{ hcloud_server_type }}"
+    image: "{{ hcloud_image }}"
     labels:
       key: value
     state: stopped

--- a/tests/integration/targets/firewall_resource/tasks/prepare.yml
+++ b/tests/integration/targets/firewall_resource/tasks/prepare.yml
@@ -2,8 +2,8 @@
 - name: Create test_server
   hetzner.hcloud.server:
     name: "{{ hcloud_server_name }}"
-    server_type: "{{ hcloud_server_type }}"
-    image: "{{ hcloud_image }}"
+    server_type: "{{ hcloud_server_type_name }}"
+    image: "{{ hcloud_image_name }}"
     labels:
       key: value
     state: stopped

--- a/tests/integration/targets/floating_ip/defaults/main/common.yml
+++ b/tests/integration/targets/floating_ip/defaults/main/common.yml
@@ -10,3 +10,18 @@ hcloud_prefix: "tests"
 hcloud_run_ns: "{{ hcloud_prefix | md5 }}"
 hcloud_role_ns: "{{ role_name | split('_') | map('batch', 2) | map('first') | flatten() | join() }}"
 hcloud_ns: "ansible-{{ hcloud_run_ns }}-{{ hcloud_role_ns }}"
+
+# Used to easily update the server types and images across all our tests.
+hcloud_server_type: cax11
+hcloud_server_type_id: 45
+
+hcloud_server_type_upgrade: cax21
+hcloud_server_type_upgrade_id: 93
+
+hcloud_image: debian-12
+hcloud_image_id: 114690389 # architecture=arm
+
+hcloud_location: hel1
+hcloud_location_id: 3
+hcloud_datacenter: hel1-dc2
+hcloud_datacenter_id: 3

--- a/tests/integration/targets/floating_ip/defaults/main/common.yml
+++ b/tests/integration/targets/floating_ip/defaults/main/common.yml
@@ -12,16 +12,16 @@ hcloud_role_ns: "{{ role_name | split('_') | map('batch', 2) | map('first') | fl
 hcloud_ns: "ansible-{{ hcloud_run_ns }}-{{ hcloud_role_ns }}"
 
 # Used to easily update the server types and images across all our tests.
-hcloud_server_type: cax11
+hcloud_server_type_name: cax11
 hcloud_server_type_id: 45
 
-hcloud_server_type_upgrade: cax21
+hcloud_server_type_upgrade_name: cax21
 hcloud_server_type_upgrade_id: 93
 
-hcloud_image: debian-12
+hcloud_image_name: debian-12
 hcloud_image_id: 114690389 # architecture=arm
 
-hcloud_location: hel1
+hcloud_location_name: hel1
 hcloud_location_id: 3
-hcloud_datacenter: hel1-dc2
+hcloud_datacenter_name: hel1-dc2
 hcloud_datacenter_id: 3

--- a/tests/integration/targets/floating_ip/tasks/test.yml
+++ b/tests/integration/targets/floating_ip/tasks/test.yml
@@ -19,10 +19,10 @@
 - name: setup server
   hetzner.hcloud.server:
     name: "{{ hcloud_server_name }}"
-    server_type: "{{ hcloud_server_type }}"
-    image: "{{ hcloud_image }}"
+    server_type: "{{ hcloud_server_type_name }}"
+    image: "{{ hcloud_image_name }}"
     state: stopped
-    location: "{{ hcloud_location }}"
+    location: "{{ hcloud_location_name }}"
   register: main_server
 - name: verify setup server
   assert:
@@ -32,8 +32,8 @@
 - name: setup another server
   hetzner.hcloud.server:
     name: "{{ hcloud_server_name }}2"
-    server_type: "{{ hcloud_server_type }}"
-    image: "{{ hcloud_image }}"
+    server_type: "{{ hcloud_server_type_name }}"
+    image: "{{ hcloud_image_name }}"
     state: stopped
   register: main_server2
 - name: verify setup another server
@@ -67,7 +67,7 @@
 - name: test missing type parameter on delete Floating IP
   hetzner.hcloud.floating_ip:
     type: ipv4
-    home_location: "{{ hcloud_location }}"
+    home_location: "{{ hcloud_location_name }}"
     state: "absent"
   register: result
   ignore_errors: true
@@ -81,7 +81,7 @@
   hetzner.hcloud.floating_ip:
     name: "{{ hcloud_floating_ip_name }}"
     type: ipv5
-    home_location: "{{ hcloud_location }}"
+    home_location: "{{ hcloud_location_name }}"
   register: result
   ignore_errors: true
 - name: verify invalid type
@@ -109,7 +109,7 @@
     name: "{{ hcloud_floating_ip_name }}"
     description: "Web Server"
     type: ipv4
-    home_location: "{{ hcloud_location }}"
+    home_location: "{{ hcloud_location_name }}"
   register: floatingIP
   check_mode: true
 - name: verify test create Floating IP with check mode
@@ -122,7 +122,7 @@
     name: "{{ hcloud_floating_ip_name }}"
     description: "Web Server"
     type: ipv4
-    home_location: "{{ hcloud_location }}"
+    home_location: "{{ hcloud_location_name }}"
   register: floatingIP
 - name: verify test create Floating IP
   assert:
@@ -130,14 +130,14 @@
       - floatingIP is changed
       - floatingIP.hcloud_floating_ip.name ==hcloud_floating_ip_name
       - floatingIP.hcloud_floating_ip.description == "Web Server"
-      - floatingIP.hcloud_floating_ip.home_location == hcloud_location
+      - floatingIP.hcloud_floating_ip.home_location == hcloud_location_name
 
 - name: test create Floating IP idempotency
   hetzner.hcloud.floating_ip:
     name: "{{ hcloud_floating_ip_name }}"
     description: "Web Server"
     type: ipv4
-    home_location: "{{ hcloud_location }}"
+    home_location: "{{ hcloud_location_name }}"
   register: floatingIP
 - name: verify test create Floating IP idempotency
   assert:
@@ -149,7 +149,7 @@
     name: "{{ hcloud_floating_ip_name }}"
     description: "changed-description"
     type: ipv4
-    home_location: "{{ hcloud_location }}"
+    home_location: "{{ hcloud_location_name }}"
   check_mode: true
   register: floatingIP
 - name: verify test create Floating IP  with check mode
@@ -163,7 +163,7 @@
     name: "{{ hcloud_floating_ip_name }}"
     description: "changed-description"
     type: ipv4
-    home_location: "{{ hcloud_location }}"
+    home_location: "{{ hcloud_location_name }}"
     labels:
       key: value
   register: floatingIP
@@ -178,7 +178,7 @@
     name: "{{ hcloud_floating_ip_name }}"
     description: "changed-description"
     type: ipv4
-    home_location: "{{ hcloud_location }}"
+    home_location: "{{ hcloud_location_name }}"
     labels:
       key: value
   register: floatingIP
@@ -191,7 +191,7 @@
   hetzner.hcloud.floating_ip:
     name: "{{ hcloud_floating_ip_name }}"
     type: ipv4
-    home_location: "{{ hcloud_location }}"
+    home_location: "{{ hcloud_location_name }}"
     labels:
       key: value
   register: floatingIP
@@ -204,7 +204,7 @@
   hetzner.hcloud.floating_ip:
     name: "{{ hcloud_floating_ip_name }}"
     type: ipv4
-    home_location: "{{ hcloud_location }}"
+    home_location: "{{ hcloud_location_name }}"
     labels:
       key: value
       other: label
@@ -218,7 +218,7 @@
   hetzner.hcloud.floating_ip:
     name: "{{ hcloud_floating_ip_name }}"
     type: ipv4
-    home_location: "{{ hcloud_location }}"
+    home_location: "{{ hcloud_location_name }}"
     labels:
       other: label
       key: value
@@ -271,7 +271,7 @@
   hetzner.hcloud.floating_ip:
     name: "{{ hcloud_floating_ip_name }}"
     type: ipv4
-    home_location: "{{ hcloud_location }}"
+    home_location: "{{ hcloud_location_name }}"
   register: floatingIP
 - name: verify test unassign Floating IP
   assert:
@@ -283,7 +283,7 @@
   hetzner.hcloud.floating_ip:
     name: "{{ hcloud_floating_ip_name }}"
     type: ipv4
-    home_location: "{{ hcloud_location }}"
+    home_location: "{{ hcloud_location_name }}"
   register: floatingIP
 - name: verify test unassign Floating IPidempotency
   assert:
@@ -401,7 +401,7 @@
   hetzner.hcloud.floating_ip:
     name: "{{ hcloud_floating_ip_name }}"
     type: ipv6
-    home_location: "{{ hcloud_location }}"
+    home_location: "{{ hcloud_location_name }}"
     state: "present"
   register: result
 - name: verify test create ipv6 floating ip
@@ -442,7 +442,7 @@
   hetzner.hcloud.floating_ip:
     name: "{{ hcloud_floating_ip_name }}"
     type: ipv4
-    home_location: "{{ hcloud_location }}"
+    home_location: "{{ hcloud_location_name }}"
     delete_protection: true
   register: floatingIP
 - name: verify create Floating IP with delete protection

--- a/tests/integration/targets/floating_ip/tasks/test.yml
+++ b/tests/integration/targets/floating_ip/tasks/test.yml
@@ -19,10 +19,10 @@
 - name: setup server
   hetzner.hcloud.server:
     name: "{{ hcloud_server_name }}"
-    server_type: cax11
-    image: ubuntu-22.04
+    server_type: "{{ hcloud_server_type }}"
+    image: "{{ hcloud_image }}"
     state: stopped
-    location: "fsn1"
+    location: "{{ hcloud_location }}"
   register: main_server
 - name: verify setup server
   assert:
@@ -32,8 +32,8 @@
 - name: setup another server
   hetzner.hcloud.server:
     name: "{{ hcloud_server_name }}2"
-    server_type: cax11
-    image: ubuntu-22.04
+    server_type: "{{ hcloud_server_type }}"
+    image: "{{ hcloud_image }}"
     state: stopped
   register: main_server2
 - name: verify setup another server
@@ -67,7 +67,7 @@
 - name: test missing type parameter on delete Floating IP
   hetzner.hcloud.floating_ip:
     type: ipv4
-    home_location: "fsn1"
+    home_location: "{{ hcloud_location }}"
     state: "absent"
   register: result
   ignore_errors: true
@@ -81,7 +81,7 @@
   hetzner.hcloud.floating_ip:
     name: "{{ hcloud_floating_ip_name }}"
     type: ipv5
-    home_location: "fsn1"
+    home_location: "{{ hcloud_location }}"
   register: result
   ignore_errors: true
 - name: verify invalid type
@@ -109,7 +109,7 @@
     name: "{{ hcloud_floating_ip_name }}"
     description: "Web Server"
     type: ipv4
-    home_location: "fsn1"
+    home_location: "{{ hcloud_location }}"
   register: floatingIP
   check_mode: true
 - name: verify test create Floating IP with check mode
@@ -122,7 +122,7 @@
     name: "{{ hcloud_floating_ip_name }}"
     description: "Web Server"
     type: ipv4
-    home_location: "fsn1"
+    home_location: "{{ hcloud_location }}"
   register: floatingIP
 - name: verify test create Floating IP
   assert:
@@ -130,14 +130,14 @@
       - floatingIP is changed
       - floatingIP.hcloud_floating_ip.name ==hcloud_floating_ip_name
       - floatingIP.hcloud_floating_ip.description == "Web Server"
-      - floatingIP.hcloud_floating_ip.home_location == "fsn1"
+      - floatingIP.hcloud_floating_ip.home_location == hcloud_location
 
 - name: test create Floating IP idempotency
   hetzner.hcloud.floating_ip:
     name: "{{ hcloud_floating_ip_name }}"
     description: "Web Server"
     type: ipv4
-    home_location: "fsn1"
+    home_location: "{{ hcloud_location }}"
   register: floatingIP
 - name: verify test create Floating IP idempotency
   assert:
@@ -149,7 +149,7 @@
     name: "{{ hcloud_floating_ip_name }}"
     description: "changed-description"
     type: ipv4
-    home_location: "fsn1"
+    home_location: "{{ hcloud_location }}"
   check_mode: true
   register: floatingIP
 - name: verify test create Floating IP  with check mode
@@ -163,7 +163,7 @@
     name: "{{ hcloud_floating_ip_name }}"
     description: "changed-description"
     type: ipv4
-    home_location: "fsn1"
+    home_location: "{{ hcloud_location }}"
     labels:
       key: value
   register: floatingIP
@@ -178,7 +178,7 @@
     name: "{{ hcloud_floating_ip_name }}"
     description: "changed-description"
     type: ipv4
-    home_location: "fsn1"
+    home_location: "{{ hcloud_location }}"
     labels:
       key: value
   register: floatingIP
@@ -191,7 +191,7 @@
   hetzner.hcloud.floating_ip:
     name: "{{ hcloud_floating_ip_name }}"
     type: ipv4
-    home_location: "fsn1"
+    home_location: "{{ hcloud_location }}"
     labels:
       key: value
   register: floatingIP
@@ -204,7 +204,7 @@
   hetzner.hcloud.floating_ip:
     name: "{{ hcloud_floating_ip_name }}"
     type: ipv4
-    home_location: "fsn1"
+    home_location: "{{ hcloud_location }}"
     labels:
       key: value
       other: label
@@ -218,7 +218,7 @@
   hetzner.hcloud.floating_ip:
     name: "{{ hcloud_floating_ip_name }}"
     type: ipv4
-    home_location: "fsn1"
+    home_location: "{{ hcloud_location }}"
     labels:
       other: label
       key: value
@@ -271,7 +271,7 @@
   hetzner.hcloud.floating_ip:
     name: "{{ hcloud_floating_ip_name }}"
     type: ipv4
-    home_location: "fsn1"
+    home_location: "{{ hcloud_location }}"
   register: floatingIP
 - name: verify test unassign Floating IP
   assert:
@@ -283,7 +283,7 @@
   hetzner.hcloud.floating_ip:
     name: "{{ hcloud_floating_ip_name }}"
     type: ipv4
-    home_location: "fsn1"
+    home_location: "{{ hcloud_location }}"
   register: floatingIP
 - name: verify test unassign Floating IPidempotency
   assert:
@@ -401,7 +401,7 @@
   hetzner.hcloud.floating_ip:
     name: "{{ hcloud_floating_ip_name }}"
     type: ipv6
-    home_location: "fsn1"
+    home_location: "{{ hcloud_location }}"
     state: "present"
   register: result
 - name: verify test create ipv6 floating ip
@@ -442,7 +442,7 @@
   hetzner.hcloud.floating_ip:
     name: "{{ hcloud_floating_ip_name }}"
     type: ipv4
-    home_location: fsn1
+    home_location: "{{ hcloud_location }}"
     delete_protection: true
   register: floatingIP
 - name: verify create Floating IP with delete protection

--- a/tests/integration/targets/floating_ip_info/defaults/main/common.yml
+++ b/tests/integration/targets/floating_ip_info/defaults/main/common.yml
@@ -10,3 +10,18 @@ hcloud_prefix: "tests"
 hcloud_run_ns: "{{ hcloud_prefix | md5 }}"
 hcloud_role_ns: "{{ role_name | split('_') | map('batch', 2) | map('first') | flatten() | join() }}"
 hcloud_ns: "ansible-{{ hcloud_run_ns }}-{{ hcloud_role_ns }}"
+
+# Used to easily update the server types and images across all our tests.
+hcloud_server_type: cax11
+hcloud_server_type_id: 45
+
+hcloud_server_type_upgrade: cax21
+hcloud_server_type_upgrade_id: 93
+
+hcloud_image: debian-12
+hcloud_image_id: 114690389 # architecture=arm
+
+hcloud_location: hel1
+hcloud_location_id: 3
+hcloud_datacenter: hel1-dc2
+hcloud_datacenter_id: 3

--- a/tests/integration/targets/floating_ip_info/defaults/main/common.yml
+++ b/tests/integration/targets/floating_ip_info/defaults/main/common.yml
@@ -12,16 +12,16 @@ hcloud_role_ns: "{{ role_name | split('_') | map('batch', 2) | map('first') | fl
 hcloud_ns: "ansible-{{ hcloud_run_ns }}-{{ hcloud_role_ns }}"
 
 # Used to easily update the server types and images across all our tests.
-hcloud_server_type: cax11
+hcloud_server_type_name: cax11
 hcloud_server_type_id: 45
 
-hcloud_server_type_upgrade: cax21
+hcloud_server_type_upgrade_name: cax21
 hcloud_server_type_upgrade_id: 93
 
-hcloud_image: debian-12
+hcloud_image_name: debian-12
 hcloud_image_id: 114690389 # architecture=arm
 
-hcloud_location: hel1
+hcloud_location_name: hel1
 hcloud_location_id: 3
-hcloud_datacenter: hel1-dc2
+hcloud_datacenter_name: hel1-dc2
 hcloud_datacenter_id: 3

--- a/tests/integration/targets/floating_ip_info/tasks/prepare.yml
+++ b/tests/integration/targets/floating_ip_info/tasks/prepare.yml
@@ -2,7 +2,7 @@
 - name: Create test_floating_ip
   hetzner.hcloud.floating_ip:
     name: "{{ hcloud_floating_ip_name }}"
-    home_location: "{{ hcloud_location }}"
+    home_location: "{{ hcloud_location_name }}"
     type: ipv4
     labels:
       key: value

--- a/tests/integration/targets/floating_ip_info/tasks/prepare.yml
+++ b/tests/integration/targets/floating_ip_info/tasks/prepare.yml
@@ -2,7 +2,7 @@
 - name: Create test_floating_ip
   hetzner.hcloud.floating_ip:
     name: "{{ hcloud_floating_ip_name }}"
-    home_location: fsn1
+    home_location: "{{ hcloud_location }}"
     type: ipv4
     labels:
       key: value

--- a/tests/integration/targets/image_info/defaults/main/common.yml
+++ b/tests/integration/targets/image_info/defaults/main/common.yml
@@ -10,3 +10,18 @@ hcloud_prefix: "tests"
 hcloud_run_ns: "{{ hcloud_prefix | md5 }}"
 hcloud_role_ns: "{{ role_name | split('_') | map('batch', 2) | map('first') | flatten() | join() }}"
 hcloud_ns: "ansible-{{ hcloud_run_ns }}-{{ hcloud_role_ns }}"
+
+# Used to easily update the server types and images across all our tests.
+hcloud_server_type: cax11
+hcloud_server_type_id: 45
+
+hcloud_server_type_upgrade: cax21
+hcloud_server_type_upgrade_id: 93
+
+hcloud_image: debian-12
+hcloud_image_id: 114690389 # architecture=arm
+
+hcloud_location: hel1
+hcloud_location_id: 3
+hcloud_datacenter: hel1-dc2
+hcloud_datacenter_id: 3

--- a/tests/integration/targets/image_info/defaults/main/common.yml
+++ b/tests/integration/targets/image_info/defaults/main/common.yml
@@ -12,16 +12,16 @@ hcloud_role_ns: "{{ role_name | split('_') | map('batch', 2) | map('first') | fl
 hcloud_ns: "ansible-{{ hcloud_run_ns }}-{{ hcloud_role_ns }}"
 
 # Used to easily update the server types and images across all our tests.
-hcloud_server_type: cax11
+hcloud_server_type_name: cax11
 hcloud_server_type_id: 45
 
-hcloud_server_type_upgrade: cax21
+hcloud_server_type_upgrade_name: cax21
 hcloud_server_type_upgrade_id: 93
 
-hcloud_image: debian-12
+hcloud_image_name: debian-12
 hcloud_image_id: 114690389 # architecture=arm
 
-hcloud_location: hel1
+hcloud_location_name: hel1
 hcloud_location_id: 3
-hcloud_datacenter: hel1-dc2
+hcloud_datacenter_name: hel1-dc2
 hcloud_datacenter_id: 3

--- a/tests/integration/targets/image_info/defaults/main/main.yml
+++ b/tests/integration/targets/image_info/defaults/main/main.yml
@@ -3,4 +3,3 @@
 ---
 hcloud_server_name: "{{ hcloud_ns }}"
 hcloud_snapshot_name: "{{ hcloud_ns }}"
-hcloud_image_name: ubuntu-22.04

--- a/tests/integration/targets/image_info/tasks/prepare.yml
+++ b/tests/integration/targets/image_info/tasks/prepare.yml
@@ -2,8 +2,8 @@
 - name: Create test_server
   hetzner.hcloud.server:
     name: "{{ hcloud_server_name }}"
-    server_type: "{{ hcloud_server_type }}"
-    image: "{{ hcloud_image }}"
+    server_type: "{{ hcloud_server_type_name }}"
+    image: "{{ hcloud_image_name }}"
     state: stopped
   register: test_server
 

--- a/tests/integration/targets/image_info/tasks/prepare.yml
+++ b/tests/integration/targets/image_info/tasks/prepare.yml
@@ -2,8 +2,8 @@
 - name: Create test_server
   hetzner.hcloud.server:
     name: "{{ hcloud_server_name }}"
-    server_type: cax11
-    image: ubuntu-22.04
+    server_type: "{{ hcloud_server_type }}"
+    image: "{{ hcloud_image }}"
     state: stopped
   register: test_server
 

--- a/tests/integration/targets/image_info/tasks/test.yml
+++ b/tests/integration/targets/image_info/tasks/test.yml
@@ -51,7 +51,7 @@
 
 - name: Gather hcloud_image_info with correct name
   hetzner.hcloud.image_info:
-    name: "{{ hcloud_image }}"
+    name: "{{ hcloud_image_name }}"
   register: result
 - name: Verify hcloud_image_info with correct name
   ansible.builtin.assert:
@@ -61,7 +61,7 @@
 
 - name: Gather hcloud_image_info with wrong name
   hetzner.hcloud.image_info:
-    name: "{{ hcloud_image }}-invalid"
+    name: "{{ hcloud_image_name }}-invalid"
   register: result
 - name: Verify hcloud_image_info with wrong name
   ansible.builtin.assert:
@@ -70,7 +70,7 @@
 
 - name: Gather hcloud_image_info with correct name and architecture
   hetzner.hcloud.image_info:
-    name: "{{ hcloud_image }}"
+    name: "{{ hcloud_image_name }}"
     architecture: arm
   register: result
 - name: Verify hcloud_image_info with correct name

--- a/tests/integration/targets/image_info/tasks/test.yml
+++ b/tests/integration/targets/image_info/tasks/test.yml
@@ -51,7 +51,7 @@
 
 - name: Gather hcloud_image_info with correct name
   hetzner.hcloud.image_info:
-    name: "{{ hcloud_image_name }}"
+    name: "{{ hcloud_image }}"
   register: result
 - name: Verify hcloud_image_info with correct name
   ansible.builtin.assert:
@@ -61,7 +61,7 @@
 
 - name: Gather hcloud_image_info with wrong name
   hetzner.hcloud.image_info:
-    name: "{{ hcloud_image_name }}-invalid"
+    name: "{{ hcloud_image }}-invalid"
   register: result
 - name: Verify hcloud_image_info with wrong name
   ansible.builtin.assert:
@@ -70,7 +70,7 @@
 
 - name: Gather hcloud_image_info with correct name and architecture
   hetzner.hcloud.image_info:
-    name: "{{ hcloud_image_name }}"
+    name: "{{ hcloud_image }}"
     architecture: arm
   register: result
 - name: Verify hcloud_image_info with correct name

--- a/tests/integration/targets/iso_info/defaults/main/common.yml
+++ b/tests/integration/targets/iso_info/defaults/main/common.yml
@@ -10,3 +10,18 @@ hcloud_prefix: "tests"
 hcloud_run_ns: "{{ hcloud_prefix | md5 }}"
 hcloud_role_ns: "{{ role_name | split('_') | map('batch', 2) | map('first') | flatten() | join() }}"
 hcloud_ns: "ansible-{{ hcloud_run_ns }}-{{ hcloud_role_ns }}"
+
+# Used to easily update the server types and images across all our tests.
+hcloud_server_type: cax11
+hcloud_server_type_id: 45
+
+hcloud_server_type_upgrade: cax21
+hcloud_server_type_upgrade_id: 93
+
+hcloud_image: debian-12
+hcloud_image_id: 114690389 # architecture=arm
+
+hcloud_location: hel1
+hcloud_location_id: 3
+hcloud_datacenter: hel1-dc2
+hcloud_datacenter_id: 3

--- a/tests/integration/targets/iso_info/defaults/main/common.yml
+++ b/tests/integration/targets/iso_info/defaults/main/common.yml
@@ -12,16 +12,16 @@ hcloud_role_ns: "{{ role_name | split('_') | map('batch', 2) | map('first') | fl
 hcloud_ns: "ansible-{{ hcloud_run_ns }}-{{ hcloud_role_ns }}"
 
 # Used to easily update the server types and images across all our tests.
-hcloud_server_type: cax11
+hcloud_server_type_name: cax11
 hcloud_server_type_id: 45
 
-hcloud_server_type_upgrade: cax21
+hcloud_server_type_upgrade_name: cax21
 hcloud_server_type_upgrade_id: 93
 
-hcloud_image: debian-12
+hcloud_image_name: debian-12
 hcloud_image_id: 114690389 # architecture=arm
 
-hcloud_location: hel1
+hcloud_location_name: hel1
 hcloud_location_id: 3
-hcloud_datacenter: hel1-dc2
+hcloud_datacenter_name: hel1-dc2
 hcloud_datacenter_id: 3

--- a/tests/integration/targets/load_balancer/defaults/main/common.yml
+++ b/tests/integration/targets/load_balancer/defaults/main/common.yml
@@ -10,3 +10,18 @@ hcloud_prefix: "tests"
 hcloud_run_ns: "{{ hcloud_prefix | md5 }}"
 hcloud_role_ns: "{{ role_name | split('_') | map('batch', 2) | map('first') | flatten() | join() }}"
 hcloud_ns: "ansible-{{ hcloud_run_ns }}-{{ hcloud_role_ns }}"
+
+# Used to easily update the server types and images across all our tests.
+hcloud_server_type: cax11
+hcloud_server_type_id: 45
+
+hcloud_server_type_upgrade: cax21
+hcloud_server_type_upgrade_id: 93
+
+hcloud_image: debian-12
+hcloud_image_id: 114690389 # architecture=arm
+
+hcloud_location: hel1
+hcloud_location_id: 3
+hcloud_datacenter: hel1-dc2
+hcloud_datacenter_id: 3

--- a/tests/integration/targets/load_balancer/defaults/main/common.yml
+++ b/tests/integration/targets/load_balancer/defaults/main/common.yml
@@ -12,16 +12,16 @@ hcloud_role_ns: "{{ role_name | split('_') | map('batch', 2) | map('first') | fl
 hcloud_ns: "ansible-{{ hcloud_run_ns }}-{{ hcloud_role_ns }}"
 
 # Used to easily update the server types and images across all our tests.
-hcloud_server_type: cax11
+hcloud_server_type_name: cax11
 hcloud_server_type_id: 45
 
-hcloud_server_type_upgrade: cax21
+hcloud_server_type_upgrade_name: cax21
 hcloud_server_type_upgrade_id: 93
 
-hcloud_image: debian-12
+hcloud_image_name: debian-12
 hcloud_image_id: 114690389 # architecture=arm
 
-hcloud_location: hel1
+hcloud_location_name: hel1
 hcloud_location_id: 3
-hcloud_datacenter: hel1-dc2
+hcloud_datacenter_name: hel1-dc2
 hcloud_datacenter_id: 3

--- a/tests/integration/targets/load_balancer_info/defaults/main/common.yml
+++ b/tests/integration/targets/load_balancer_info/defaults/main/common.yml
@@ -10,3 +10,18 @@ hcloud_prefix: "tests"
 hcloud_run_ns: "{{ hcloud_prefix | md5 }}"
 hcloud_role_ns: "{{ role_name | split('_') | map('batch', 2) | map('first') | flatten() | join() }}"
 hcloud_ns: "ansible-{{ hcloud_run_ns }}-{{ hcloud_role_ns }}"
+
+# Used to easily update the server types and images across all our tests.
+hcloud_server_type: cax11
+hcloud_server_type_id: 45
+
+hcloud_server_type_upgrade: cax21
+hcloud_server_type_upgrade_id: 93
+
+hcloud_image: debian-12
+hcloud_image_id: 114690389 # architecture=arm
+
+hcloud_location: hel1
+hcloud_location_id: 3
+hcloud_datacenter: hel1-dc2
+hcloud_datacenter_id: 3

--- a/tests/integration/targets/load_balancer_info/defaults/main/common.yml
+++ b/tests/integration/targets/load_balancer_info/defaults/main/common.yml
@@ -12,16 +12,16 @@ hcloud_role_ns: "{{ role_name | split('_') | map('batch', 2) | map('first') | fl
 hcloud_ns: "ansible-{{ hcloud_run_ns }}-{{ hcloud_role_ns }}"
 
 # Used to easily update the server types and images across all our tests.
-hcloud_server_type: cax11
+hcloud_server_type_name: cax11
 hcloud_server_type_id: 45
 
-hcloud_server_type_upgrade: cax21
+hcloud_server_type_upgrade_name: cax21
 hcloud_server_type_upgrade_id: 93
 
-hcloud_image: debian-12
+hcloud_image_name: debian-12
 hcloud_image_id: 114690389 # architecture=arm
 
-hcloud_location: hel1
+hcloud_location_name: hel1
 hcloud_location_id: 3
-hcloud_datacenter: hel1-dc2
+hcloud_datacenter_name: hel1-dc2
 hcloud_datacenter_id: 3

--- a/tests/integration/targets/load_balancer_info/tasks/prepare.yml
+++ b/tests/integration/targets/load_balancer_info/tasks/prepare.yml
@@ -2,8 +2,8 @@
 - name: Create test_server
   hetzner.hcloud.server:
     name: "{{ hcloud_server_name }}"
-    server_type: "{{ hcloud_server_type }}"
-    image: "{{ hcloud_image }}"
+    server_type: "{{ hcloud_server_type_name }}"
+    image: "{{ hcloud_image_name }}"
     state: stopped
   register: test_server
 

--- a/tests/integration/targets/load_balancer_info/tasks/prepare.yml
+++ b/tests/integration/targets/load_balancer_info/tasks/prepare.yml
@@ -2,8 +2,8 @@
 - name: Create test_server
   hetzner.hcloud.server:
     name: "{{ hcloud_server_name }}"
-    server_type: cax11
-    image: ubuntu-22.04
+    server_type: "{{ hcloud_server_type }}"
+    image: "{{ hcloud_image }}"
     state: stopped
   register: test_server
 

--- a/tests/integration/targets/load_balancer_network/defaults/main/common.yml
+++ b/tests/integration/targets/load_balancer_network/defaults/main/common.yml
@@ -10,3 +10,18 @@ hcloud_prefix: "tests"
 hcloud_run_ns: "{{ hcloud_prefix | md5 }}"
 hcloud_role_ns: "{{ role_name | split('_') | map('batch', 2) | map('first') | flatten() | join() }}"
 hcloud_ns: "ansible-{{ hcloud_run_ns }}-{{ hcloud_role_ns }}"
+
+# Used to easily update the server types and images across all our tests.
+hcloud_server_type: cax11
+hcloud_server_type_id: 45
+
+hcloud_server_type_upgrade: cax21
+hcloud_server_type_upgrade_id: 93
+
+hcloud_image: debian-12
+hcloud_image_id: 114690389 # architecture=arm
+
+hcloud_location: hel1
+hcloud_location_id: 3
+hcloud_datacenter: hel1-dc2
+hcloud_datacenter_id: 3

--- a/tests/integration/targets/load_balancer_network/defaults/main/common.yml
+++ b/tests/integration/targets/load_balancer_network/defaults/main/common.yml
@@ -12,16 +12,16 @@ hcloud_role_ns: "{{ role_name | split('_') | map('batch', 2) | map('first') | fl
 hcloud_ns: "ansible-{{ hcloud_run_ns }}-{{ hcloud_role_ns }}"
 
 # Used to easily update the server types and images across all our tests.
-hcloud_server_type: cax11
+hcloud_server_type_name: cax11
 hcloud_server_type_id: 45
 
-hcloud_server_type_upgrade: cax21
+hcloud_server_type_upgrade_name: cax21
 hcloud_server_type_upgrade_id: 93
 
-hcloud_image: debian-12
+hcloud_image_name: debian-12
 hcloud_image_id: 114690389 # architecture=arm
 
-hcloud_location: hel1
+hcloud_location_name: hel1
 hcloud_location_id: 3
-hcloud_datacenter: hel1-dc2
+hcloud_datacenter_name: hel1-dc2
 hcloud_datacenter_id: 3

--- a/tests/integration/targets/load_balancer_network/tasks/test.yml
+++ b/tests/integration/targets/load_balancer_network/tasks/test.yml
@@ -30,7 +30,7 @@
     name: "{{hcloud_load_balancer_name}}"
     load_balancer_type: lb11
     state: present
-    location: "fsn1"
+    location: "{{ hcloud_location }}"
   register: load_balancer
 - name: verify setup load_balancer
   assert:

--- a/tests/integration/targets/load_balancer_network/tasks/test.yml
+++ b/tests/integration/targets/load_balancer_network/tasks/test.yml
@@ -30,7 +30,7 @@
     name: "{{hcloud_load_balancer_name}}"
     load_balancer_type: lb11
     state: present
-    location: "{{ hcloud_location }}"
+    location: "{{ hcloud_location_name }}"
   register: load_balancer
 - name: verify setup load_balancer
   assert:

--- a/tests/integration/targets/load_balancer_service/defaults/main/common.yml
+++ b/tests/integration/targets/load_balancer_service/defaults/main/common.yml
@@ -10,3 +10,18 @@ hcloud_prefix: "tests"
 hcloud_run_ns: "{{ hcloud_prefix | md5 }}"
 hcloud_role_ns: "{{ role_name | split('_') | map('batch', 2) | map('first') | flatten() | join() }}"
 hcloud_ns: "ansible-{{ hcloud_run_ns }}-{{ hcloud_role_ns }}"
+
+# Used to easily update the server types and images across all our tests.
+hcloud_server_type: cax11
+hcloud_server_type_id: 45
+
+hcloud_server_type_upgrade: cax21
+hcloud_server_type_upgrade_id: 93
+
+hcloud_image: debian-12
+hcloud_image_id: 114690389 # architecture=arm
+
+hcloud_location: hel1
+hcloud_location_id: 3
+hcloud_datacenter: hel1-dc2
+hcloud_datacenter_id: 3

--- a/tests/integration/targets/load_balancer_service/defaults/main/common.yml
+++ b/tests/integration/targets/load_balancer_service/defaults/main/common.yml
@@ -12,16 +12,16 @@ hcloud_role_ns: "{{ role_name | split('_') | map('batch', 2) | map('first') | fl
 hcloud_ns: "ansible-{{ hcloud_run_ns }}-{{ hcloud_role_ns }}"
 
 # Used to easily update the server types and images across all our tests.
-hcloud_server_type: cax11
+hcloud_server_type_name: cax11
 hcloud_server_type_id: 45
 
-hcloud_server_type_upgrade: cax21
+hcloud_server_type_upgrade_name: cax21
 hcloud_server_type_upgrade_id: 93
 
-hcloud_image: debian-12
+hcloud_image_name: debian-12
 hcloud_image_id: 114690389 # architecture=arm
 
-hcloud_location: hel1
+hcloud_location_name: hel1
 hcloud_location_id: 3
-hcloud_datacenter: hel1-dc2
+hcloud_datacenter_name: hel1-dc2
 hcloud_datacenter_id: 3

--- a/tests/integration/targets/load_balancer_service/tasks/test.yml
+++ b/tests/integration/targets/load_balancer_service/tasks/test.yml
@@ -6,7 +6,7 @@
     name: "{{hcloud_load_balancer_name}}"
     load_balancer_type: lb11
     state: present
-    location: "{{ hcloud_location }}"
+    location: "{{ hcloud_location_name }}"
   register: load_balancer
 - name: verify setup load_balancer
   assert:

--- a/tests/integration/targets/load_balancer_service/tasks/test.yml
+++ b/tests/integration/targets/load_balancer_service/tasks/test.yml
@@ -6,7 +6,7 @@
     name: "{{hcloud_load_balancer_name}}"
     load_balancer_type: lb11
     state: present
-    location: "fsn1"
+    location: "{{ hcloud_location }}"
   register: load_balancer
 - name: verify setup load_balancer
   assert:

--- a/tests/integration/targets/load_balancer_target/defaults/main/common.yml
+++ b/tests/integration/targets/load_balancer_target/defaults/main/common.yml
@@ -10,3 +10,18 @@ hcloud_prefix: "tests"
 hcloud_run_ns: "{{ hcloud_prefix | md5 }}"
 hcloud_role_ns: "{{ role_name | split('_') | map('batch', 2) | map('first') | flatten() | join() }}"
 hcloud_ns: "ansible-{{ hcloud_run_ns }}-{{ hcloud_role_ns }}"
+
+# Used to easily update the server types and images across all our tests.
+hcloud_server_type: cax11
+hcloud_server_type_id: 45
+
+hcloud_server_type_upgrade: cax21
+hcloud_server_type_upgrade_id: 93
+
+hcloud_image: debian-12
+hcloud_image_id: 114690389 # architecture=arm
+
+hcloud_location: hel1
+hcloud_location_id: 3
+hcloud_datacenter: hel1-dc2
+hcloud_datacenter_id: 3

--- a/tests/integration/targets/load_balancer_target/defaults/main/common.yml
+++ b/tests/integration/targets/load_balancer_target/defaults/main/common.yml
@@ -12,16 +12,16 @@ hcloud_role_ns: "{{ role_name | split('_') | map('batch', 2) | map('first') | fl
 hcloud_ns: "ansible-{{ hcloud_run_ns }}-{{ hcloud_role_ns }}"
 
 # Used to easily update the server types and images across all our tests.
-hcloud_server_type: cax11
+hcloud_server_type_name: cax11
 hcloud_server_type_id: 45
 
-hcloud_server_type_upgrade: cax21
+hcloud_server_type_upgrade_name: cax21
 hcloud_server_type_upgrade_id: 93
 
-hcloud_image: debian-12
+hcloud_image_name: debian-12
 hcloud_image_id: 114690389 # architecture=arm
 
-hcloud_location: hel1
+hcloud_location_name: hel1
 hcloud_location_id: 3
-hcloud_datacenter: hel1-dc2
+hcloud_datacenter_name: hel1-dc2
 hcloud_datacenter_id: 3

--- a/tests/integration/targets/load_balancer_target/tasks/test.yml
+++ b/tests/integration/targets/load_balancer_target/tasks/test.yml
@@ -4,10 +4,10 @@
 - name: setup server
   hetzner.hcloud.server:
     name: "{{hcloud_server_name}}"
-    server_type: "{{ hcloud_server_type }}"
-    image: "{{ hcloud_image }}"
+    server_type: "{{ hcloud_server_type_name }}"
+    image: "{{ hcloud_image_name }}"
     state: stopped
-    location: "{{ hcloud_location }}"
+    location: "{{ hcloud_location_name }}"
   register: server
 - name: verify setup server
   assert:
@@ -19,7 +19,7 @@
     name: "{{hcloud_load_balancer_name}}"
     load_balancer_type: lb11
     state: present
-    location: "{{ hcloud_location }}"
+    location: "{{ hcloud_location_name }}"
   register: load_balancer
 - name: verify setup load_balancer
   assert:

--- a/tests/integration/targets/load_balancer_target/tasks/test.yml
+++ b/tests/integration/targets/load_balancer_target/tasks/test.yml
@@ -4,10 +4,10 @@
 - name: setup server
   hetzner.hcloud.server:
     name: "{{hcloud_server_name}}"
-    server_type: cax11
-    image: ubuntu-22.04
+    server_type: "{{ hcloud_server_type }}"
+    image: "{{ hcloud_image }}"
     state: stopped
-    location: "fsn1"
+    location: "{{ hcloud_location }}"
   register: server
 - name: verify setup server
   assert:
@@ -19,7 +19,7 @@
     name: "{{hcloud_load_balancer_name}}"
     load_balancer_type: lb11
     state: present
-    location: "fsn1"
+    location: "{{ hcloud_location }}"
   register: load_balancer
 - name: verify setup load_balancer
   assert:

--- a/tests/integration/targets/load_balancer_type_info/defaults/main/common.yml
+++ b/tests/integration/targets/load_balancer_type_info/defaults/main/common.yml
@@ -10,3 +10,18 @@ hcloud_prefix: "tests"
 hcloud_run_ns: "{{ hcloud_prefix | md5 }}"
 hcloud_role_ns: "{{ role_name | split('_') | map('batch', 2) | map('first') | flatten() | join() }}"
 hcloud_ns: "ansible-{{ hcloud_run_ns }}-{{ hcloud_role_ns }}"
+
+# Used to easily update the server types and images across all our tests.
+hcloud_server_type: cax11
+hcloud_server_type_id: 45
+
+hcloud_server_type_upgrade: cax21
+hcloud_server_type_upgrade_id: 93
+
+hcloud_image: debian-12
+hcloud_image_id: 114690389 # architecture=arm
+
+hcloud_location: hel1
+hcloud_location_id: 3
+hcloud_datacenter: hel1-dc2
+hcloud_datacenter_id: 3

--- a/tests/integration/targets/load_balancer_type_info/defaults/main/common.yml
+++ b/tests/integration/targets/load_balancer_type_info/defaults/main/common.yml
@@ -12,16 +12,16 @@ hcloud_role_ns: "{{ role_name | split('_') | map('batch', 2) | map('first') | fl
 hcloud_ns: "ansible-{{ hcloud_run_ns }}-{{ hcloud_role_ns }}"
 
 # Used to easily update the server types and images across all our tests.
-hcloud_server_type: cax11
+hcloud_server_type_name: cax11
 hcloud_server_type_id: 45
 
-hcloud_server_type_upgrade: cax21
+hcloud_server_type_upgrade_name: cax21
 hcloud_server_type_upgrade_id: 93
 
-hcloud_image: debian-12
+hcloud_image_name: debian-12
 hcloud_image_id: 114690389 # architecture=arm
 
-hcloud_location: hel1
+hcloud_location_name: hel1
 hcloud_location_id: 3
-hcloud_datacenter: hel1-dc2
+hcloud_datacenter_name: hel1-dc2
 hcloud_datacenter_id: 3

--- a/tests/integration/targets/location_info/defaults/main/common.yml
+++ b/tests/integration/targets/location_info/defaults/main/common.yml
@@ -10,3 +10,18 @@ hcloud_prefix: "tests"
 hcloud_run_ns: "{{ hcloud_prefix | md5 }}"
 hcloud_role_ns: "{{ role_name | split('_') | map('batch', 2) | map('first') | flatten() | join() }}"
 hcloud_ns: "ansible-{{ hcloud_run_ns }}-{{ hcloud_role_ns }}"
+
+# Used to easily update the server types and images across all our tests.
+hcloud_server_type: cax11
+hcloud_server_type_id: 45
+
+hcloud_server_type_upgrade: cax21
+hcloud_server_type_upgrade_id: 93
+
+hcloud_image: debian-12
+hcloud_image_id: 114690389 # architecture=arm
+
+hcloud_location: hel1
+hcloud_location_id: 3
+hcloud_datacenter: hel1-dc2
+hcloud_datacenter_id: 3

--- a/tests/integration/targets/location_info/defaults/main/common.yml
+++ b/tests/integration/targets/location_info/defaults/main/common.yml
@@ -12,16 +12,16 @@ hcloud_role_ns: "{{ role_name | split('_') | map('batch', 2) | map('first') | fl
 hcloud_ns: "ansible-{{ hcloud_run_ns }}-{{ hcloud_role_ns }}"
 
 # Used to easily update the server types and images across all our tests.
-hcloud_server_type: cax11
+hcloud_server_type_name: cax11
 hcloud_server_type_id: 45
 
-hcloud_server_type_upgrade: cax21
+hcloud_server_type_upgrade_name: cax21
 hcloud_server_type_upgrade_id: 93
 
-hcloud_image: debian-12
+hcloud_image_name: debian-12
 hcloud_image_id: 114690389 # architecture=arm
 
-hcloud_location: hel1
+hcloud_location_name: hel1
 hcloud_location_id: 3
-hcloud_datacenter: hel1-dc2
+hcloud_datacenter_name: hel1-dc2
 hcloud_datacenter_id: 3

--- a/tests/integration/targets/location_info/defaults/main/main.yml
+++ b/tests/integration/targets/location_info/defaults/main/main.yml
@@ -1,5 +1,0 @@
-# Copyright: (c) 2019, Hetzner Cloud GmbH <info@hetzner-cloud.de>
-# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
----
-hcloud_location_id: 1
-hcloud_location_name: fsn1

--- a/tests/integration/targets/location_info/tasks/test.yml
+++ b/tests/integration/targets/location_info/tasks/test.yml
@@ -39,7 +39,7 @@
 
 - name: Gather hcloud_location_info with correct name
   hetzner.hcloud.location_info:
-    name: "{{ hcloud_location }}"
+    name: "{{ hcloud_location_name }}"
   register: result
 - name: Verify hcloud_location_info with correct name
   ansible.builtin.assert:
@@ -48,7 +48,7 @@
 
 - name: Gather hcloud_location_info with wrong name
   hetzner.hcloud.location_info:
-    name: "{{ hcloud_location }}-invalid"
+    name: "{{ hcloud_location_name }}-invalid"
   register: result
 - name: Verify hcloud_location_info with wrong name
   ansible.builtin.assert:

--- a/tests/integration/targets/location_info/tasks/test.yml
+++ b/tests/integration/targets/location_info/tasks/test.yml
@@ -39,7 +39,7 @@
 
 - name: Gather hcloud_location_info with correct name
   hetzner.hcloud.location_info:
-    name: "{{ hcloud_location_name }}"
+    name: "{{ hcloud_location }}"
   register: result
 - name: Verify hcloud_location_info with correct name
   ansible.builtin.assert:
@@ -48,7 +48,7 @@
 
 - name: Gather hcloud_location_info with wrong name
   hetzner.hcloud.location_info:
-    name: "{{ hcloud_location_name }}-invalid"
+    name: "{{ hcloud_location }}-invalid"
   register: result
 - name: Verify hcloud_location_info with wrong name
   ansible.builtin.assert:

--- a/tests/integration/targets/network/defaults/main/common.yml
+++ b/tests/integration/targets/network/defaults/main/common.yml
@@ -10,3 +10,18 @@ hcloud_prefix: "tests"
 hcloud_run_ns: "{{ hcloud_prefix | md5 }}"
 hcloud_role_ns: "{{ role_name | split('_') | map('batch', 2) | map('first') | flatten() | join() }}"
 hcloud_ns: "ansible-{{ hcloud_run_ns }}-{{ hcloud_role_ns }}"
+
+# Used to easily update the server types and images across all our tests.
+hcloud_server_type: cax11
+hcloud_server_type_id: 45
+
+hcloud_server_type_upgrade: cax21
+hcloud_server_type_upgrade_id: 93
+
+hcloud_image: debian-12
+hcloud_image_id: 114690389 # architecture=arm
+
+hcloud_location: hel1
+hcloud_location_id: 3
+hcloud_datacenter: hel1-dc2
+hcloud_datacenter_id: 3

--- a/tests/integration/targets/network/defaults/main/common.yml
+++ b/tests/integration/targets/network/defaults/main/common.yml
@@ -12,16 +12,16 @@ hcloud_role_ns: "{{ role_name | split('_') | map('batch', 2) | map('first') | fl
 hcloud_ns: "ansible-{{ hcloud_run_ns }}-{{ hcloud_role_ns }}"
 
 # Used to easily update the server types and images across all our tests.
-hcloud_server_type: cax11
+hcloud_server_type_name: cax11
 hcloud_server_type_id: 45
 
-hcloud_server_type_upgrade: cax21
+hcloud_server_type_upgrade_name: cax21
 hcloud_server_type_upgrade_id: 93
 
-hcloud_image: debian-12
+hcloud_image_name: debian-12
 hcloud_image_id: 114690389 # architecture=arm
 
-hcloud_location: hel1
+hcloud_location_name: hel1
 hcloud_location_id: 3
-hcloud_datacenter: hel1-dc2
+hcloud_datacenter_name: hel1-dc2
 hcloud_datacenter_id: 3

--- a/tests/integration/targets/network_info/defaults/main/common.yml
+++ b/tests/integration/targets/network_info/defaults/main/common.yml
@@ -10,3 +10,18 @@ hcloud_prefix: "tests"
 hcloud_run_ns: "{{ hcloud_prefix | md5 }}"
 hcloud_role_ns: "{{ role_name | split('_') | map('batch', 2) | map('first') | flatten() | join() }}"
 hcloud_ns: "ansible-{{ hcloud_run_ns }}-{{ hcloud_role_ns }}"
+
+# Used to easily update the server types and images across all our tests.
+hcloud_server_type: cax11
+hcloud_server_type_id: 45
+
+hcloud_server_type_upgrade: cax21
+hcloud_server_type_upgrade_id: 93
+
+hcloud_image: debian-12
+hcloud_image_id: 114690389 # architecture=arm
+
+hcloud_location: hel1
+hcloud_location_id: 3
+hcloud_datacenter: hel1-dc2
+hcloud_datacenter_id: 3

--- a/tests/integration/targets/network_info/defaults/main/common.yml
+++ b/tests/integration/targets/network_info/defaults/main/common.yml
@@ -12,16 +12,16 @@ hcloud_role_ns: "{{ role_name | split('_') | map('batch', 2) | map('first') | fl
 hcloud_ns: "ansible-{{ hcloud_run_ns }}-{{ hcloud_role_ns }}"
 
 # Used to easily update the server types and images across all our tests.
-hcloud_server_type: cax11
+hcloud_server_type_name: cax11
 hcloud_server_type_id: 45
 
-hcloud_server_type_upgrade: cax21
+hcloud_server_type_upgrade_name: cax21
 hcloud_server_type_upgrade_id: 93
 
-hcloud_image: debian-12
+hcloud_image_name: debian-12
 hcloud_image_id: 114690389 # architecture=arm
 
-hcloud_location: hel1
+hcloud_location_name: hel1
 hcloud_location_id: 3
-hcloud_datacenter: hel1-dc2
+hcloud_datacenter_name: hel1-dc2
 hcloud_datacenter_id: 3

--- a/tests/integration/targets/placement_group/defaults/main/common.yml
+++ b/tests/integration/targets/placement_group/defaults/main/common.yml
@@ -10,3 +10,18 @@ hcloud_prefix: "tests"
 hcloud_run_ns: "{{ hcloud_prefix | md5 }}"
 hcloud_role_ns: "{{ role_name | split('_') | map('batch', 2) | map('first') | flatten() | join() }}"
 hcloud_ns: "ansible-{{ hcloud_run_ns }}-{{ hcloud_role_ns }}"
+
+# Used to easily update the server types and images across all our tests.
+hcloud_server_type: cax11
+hcloud_server_type_id: 45
+
+hcloud_server_type_upgrade: cax21
+hcloud_server_type_upgrade_id: 93
+
+hcloud_image: debian-12
+hcloud_image_id: 114690389 # architecture=arm
+
+hcloud_location: hel1
+hcloud_location_id: 3
+hcloud_datacenter: hel1-dc2
+hcloud_datacenter_id: 3

--- a/tests/integration/targets/placement_group/defaults/main/common.yml
+++ b/tests/integration/targets/placement_group/defaults/main/common.yml
@@ -12,16 +12,16 @@ hcloud_role_ns: "{{ role_name | split('_') | map('batch', 2) | map('first') | fl
 hcloud_ns: "ansible-{{ hcloud_run_ns }}-{{ hcloud_role_ns }}"
 
 # Used to easily update the server types and images across all our tests.
-hcloud_server_type: cax11
+hcloud_server_type_name: cax11
 hcloud_server_type_id: 45
 
-hcloud_server_type_upgrade: cax21
+hcloud_server_type_upgrade_name: cax21
 hcloud_server_type_upgrade_id: 93
 
-hcloud_image: debian-12
+hcloud_image_name: debian-12
 hcloud_image_id: 114690389 # architecture=arm
 
-hcloud_location: hel1
+hcloud_location_name: hel1
 hcloud_location_id: 3
-hcloud_datacenter: hel1-dc2
+hcloud_datacenter_name: hel1-dc2
 hcloud_datacenter_id: 3

--- a/tests/integration/targets/placement_group/tasks/test.yml
+++ b/tests/integration/targets/placement_group/tasks/test.yml
@@ -64,9 +64,9 @@
 - name: test create server with placement group
   hetzner.hcloud.server:
     name: "{{ hcloud_server_name }}"
-    server_type: cax11
+    server_type: "{{ hcloud_server_type }}"
     placement_group: "{{ hcloud_placement_group_name }}"
-    image: "ubuntu-22.04"
+    image: "{{ hcloud_image }}"
     ssh_keys:
       - "{{ hcloud_ssh_key_name }}"
     state: present

--- a/tests/integration/targets/placement_group/tasks/test.yml
+++ b/tests/integration/targets/placement_group/tasks/test.yml
@@ -64,9 +64,9 @@
 - name: test create server with placement group
   hetzner.hcloud.server:
     name: "{{ hcloud_server_name }}"
-    server_type: "{{ hcloud_server_type }}"
+    server_type: "{{ hcloud_server_type_name }}"
     placement_group: "{{ hcloud_placement_group_name }}"
-    image: "{{ hcloud_image }}"
+    image: "{{ hcloud_image_name }}"
     ssh_keys:
       - "{{ hcloud_ssh_key_name }}"
     state: present

--- a/tests/integration/targets/primary_ip/defaults/main/common.yml
+++ b/tests/integration/targets/primary_ip/defaults/main/common.yml
@@ -10,3 +10,18 @@ hcloud_prefix: "tests"
 hcloud_run_ns: "{{ hcloud_prefix | md5 }}"
 hcloud_role_ns: "{{ role_name | split('_') | map('batch', 2) | map('first') | flatten() | join() }}"
 hcloud_ns: "ansible-{{ hcloud_run_ns }}-{{ hcloud_role_ns }}"
+
+# Used to easily update the server types and images across all our tests.
+hcloud_server_type: cax11
+hcloud_server_type_id: 45
+
+hcloud_server_type_upgrade: cax21
+hcloud_server_type_upgrade_id: 93
+
+hcloud_image: debian-12
+hcloud_image_id: 114690389 # architecture=arm
+
+hcloud_location: hel1
+hcloud_location_id: 3
+hcloud_datacenter: hel1-dc2
+hcloud_datacenter_id: 3

--- a/tests/integration/targets/primary_ip/defaults/main/common.yml
+++ b/tests/integration/targets/primary_ip/defaults/main/common.yml
@@ -12,16 +12,16 @@ hcloud_role_ns: "{{ role_name | split('_') | map('batch', 2) | map('first') | fl
 hcloud_ns: "ansible-{{ hcloud_run_ns }}-{{ hcloud_role_ns }}"
 
 # Used to easily update the server types and images across all our tests.
-hcloud_server_type: cax11
+hcloud_server_type_name: cax11
 hcloud_server_type_id: 45
 
-hcloud_server_type_upgrade: cax21
+hcloud_server_type_upgrade_name: cax21
 hcloud_server_type_upgrade_id: 93
 
-hcloud_image: debian-12
+hcloud_image_name: debian-12
 hcloud_image_id: 114690389 # architecture=arm
 
-hcloud_location: hel1
+hcloud_location_name: hel1
 hcloud_location_id: 3
-hcloud_datacenter: hel1-dc2
+hcloud_datacenter_name: hel1-dc2
 hcloud_datacenter_id: 3

--- a/tests/integration/targets/primary_ip/tasks/prepare.yml
+++ b/tests/integration/targets/primary_ip/tasks/prepare.yml
@@ -2,8 +2,8 @@
 - name: Create test_server
   hetzner.hcloud.server:
     name: "{{ hcloud_server_name }}"
-    server_type: "{{ hcloud_server_type }}"
-    image: "{{ hcloud_image }}"
+    server_type: "{{ hcloud_server_type_name }}"
+    image: "{{ hcloud_image_name }}"
     state: stopped
     enable_ipv4: false
     enable_ipv6: false

--- a/tests/integration/targets/primary_ip/tasks/prepare.yml
+++ b/tests/integration/targets/primary_ip/tasks/prepare.yml
@@ -2,8 +2,8 @@
 - name: Create test_server
   hetzner.hcloud.server:
     name: "{{ hcloud_server_name }}"
-    server_type: cax11
-    image: ubuntu-22.04
+    server_type: "{{ hcloud_server_type }}"
+    image: "{{ hcloud_image }}"
     state: stopped
     enable_ipv4: false
     enable_ipv6: false

--- a/tests/integration/targets/primary_ip/tasks/test.yml
+++ b/tests/integration/targets/primary_ip/tasks/test.yml
@@ -16,7 +16,7 @@
   hetzner.hcloud.primary_ip:
     name: "{{ hcloud_primary_ip_name }}"
     type: ipv6
-    datacenter: fsn1-dc14
+    datacenter: "{{ hcloud_datacenter_name }}"
     labels:
       key: value
   check_mode: true
@@ -30,7 +30,7 @@
   hetzner.hcloud.primary_ip:
     name: "{{ hcloud_primary_ip_name }}"
     type: ipv6
-    datacenter: fsn1-dc14
+    datacenter: "{{ hcloud_datacenter_name }}"
     labels:
       key: value
   register: result
@@ -40,7 +40,7 @@
       - result is changed
       - result.hcloud_primary_ip.name == hcloud_primary_ip_name
       - result.hcloud_primary_ip.type == "ipv6"
-      - result.hcloud_primary_ip.datacenter == "fsn1-dc14"
+      - result.hcloud_primary_ip.datacenter == hcloud_datacenter_name
       - result.hcloud_primary_ip.assignee_type == "server"
       - result.hcloud_primary_ip.assignee_id is none
       - result.hcloud_primary_ip.labels.key == "value"
@@ -51,7 +51,7 @@
   hetzner.hcloud.primary_ip:
     name: "{{ hcloud_primary_ip_name }}"
     type: ipv6
-    datacenter: fsn1-dc14
+    datacenter: "{{ hcloud_datacenter_name }}"
     labels:
       key: value
   register: result
@@ -64,7 +64,7 @@
   hetzner.hcloud.primary_ip:
     name: "{{ hcloud_primary_ip_name }}"
     type: ipv6
-    datacenter: fsn1-dc14
+    datacenter: "{{ hcloud_datacenter_name }}"
     labels:
       key: value
       foo: bar
@@ -76,7 +76,7 @@
       - result is changed
       - result.hcloud_primary_ip.name == hcloud_primary_ip_name
       - result.hcloud_primary_ip.type == "ipv6"
-      - result.hcloud_primary_ip.datacenter == "fsn1-dc14"
+      - result.hcloud_primary_ip.datacenter == hcloud_datacenter_name
       - result.hcloud_primary_ip.assignee_type == "server"
       - result.hcloud_primary_ip.assignee_id is none
       - result.hcloud_primary_ip.labels.key == "value"
@@ -88,7 +88,7 @@
   hetzner.hcloud.primary_ip:
     name: "{{ hcloud_primary_ip_name }}"
     type: ipv6
-    datacenter: fsn1-dc14
+    datacenter: "{{ hcloud_datacenter_name }}"
     labels:
       key: value
       foo: bar

--- a/tests/integration/targets/primary_ip_info/defaults/main/common.yml
+++ b/tests/integration/targets/primary_ip_info/defaults/main/common.yml
@@ -10,3 +10,18 @@ hcloud_prefix: "tests"
 hcloud_run_ns: "{{ hcloud_prefix | md5 }}"
 hcloud_role_ns: "{{ role_name | split('_') | map('batch', 2) | map('first') | flatten() | join() }}"
 hcloud_ns: "ansible-{{ hcloud_run_ns }}-{{ hcloud_role_ns }}"
+
+# Used to easily update the server types and images across all our tests.
+hcloud_server_type: cax11
+hcloud_server_type_id: 45
+
+hcloud_server_type_upgrade: cax21
+hcloud_server_type_upgrade_id: 93
+
+hcloud_image: debian-12
+hcloud_image_id: 114690389 # architecture=arm
+
+hcloud_location: hel1
+hcloud_location_id: 3
+hcloud_datacenter: hel1-dc2
+hcloud_datacenter_id: 3

--- a/tests/integration/targets/primary_ip_info/defaults/main/common.yml
+++ b/tests/integration/targets/primary_ip_info/defaults/main/common.yml
@@ -12,16 +12,16 @@ hcloud_role_ns: "{{ role_name | split('_') | map('batch', 2) | map('first') | fl
 hcloud_ns: "ansible-{{ hcloud_run_ns }}-{{ hcloud_role_ns }}"
 
 # Used to easily update the server types and images across all our tests.
-hcloud_server_type: cax11
+hcloud_server_type_name: cax11
 hcloud_server_type_id: 45
 
-hcloud_server_type_upgrade: cax21
+hcloud_server_type_upgrade_name: cax21
 hcloud_server_type_upgrade_id: 93
 
-hcloud_image: debian-12
+hcloud_image_name: debian-12
 hcloud_image_id: 114690389 # architecture=arm
 
-hcloud_location: hel1
+hcloud_location_name: hel1
 hcloud_location_id: 3
-hcloud_datacenter: hel1-dc2
+hcloud_datacenter_name: hel1-dc2
 hcloud_datacenter_id: 3

--- a/tests/integration/targets/primary_ip_info/tasks/prepare.yml
+++ b/tests/integration/targets/primary_ip_info/tasks/prepare.yml
@@ -2,7 +2,7 @@
 - name: Create test_primary_ip
   hetzner.hcloud.primary_ip:
     name: "{{ hcloud_primary_ip_name }}"
-    datacenter: fsn1-dc14
+    datacenter: "{{ hcloud_datacenter_name }}"
     type: ipv4
     labels:
       key: value

--- a/tests/integration/targets/rdns/defaults/main/common.yml
+++ b/tests/integration/targets/rdns/defaults/main/common.yml
@@ -10,3 +10,18 @@ hcloud_prefix: "tests"
 hcloud_run_ns: "{{ hcloud_prefix | md5 }}"
 hcloud_role_ns: "{{ role_name | split('_') | map('batch', 2) | map('first') | flatten() | join() }}"
 hcloud_ns: "ansible-{{ hcloud_run_ns }}-{{ hcloud_role_ns }}"
+
+# Used to easily update the server types and images across all our tests.
+hcloud_server_type: cax11
+hcloud_server_type_id: 45
+
+hcloud_server_type_upgrade: cax21
+hcloud_server_type_upgrade_id: 93
+
+hcloud_image: debian-12
+hcloud_image_id: 114690389 # architecture=arm
+
+hcloud_location: hel1
+hcloud_location_id: 3
+hcloud_datacenter: hel1-dc2
+hcloud_datacenter_id: 3

--- a/tests/integration/targets/rdns/defaults/main/common.yml
+++ b/tests/integration/targets/rdns/defaults/main/common.yml
@@ -12,16 +12,16 @@ hcloud_role_ns: "{{ role_name | split('_') | map('batch', 2) | map('first') | fl
 hcloud_ns: "ansible-{{ hcloud_run_ns }}-{{ hcloud_role_ns }}"
 
 # Used to easily update the server types and images across all our tests.
-hcloud_server_type: cax11
+hcloud_server_type_name: cax11
 hcloud_server_type_id: 45
 
-hcloud_server_type_upgrade: cax21
+hcloud_server_type_upgrade_name: cax21
 hcloud_server_type_upgrade_id: 93
 
-hcloud_image: debian-12
+hcloud_image_name: debian-12
 hcloud_image_id: 114690389 # architecture=arm
 
-hcloud_location: hel1
+hcloud_location_name: hel1
 hcloud_location_id: 3
-hcloud_datacenter: hel1-dc2
+hcloud_datacenter_name: hel1-dc2
 hcloud_datacenter_id: 3

--- a/tests/integration/targets/rdns/tasks/prepare.yml
+++ b/tests/integration/targets/rdns/tasks/prepare.yml
@@ -2,8 +2,8 @@
 - name: Create test_server
   hetzner.hcloud.server:
     name: "{{ hcloud_server_name }}"
-    server_type: "{{ hcloud_server_type }}"
-    image: "{{ hcloud_image }}"
+    server_type: "{{ hcloud_server_type_name }}"
+    image: "{{ hcloud_image_name }}"
     state: present
   register: test_server
 
@@ -19,7 +19,7 @@
   hetzner.hcloud.floating_ip:
     name: "{{ hcloud_floating_ip_name }}"
     type: ipv4
-    home_location: "{{ hcloud_location }}"
+    home_location: "{{ hcloud_location_name }}"
     state: present
   register: test_floating_ip
 

--- a/tests/integration/targets/rdns/tasks/prepare.yml
+++ b/tests/integration/targets/rdns/tasks/prepare.yml
@@ -11,7 +11,7 @@
   hetzner.hcloud.primary_ip:
     name: "{{ hcloud_primary_ip_name }}"
     type: ipv4
-    datacenter: fsn1-dc14
+    datacenter: "{{ hcloud_datacenter_name }}"
     state: present
   register: test_primary_ip
 

--- a/tests/integration/targets/rdns/tasks/prepare.yml
+++ b/tests/integration/targets/rdns/tasks/prepare.yml
@@ -2,8 +2,8 @@
 - name: Create test_server
   hetzner.hcloud.server:
     name: "{{ hcloud_server_name }}"
-    server_type: cax11
-    image: ubuntu-22.04
+    server_type: "{{ hcloud_server_type }}"
+    image: "{{ hcloud_image }}"
     state: present
   register: test_server
 
@@ -19,7 +19,7 @@
   hetzner.hcloud.floating_ip:
     name: "{{ hcloud_floating_ip_name }}"
     type: ipv4
-    home_location: fsn1
+    home_location: "{{ hcloud_location }}"
     state: present
   register: test_floating_ip
 

--- a/tests/integration/targets/route/defaults/main/common.yml
+++ b/tests/integration/targets/route/defaults/main/common.yml
@@ -10,3 +10,18 @@ hcloud_prefix: "tests"
 hcloud_run_ns: "{{ hcloud_prefix | md5 }}"
 hcloud_role_ns: "{{ role_name | split('_') | map('batch', 2) | map('first') | flatten() | join() }}"
 hcloud_ns: "ansible-{{ hcloud_run_ns }}-{{ hcloud_role_ns }}"
+
+# Used to easily update the server types and images across all our tests.
+hcloud_server_type: cax11
+hcloud_server_type_id: 45
+
+hcloud_server_type_upgrade: cax21
+hcloud_server_type_upgrade_id: 93
+
+hcloud_image: debian-12
+hcloud_image_id: 114690389 # architecture=arm
+
+hcloud_location: hel1
+hcloud_location_id: 3
+hcloud_datacenter: hel1-dc2
+hcloud_datacenter_id: 3

--- a/tests/integration/targets/route/defaults/main/common.yml
+++ b/tests/integration/targets/route/defaults/main/common.yml
@@ -12,16 +12,16 @@ hcloud_role_ns: "{{ role_name | split('_') | map('batch', 2) | map('first') | fl
 hcloud_ns: "ansible-{{ hcloud_run_ns }}-{{ hcloud_role_ns }}"
 
 # Used to easily update the server types and images across all our tests.
-hcloud_server_type: cax11
+hcloud_server_type_name: cax11
 hcloud_server_type_id: 45
 
-hcloud_server_type_upgrade: cax21
+hcloud_server_type_upgrade_name: cax21
 hcloud_server_type_upgrade_id: 93
 
-hcloud_image: debian-12
+hcloud_image_name: debian-12
 hcloud_image_id: 114690389 # architecture=arm
 
-hcloud_location: hel1
+hcloud_location_name: hel1
 hcloud_location_id: 3
-hcloud_datacenter: hel1-dc2
+hcloud_datacenter_name: hel1-dc2
 hcloud_datacenter_id: 3

--- a/tests/integration/targets/server/defaults/main/common.yml
+++ b/tests/integration/targets/server/defaults/main/common.yml
@@ -10,3 +10,18 @@ hcloud_prefix: "tests"
 hcloud_run_ns: "{{ hcloud_prefix | md5 }}"
 hcloud_role_ns: "{{ role_name | split('_') | map('batch', 2) | map('first') | flatten() | join() }}"
 hcloud_ns: "ansible-{{ hcloud_run_ns }}-{{ hcloud_role_ns }}"
+
+# Used to easily update the server types and images across all our tests.
+hcloud_server_type: cax11
+hcloud_server_type_id: 45
+
+hcloud_server_type_upgrade: cax21
+hcloud_server_type_upgrade_id: 93
+
+hcloud_image: debian-12
+hcloud_image_id: 114690389 # architecture=arm
+
+hcloud_location: hel1
+hcloud_location_id: 3
+hcloud_datacenter: hel1-dc2
+hcloud_datacenter_id: 3

--- a/tests/integration/targets/server/defaults/main/common.yml
+++ b/tests/integration/targets/server/defaults/main/common.yml
@@ -12,16 +12,16 @@ hcloud_role_ns: "{{ role_name | split('_') | map('batch', 2) | map('first') | fl
 hcloud_ns: "ansible-{{ hcloud_run_ns }}-{{ hcloud_role_ns }}"
 
 # Used to easily update the server types and images across all our tests.
-hcloud_server_type: cax11
+hcloud_server_type_name: cax11
 hcloud_server_type_id: 45
 
-hcloud_server_type_upgrade: cax21
+hcloud_server_type_upgrade_name: cax21
 hcloud_server_type_upgrade_id: 93
 
-hcloud_image: debian-12
+hcloud_image_name: debian-12
 hcloud_image_id: 114690389 # architecture=arm
 
-hcloud_location: hel1
+hcloud_location_name: hel1
 hcloud_location_id: 3
-hcloud_datacenter: hel1-dc2
+hcloud_datacenter_name: hel1-dc2
 hcloud_datacenter_id: 3

--- a/tests/integration/targets/server/tasks/test_basic.yml
+++ b/tests/integration/targets/server/tasks/test_basic.yml
@@ -1,8 +1,8 @@
 - name: test create server with check mode
   hetzner.hcloud.server:
     name: "{{ hcloud_server_name }}"
-    server_type: cax11
-    image: ubuntu-22.04
+    server_type: "{{ hcloud_server_type }}"
+    image: "{{ hcloud_image }}"
     state: present
   register: result
   check_mode: true
@@ -14,8 +14,8 @@
 - name: test create server
   hetzner.hcloud.server:
     name: "{{ hcloud_server_name}}"
-    server_type: cax11
-    image: ubuntu-22.04
+    server_type: "{{ hcloud_server_type }}"
+    image: "{{ hcloud_image }}"
     enable_ipv6: False
     state: started
   register: main_server
@@ -24,7 +24,7 @@
     that:
       - main_server is changed
       - main_server.hcloud_server.name == hcloud_server_name
-      - main_server.hcloud_server.server_type == "cax11"
+      - main_server.hcloud_server.server_type == hcloud_server_type
       - main_server.hcloud_server.status == "running"
       - main_server.root_password != ""
 
@@ -108,7 +108,7 @@
 - name: test resize server running without force
   hetzner.hcloud.server:
     name: "{{ hcloud_server_name }}"
-    server_type: "cax21"
+    server_type: "{{ hcloud_server_type_upgrade }}"
     state: present
   register: result
   check_mode: true
@@ -116,12 +116,12 @@
   assert:
     that:
       - result is changed
-      - result.hcloud_server.server_type == "cax11"
+      - result.hcloud_server.server_type == hcloud_server_type
 
 - name: test resize server with check mode
   hetzner.hcloud.server:
     name: "{{ hcloud_server_name }}"
-    server_type: "cax21"
+    server_type: "{{ hcloud_server_type_upgrade }}"
     state: stopped
   register: result
   check_mode: true
@@ -133,19 +133,19 @@
 - name: test resize server without disk
   hetzner.hcloud.server:
     name: "{{ hcloud_server_name }}"
-    server_type: "cax21"
+    server_type: "{{ hcloud_server_type_upgrade }}"
     state: stopped
   register: result
 - name: verify resize server without disk
   assert:
     that:
       - result is changed
-      - result.hcloud_server.server_type == "cax21"
+      - result.hcloud_server.server_type == hcloud_server_type_upgrade
 
 - name: test resize server idempotence
   hetzner.hcloud.server:
     name: "{{ hcloud_server_name }}"
-    server_type: "cax21"
+    server_type: "{{ hcloud_server_type_upgrade }}"
     state: stopped
   register: result
 - name: verify resize server idempotence
@@ -156,19 +156,19 @@
 - name: test resize server to smaller plan
   hetzner.hcloud.server:
     name: "{{ hcloud_server_name }}"
-    server_type: "cax11"
+    server_type: "{{ hcloud_server_type }}"
     state: stopped
   register: result
 - name: verify resize server to smaller plan
   assert:
     that:
       - result is changed
-      - result.hcloud_server.server_type == "cax11"
+      - result.hcloud_server.server_type == hcloud_server_type
 
 - name: test resize server with disk
   hetzner.hcloud.server:
     name: "{{ hcloud_server_name }}"
-    server_type: "cax21"
+    server_type: "{{ hcloud_server_type_upgrade }}"
     upgrade_disk: true
     state: stopped
   register: result
@@ -176,7 +176,7 @@
   assert:
     that:
       - result is changed
-      - result.hcloud_server.server_type == "cax21"
+      - result.hcloud_server.server_type == hcloud_server_type_upgrade
 
 - name: test enable backups with check mode
   hetzner.hcloud.server:
@@ -232,7 +232,7 @@
 - name: test rebuild server
   hetzner.hcloud.server:
     name: "{{ hcloud_server_name }}"
-    image: ubuntu-22.04
+    image: "{{ hcloud_image }}"
     state: rebuild
   register: result_after_test
 - name: verify rebuild server
@@ -244,7 +244,7 @@
 - name: test rebuild server with check mode
   hetzner.hcloud.server:
     name: "{{ hcloud_server_name }}"
-    image: ubuntu-22.04
+    image: "{{ hcloud_image }}"
     state: rebuild
   register: result_after_test
   check_mode: true
@@ -321,7 +321,7 @@
 - name: test rebuild server fails if it is protected
   hetzner.hcloud.server:
     name: "{{hcloud_server_name}}"
-    image: ubuntu-22.04
+    image: "{{ hcloud_image }}"
     state: rebuild
   ignore_errors: true
   register: result
@@ -360,8 +360,8 @@
 - name: test create server with ssh key
   hetzner.hcloud.server:
     name: "{{ hcloud_server_name}}"
-    server_type: cax11
-    image: "ubuntu-22.04"
+    server_type: "{{ hcloud_server_type }}"
+    image: "{{ hcloud_image }}"
     ssh_keys:
       - "{{ hcloud_ssh_key_name }}"
     state: started
@@ -371,7 +371,7 @@
     that:
       - main_server is changed
       - main_server.hcloud_server.name == hcloud_server_name
-      - main_server.hcloud_server.server_type == "cax11"
+      - main_server.hcloud_server.server_type == hcloud_server_type
       - main_server.hcloud_server.status == "running"
       - main_server.root_password != ""
 
@@ -441,8 +441,8 @@
 - name: test create server with rescue_mode
   hetzner.hcloud.server:
     name: "{{ hcloud_server_name}}"
-    server_type: cax11
-    image: "ubuntu-22.04"
+    server_type: "{{ hcloud_server_type }}"
+    image: "{{ hcloud_image }}"
     ssh_keys:
       - "{{ hcloud_ssh_key_name }}"
     rescue_mode: "linux64"
@@ -453,7 +453,7 @@
     that:
       - main_server is changed
       - main_server.hcloud_server.name == hcloud_server_name
-      - main_server.hcloud_server.server_type == "cax11"
+      - main_server.hcloud_server.server_type == hcloud_server_type
       - main_server.hcloud_server.status == "running"
       - main_server.root_password != ""
       - main_server.hcloud_server.rescue_enabled is sameas true
@@ -470,8 +470,8 @@
 - name: test create server with labels
   hetzner.hcloud.server:
     name: "{{ hcloud_server_name}}"
-    server_type: cax11
-    image: "ubuntu-22.04"
+    server_type: "{{ hcloud_server_type }}"
+    image: "{{ hcloud_image }}"
     ssh_keys:
       - "{{ hcloud_ssh_key_name }}"
     labels:
@@ -489,8 +489,8 @@
 - name: test update server with labels
   hetzner.hcloud.server:
     name: "{{ hcloud_server_name}}"
-    server_type: cax11
-    image: "ubuntu-22.04"
+    server_type: "{{ hcloud_server_type }}"
+    image: "{{ hcloud_image }}"
     ssh_keys:
       - "{{ hcloud_ssh_key_name }}"
     labels:
@@ -508,8 +508,8 @@
 - name: test update server with labels in other order
   hetzner.hcloud.server:
     name: "{{ hcloud_server_name}}"
-    server_type: cax11
-    image: "ubuntu-22.04"
+    server_type: "{{ hcloud_server_type }}"
+    image: "{{ hcloud_image }}"
     ssh_keys:
       - "{{ hcloud_ssh_key_name }}"
     labels:
@@ -535,9 +535,9 @@
 - name: test create server with enabled backups
   hetzner.hcloud.server:
     name: "{{ hcloud_server_name }}"
-    server_type: cax11
+    server_type: "{{ hcloud_server_type }}"
     backups: true
-    image: "ubuntu-22.04"
+    image: "{{ hcloud_image }}"
     ssh_keys:
       - "{{ hcloud_ssh_key_name }}"
     state: present
@@ -563,8 +563,8 @@
     name: "{{ hcloud_server_name }}"
     delete_protection: true
     rebuild_protection: true
-    server_type: cax11
-    image: "ubuntu-22.04"
+    server_type: "{{ hcloud_server_type }}"
+    image: "{{ hcloud_image }}"
     ssh_keys:
       - "{{ hcloud_ssh_key_name }}"
     state: present

--- a/tests/integration/targets/server/tasks/test_basic.yml
+++ b/tests/integration/targets/server/tasks/test_basic.yml
@@ -1,8 +1,8 @@
 - name: test create server with check mode
   hetzner.hcloud.server:
     name: "{{ hcloud_server_name }}"
-    server_type: "{{ hcloud_server_type }}"
-    image: "{{ hcloud_image }}"
+    server_type: "{{ hcloud_server_type_name }}"
+    image: "{{ hcloud_image_name }}"
     state: present
   register: result
   check_mode: true
@@ -14,8 +14,8 @@
 - name: test create server
   hetzner.hcloud.server:
     name: "{{ hcloud_server_name}}"
-    server_type: "{{ hcloud_server_type }}"
-    image: "{{ hcloud_image }}"
+    server_type: "{{ hcloud_server_type_name }}"
+    image: "{{ hcloud_image_name }}"
     enable_ipv6: False
     state: started
   register: main_server
@@ -24,7 +24,7 @@
     that:
       - main_server is changed
       - main_server.hcloud_server.name == hcloud_server_name
-      - main_server.hcloud_server.server_type == hcloud_server_type
+      - main_server.hcloud_server.server_type == hcloud_server_type_name
       - main_server.hcloud_server.status == "running"
       - main_server.root_password != ""
 
@@ -108,7 +108,7 @@
 - name: test resize server running without force
   hetzner.hcloud.server:
     name: "{{ hcloud_server_name }}"
-    server_type: "{{ hcloud_server_type_upgrade }}"
+    server_type: "{{ hcloud_server_type_upgrade_name }}"
     state: present
   register: result
   check_mode: true
@@ -116,12 +116,12 @@
   assert:
     that:
       - result is changed
-      - result.hcloud_server.server_type == hcloud_server_type
+      - result.hcloud_server.server_type == hcloud_server_type_name
 
 - name: test resize server with check mode
   hetzner.hcloud.server:
     name: "{{ hcloud_server_name }}"
-    server_type: "{{ hcloud_server_type_upgrade }}"
+    server_type: "{{ hcloud_server_type_upgrade_name }}"
     state: stopped
   register: result
   check_mode: true
@@ -133,19 +133,19 @@
 - name: test resize server without disk
   hetzner.hcloud.server:
     name: "{{ hcloud_server_name }}"
-    server_type: "{{ hcloud_server_type_upgrade }}"
+    server_type: "{{ hcloud_server_type_upgrade_name }}"
     state: stopped
   register: result
 - name: verify resize server without disk
   assert:
     that:
       - result is changed
-      - result.hcloud_server.server_type == hcloud_server_type_upgrade
+      - result.hcloud_server.server_type == hcloud_server_type_upgrade_name
 
 - name: test resize server idempotence
   hetzner.hcloud.server:
     name: "{{ hcloud_server_name }}"
-    server_type: "{{ hcloud_server_type_upgrade }}"
+    server_type: "{{ hcloud_server_type_upgrade_name }}"
     state: stopped
   register: result
 - name: verify resize server idempotence
@@ -156,19 +156,19 @@
 - name: test resize server to smaller plan
   hetzner.hcloud.server:
     name: "{{ hcloud_server_name }}"
-    server_type: "{{ hcloud_server_type }}"
+    server_type: "{{ hcloud_server_type_name }}"
     state: stopped
   register: result
 - name: verify resize server to smaller plan
   assert:
     that:
       - result is changed
-      - result.hcloud_server.server_type == hcloud_server_type
+      - result.hcloud_server.server_type == hcloud_server_type_name
 
 - name: test resize server with disk
   hetzner.hcloud.server:
     name: "{{ hcloud_server_name }}"
-    server_type: "{{ hcloud_server_type_upgrade }}"
+    server_type: "{{ hcloud_server_type_upgrade_name }}"
     upgrade_disk: true
     state: stopped
   register: result
@@ -176,7 +176,7 @@
   assert:
     that:
       - result is changed
-      - result.hcloud_server.server_type == hcloud_server_type_upgrade
+      - result.hcloud_server.server_type == hcloud_server_type_upgrade_name
 
 - name: test enable backups with check mode
   hetzner.hcloud.server:
@@ -232,7 +232,7 @@
 - name: test rebuild server
   hetzner.hcloud.server:
     name: "{{ hcloud_server_name }}"
-    image: "{{ hcloud_image }}"
+    image: "{{ hcloud_image_name }}"
     state: rebuild
   register: result_after_test
 - name: verify rebuild server
@@ -244,7 +244,7 @@
 - name: test rebuild server with check mode
   hetzner.hcloud.server:
     name: "{{ hcloud_server_name }}"
-    image: "{{ hcloud_image }}"
+    image: "{{ hcloud_image_name }}"
     state: rebuild
   register: result_after_test
   check_mode: true
@@ -321,7 +321,7 @@
 - name: test rebuild server fails if it is protected
   hetzner.hcloud.server:
     name: "{{hcloud_server_name}}"
-    image: "{{ hcloud_image }}"
+    image: "{{ hcloud_image_name }}"
     state: rebuild
   ignore_errors: true
   register: result
@@ -360,8 +360,8 @@
 - name: test create server with ssh key
   hetzner.hcloud.server:
     name: "{{ hcloud_server_name}}"
-    server_type: "{{ hcloud_server_type }}"
-    image: "{{ hcloud_image }}"
+    server_type: "{{ hcloud_server_type_name }}"
+    image: "{{ hcloud_image_name }}"
     ssh_keys:
       - "{{ hcloud_ssh_key_name }}"
     state: started
@@ -371,7 +371,7 @@
     that:
       - main_server is changed
       - main_server.hcloud_server.name == hcloud_server_name
-      - main_server.hcloud_server.server_type == hcloud_server_type
+      - main_server.hcloud_server.server_type == hcloud_server_type_name
       - main_server.hcloud_server.status == "running"
       - main_server.root_password != ""
 
@@ -441,8 +441,8 @@
 - name: test create server with rescue_mode
   hetzner.hcloud.server:
     name: "{{ hcloud_server_name}}"
-    server_type: "{{ hcloud_server_type }}"
-    image: "{{ hcloud_image }}"
+    server_type: "{{ hcloud_server_type_name }}"
+    image: "{{ hcloud_image_name }}"
     ssh_keys:
       - "{{ hcloud_ssh_key_name }}"
     rescue_mode: "linux64"
@@ -453,7 +453,7 @@
     that:
       - main_server is changed
       - main_server.hcloud_server.name == hcloud_server_name
-      - main_server.hcloud_server.server_type == hcloud_server_type
+      - main_server.hcloud_server.server_type == hcloud_server_type_name
       - main_server.hcloud_server.status == "running"
       - main_server.root_password != ""
       - main_server.hcloud_server.rescue_enabled is sameas true
@@ -470,8 +470,8 @@
 - name: test create server with labels
   hetzner.hcloud.server:
     name: "{{ hcloud_server_name}}"
-    server_type: "{{ hcloud_server_type }}"
-    image: "{{ hcloud_image }}"
+    server_type: "{{ hcloud_server_type_name }}"
+    image: "{{ hcloud_image_name }}"
     ssh_keys:
       - "{{ hcloud_ssh_key_name }}"
     labels:
@@ -489,8 +489,8 @@
 - name: test update server with labels
   hetzner.hcloud.server:
     name: "{{ hcloud_server_name}}"
-    server_type: "{{ hcloud_server_type }}"
-    image: "{{ hcloud_image }}"
+    server_type: "{{ hcloud_server_type_name }}"
+    image: "{{ hcloud_image_name }}"
     ssh_keys:
       - "{{ hcloud_ssh_key_name }}"
     labels:
@@ -508,8 +508,8 @@
 - name: test update server with labels in other order
   hetzner.hcloud.server:
     name: "{{ hcloud_server_name}}"
-    server_type: "{{ hcloud_server_type }}"
-    image: "{{ hcloud_image }}"
+    server_type: "{{ hcloud_server_type_name }}"
+    image: "{{ hcloud_image_name }}"
     ssh_keys:
       - "{{ hcloud_ssh_key_name }}"
     labels:
@@ -535,9 +535,9 @@
 - name: test create server with enabled backups
   hetzner.hcloud.server:
     name: "{{ hcloud_server_name }}"
-    server_type: "{{ hcloud_server_type }}"
+    server_type: "{{ hcloud_server_type_name }}"
     backups: true
-    image: "{{ hcloud_image }}"
+    image: "{{ hcloud_image_name }}"
     ssh_keys:
       - "{{ hcloud_ssh_key_name }}"
     state: present
@@ -563,8 +563,8 @@
     name: "{{ hcloud_server_name }}"
     delete_protection: true
     rebuild_protection: true
-    server_type: "{{ hcloud_server_type }}"
-    image: "{{ hcloud_image }}"
+    server_type: "{{ hcloud_server_type_name }}"
+    image: "{{ hcloud_image_name }}"
     ssh_keys:
       - "{{ hcloud_ssh_key_name }}"
     state: present

--- a/tests/integration/targets/server/tasks/test_firewalls.yml
+++ b/tests/integration/targets/server/tasks/test_firewalls.yml
@@ -32,10 +32,10 @@
 - name: test create server with firewalls
   hetzner.hcloud.server:
     name: "{{ hcloud_server_name }}"
-    server_type: "{{ hcloud_server_type }}"
+    server_type: "{{ hcloud_server_type_name }}"
     firewalls:
       - "{{ hcloud_firewall_name }}"
-    image: "{{ hcloud_image }}"
+    image: "{{ hcloud_image_name }}"
     ssh_keys:
       - "{{ hcloud_ssh_key_name }}"
     state: present
@@ -48,10 +48,10 @@
 - name: test create server with firewalls idempotence
   hetzner.hcloud.server:
     name: "{{ hcloud_server_name }}"
-    server_type: "{{ hcloud_server_type }}"
+    server_type: "{{ hcloud_server_type_name }}"
     firewalls:
       - "{{ hcloud_firewall_name }}"
-    image: "{{ hcloud_image }}"
+    image: "{{ hcloud_image_name }}"
     ssh_keys:
       - "{{ hcloud_ssh_key_name }}"
     state: present
@@ -64,10 +64,10 @@
 - name: test update server with firewalls
   hetzner.hcloud.server:
     name: "{{ hcloud_server_name }}"
-    server_type: "{{ hcloud_server_type }}"
+    server_type: "{{ hcloud_server_type_name }}"
     firewalls:
       - "{{ hcloud_firewall_name }}2"
-    image: "{{ hcloud_image }}"
+    image: "{{ hcloud_image_name }}"
     ssh_keys:
       - "{{ hcloud_ssh_key_name }}"
     state: present
@@ -80,10 +80,10 @@
 - name: test update server with firewalls idempotence
   hetzner.hcloud.server:
     name: "{{ hcloud_server_name }}"
-    server_type: "{{ hcloud_server_type }}"
+    server_type: "{{ hcloud_server_type_name }}"
     firewalls:
       - "{{ hcloud_firewall_name }}2"
-    image: "{{ hcloud_image }}"
+    image: "{{ hcloud_image_name }}"
     ssh_keys:
       - "{{ hcloud_ssh_key_name }}"
     state: present

--- a/tests/integration/targets/server/tasks/test_firewalls.yml
+++ b/tests/integration/targets/server/tasks/test_firewalls.yml
@@ -32,10 +32,10 @@
 - name: test create server with firewalls
   hetzner.hcloud.server:
     name: "{{ hcloud_server_name }}"
-    server_type: cax11
+    server_type: "{{ hcloud_server_type }}"
     firewalls:
       - "{{ hcloud_firewall_name }}"
-    image: "ubuntu-22.04"
+    image: "{{ hcloud_image }}"
     ssh_keys:
       - "{{ hcloud_ssh_key_name }}"
     state: present
@@ -48,10 +48,10 @@
 - name: test create server with firewalls idempotence
   hetzner.hcloud.server:
     name: "{{ hcloud_server_name }}"
-    server_type: cax11
+    server_type: "{{ hcloud_server_type }}"
     firewalls:
       - "{{ hcloud_firewall_name }}"
-    image: "ubuntu-22.04"
+    image: "{{ hcloud_image }}"
     ssh_keys:
       - "{{ hcloud_ssh_key_name }}"
     state: present
@@ -64,10 +64,10 @@
 - name: test update server with firewalls
   hetzner.hcloud.server:
     name: "{{ hcloud_server_name }}"
-    server_type: cax11
+    server_type: "{{ hcloud_server_type }}"
     firewalls:
       - "{{ hcloud_firewall_name }}2"
-    image: "ubuntu-22.04"
+    image: "{{ hcloud_image }}"
     ssh_keys:
       - "{{ hcloud_ssh_key_name }}"
     state: present
@@ -80,10 +80,10 @@
 - name: test update server with firewalls idempotence
   hetzner.hcloud.server:
     name: "{{ hcloud_server_name }}"
-    server_type: cax11
+    server_type: "{{ hcloud_server_type }}"
     firewalls:
       - "{{ hcloud_firewall_name }}2"
-    image: "ubuntu-22.04"
+    image: "{{ hcloud_image }}"
     ssh_keys:
       - "{{ hcloud_ssh_key_name }}"
     state: present

--- a/tests/integration/targets/server/tasks/test_primary_ips.yml
+++ b/tests/integration/targets/server/tasks/test_primary_ips.yml
@@ -5,29 +5,29 @@
   hetzner.hcloud.primary_ip:
     name: "{{ hcloud_primary_ip_name }}v4"
     type: ipv4
-    datacenter: "{{ hcloud_datacenter }}"
+    datacenter: "{{ hcloud_datacenter_name }}"
   register: primaryIPv4
 
 - name: setup create second primary ipv4
   hetzner.hcloud.primary_ip:
     name: "{{ hcloud_primary_ip_name }}v42"
     type: ipv4
-    datacenter: "{{ hcloud_datacenter }}"
+    datacenter: "{{ hcloud_datacenter_name }}"
   register: secondPrimaryIPv4
 
 - name: setup create primary ipv6
   hetzner.hcloud.primary_ip:
     name: "{{ hcloud_primary_ip_name }}v6"
     type: ipv6
-    datacenter: "{{ hcloud_datacenter }}"
+    datacenter: "{{ hcloud_datacenter_name }}"
   register: primaryIPv6
 
 - name: test create server with primary ips
   hetzner.hcloud.server:
     name: "{{ hcloud_server_name }}"
-    server_type: "{{ hcloud_server_type }}"
-    datacenter: "{{ hcloud_datacenter }}"
-    image: "{{ hcloud_image }}"
+    server_type: "{{ hcloud_server_type_name }}"
+    datacenter: "{{ hcloud_datacenter_name }}"
+    image: "{{ hcloud_image_name }}"
     ipv4: "{{primaryIPv4.hcloud_primary_ip.id}}"
     ipv6: "{{primaryIPv6.hcloud_primary_ip.id}}"
     ssh_keys:
@@ -42,9 +42,9 @@
 - name: test update server with primary ips
   hetzner.hcloud.server:
     name: "{{ hcloud_server_name }}"
-    server_type: "{{ hcloud_server_type }}"
-    datacenter: "{{ hcloud_datacenter }}"
-    image: "{{ hcloud_image }}"
+    server_type: "{{ hcloud_server_type_name }}"
+    datacenter: "{{ hcloud_datacenter_name }}"
+    image: "{{ hcloud_image_name }}"
     ipv4: "{{secondPrimaryIPv4.hcloud_primary_ip.id}}"
     ipv6: ""
     enable_ipv6: false

--- a/tests/integration/targets/server/tasks/test_primary_ips.yml
+++ b/tests/integration/targets/server/tasks/test_primary_ips.yml
@@ -5,29 +5,29 @@
   hetzner.hcloud.primary_ip:
     name: "{{ hcloud_primary_ip_name }}v4"
     type: ipv4
-    datacenter: "fsn1-dc14"
+    datacenter: "{{ hcloud_datacenter }}"
   register: primaryIPv4
 
 - name: setup create second primary ipv4
   hetzner.hcloud.primary_ip:
     name: "{{ hcloud_primary_ip_name }}v42"
     type: ipv4
-    datacenter: "fsn1-dc14"
+    datacenter: "{{ hcloud_datacenter }}"
   register: secondPrimaryIPv4
 
 - name: setup create primary ipv6
   hetzner.hcloud.primary_ip:
     name: "{{ hcloud_primary_ip_name }}v6"
     type: ipv6
-    datacenter: "fsn1-dc14"
+    datacenter: "{{ hcloud_datacenter }}"
   register: primaryIPv6
 
 - name: test create server with primary ips
   hetzner.hcloud.server:
     name: "{{ hcloud_server_name }}"
-    server_type: cax11
-    datacenter: "fsn1-dc14"
-    image: "ubuntu-22.04"
+    server_type: "{{ hcloud_server_type }}"
+    datacenter: "{{ hcloud_datacenter }}"
+    image: "{{ hcloud_image }}"
     ipv4: "{{primaryIPv4.hcloud_primary_ip.id}}"
     ipv6: "{{primaryIPv6.hcloud_primary_ip.id}}"
     ssh_keys:
@@ -42,9 +42,9 @@
 - name: test update server with primary ips
   hetzner.hcloud.server:
     name: "{{ hcloud_server_name }}"
-    server_type: cax11
-    datacenter: "fsn1-dc14"
-    image: "ubuntu-22.04"
+    server_type: "{{ hcloud_server_type }}"
+    datacenter: "{{ hcloud_datacenter }}"
+    image: "{{ hcloud_image }}"
     ipv4: "{{secondPrimaryIPv4.hcloud_primary_ip.id}}"
     ipv6: ""
     enable_ipv6: false

--- a/tests/integration/targets/server/tasks/test_private_network_only.yml
+++ b/tests/integration/targets/server/tasks/test_private_network_only.yml
@@ -63,9 +63,9 @@
 - name: test create server with primary network and no internet
   hetzner.hcloud.server:
     name: "{{ hcloud_server_name }}"
-    server_type: cax11
-    datacenter: "fsn1-dc14"
-    image: "ubuntu-22.04"
+    server_type: "{{ hcloud_server_type }}"
+    datacenter: "{{ hcloud_datacenter }}"
+    image: "{{ hcloud_image }}"
     enable_ipv4: false
     enable_ipv6: false
     private_networks:
@@ -82,9 +82,9 @@
 - name: test update server by adding secondary network
   hetzner.hcloud.server:
     name: "{{ hcloud_server_name }}"
-    server_type: cax11
-    datacenter: "fsn1-dc14"
-    image: "ubuntu-22.04"
+    server_type: "{{ hcloud_server_type }}"
+    datacenter: "{{ hcloud_datacenter }}"
+    image: "{{ hcloud_image }}"
     enable_ipv4: false
     enable_ipv6: false
     private_networks:
@@ -102,9 +102,9 @@
 - name: test update server idem
   hetzner.hcloud.server:
     name: "{{ hcloud_server_name }}"
-    server_type: cax11
-    datacenter: "fsn1-dc14"
-    image: "ubuntu-22.04"
+    server_type: "{{ hcloud_server_type }}"
+    datacenter: "{{ hcloud_datacenter }}"
+    image: "{{ hcloud_image }}"
     enable_ipv4: false
     enable_ipv6: false
     private_networks:

--- a/tests/integration/targets/server/tasks/test_private_network_only.yml
+++ b/tests/integration/targets/server/tasks/test_private_network_only.yml
@@ -63,9 +63,9 @@
 - name: test create server with primary network and no internet
   hetzner.hcloud.server:
     name: "{{ hcloud_server_name }}"
-    server_type: "{{ hcloud_server_type }}"
-    datacenter: "{{ hcloud_datacenter }}"
-    image: "{{ hcloud_image }}"
+    server_type: "{{ hcloud_server_type_name }}"
+    datacenter: "{{ hcloud_datacenter_name }}"
+    image: "{{ hcloud_image_name }}"
     enable_ipv4: false
     enable_ipv6: false
     private_networks:
@@ -82,9 +82,9 @@
 - name: test update server by adding secondary network
   hetzner.hcloud.server:
     name: "{{ hcloud_server_name }}"
-    server_type: "{{ hcloud_server_type }}"
-    datacenter: "{{ hcloud_datacenter }}"
-    image: "{{ hcloud_image }}"
+    server_type: "{{ hcloud_server_type_name }}"
+    datacenter: "{{ hcloud_datacenter_name }}"
+    image: "{{ hcloud_image_name }}"
     enable_ipv4: false
     enable_ipv6: false
     private_networks:
@@ -102,9 +102,9 @@
 - name: test update server idem
   hetzner.hcloud.server:
     name: "{{ hcloud_server_name }}"
-    server_type: "{{ hcloud_server_type }}"
-    datacenter: "{{ hcloud_datacenter }}"
-    image: "{{ hcloud_image }}"
+    server_type: "{{ hcloud_server_type_name }}"
+    datacenter: "{{ hcloud_datacenter_name }}"
+    image: "{{ hcloud_image_name }}"
     enable_ipv4: false
     enable_ipv6: false
     private_networks:

--- a/tests/integration/targets/server/tasks/test_validation.yml
+++ b/tests/integration/targets/server/tasks/test_validation.yml
@@ -26,7 +26,7 @@
   hetzner.hcloud.server:
     name: "{{ hcloud_server_name }}"
     server_type: not-existing-server-type
-    image: "{{ hcloud_image }}"
+    image: "{{ hcloud_image_name }}"
     state: present
   register: result
   ignore_errors: true
@@ -40,7 +40,7 @@
 - name: test create server with not existing image
   hetzner.hcloud.server:
     name: "{{ hcloud_server_name }}"
-    server_type: "{{ hcloud_server_type }}"
+    server_type: "{{ hcloud_server_type_name }}"
     image: my-not-existing-image-20.04
     state: present
   register: result

--- a/tests/integration/targets/server/tasks/test_validation.yml
+++ b/tests/integration/targets/server/tasks/test_validation.yml
@@ -26,7 +26,7 @@
   hetzner.hcloud.server:
     name: "{{ hcloud_server_name }}"
     server_type: not-existing-server-type
-    image: ubuntu-22.04
+    image: "{{ hcloud_image }}"
     state: present
   register: result
   ignore_errors: true
@@ -40,7 +40,7 @@
 - name: test create server with not existing image
   hetzner.hcloud.server:
     name: "{{ hcloud_server_name }}"
-    server_type: cax11
+    server_type: "{{ hcloud_server_type }}"
     image: my-not-existing-image-20.04
     state: present
   register: result

--- a/tests/integration/targets/server_info/defaults/main/common.yml
+++ b/tests/integration/targets/server_info/defaults/main/common.yml
@@ -10,3 +10,18 @@ hcloud_prefix: "tests"
 hcloud_run_ns: "{{ hcloud_prefix | md5 }}"
 hcloud_role_ns: "{{ role_name | split('_') | map('batch', 2) | map('first') | flatten() | join() }}"
 hcloud_ns: "ansible-{{ hcloud_run_ns }}-{{ hcloud_role_ns }}"
+
+# Used to easily update the server types and images across all our tests.
+hcloud_server_type: cax11
+hcloud_server_type_id: 45
+
+hcloud_server_type_upgrade: cax21
+hcloud_server_type_upgrade_id: 93
+
+hcloud_image: debian-12
+hcloud_image_id: 114690389 # architecture=arm
+
+hcloud_location: hel1
+hcloud_location_id: 3
+hcloud_datacenter: hel1-dc2
+hcloud_datacenter_id: 3

--- a/tests/integration/targets/server_info/defaults/main/common.yml
+++ b/tests/integration/targets/server_info/defaults/main/common.yml
@@ -12,16 +12,16 @@ hcloud_role_ns: "{{ role_name | split('_') | map('batch', 2) | map('first') | fl
 hcloud_ns: "ansible-{{ hcloud_run_ns }}-{{ hcloud_role_ns }}"
 
 # Used to easily update the server types and images across all our tests.
-hcloud_server_type: cax11
+hcloud_server_type_name: cax11
 hcloud_server_type_id: 45
 
-hcloud_server_type_upgrade: cax21
+hcloud_server_type_upgrade_name: cax21
 hcloud_server_type_upgrade_id: 93
 
-hcloud_image: debian-12
+hcloud_image_name: debian-12
 hcloud_image_id: 114690389 # architecture=arm
 
-hcloud_location: hel1
+hcloud_location_name: hel1
 hcloud_location_id: 3
-hcloud_datacenter: hel1-dc2
+hcloud_datacenter_name: hel1-dc2
 hcloud_datacenter_id: 3

--- a/tests/integration/targets/server_info/tasks/prepare.yml
+++ b/tests/integration/targets/server_info/tasks/prepare.yml
@@ -2,8 +2,8 @@
 - name: Create test_server
   hetzner.hcloud.server:
     name: "{{ hcloud_server_name }}"
-    server_type: "{{ hcloud_server_type }}"
-    image: "{{ hcloud_image }}"
+    server_type: "{{ hcloud_server_type_name }}"
+    image: "{{ hcloud_image_name }}"
     state: stopped
     labels:
       key: value
@@ -12,8 +12,8 @@
 - name: Create test_server2 (stopped + without ip)
   hetzner.hcloud.server:
     name: "{{ hcloud_server_name }}2"
-    server_type: "{{ hcloud_server_type }}"
-    image: "{{ hcloud_image }}"
+    server_type: "{{ hcloud_server_type_name }}"
+    image: "{{ hcloud_image_name }}"
     state: stopped
     labels:
       key: value

--- a/tests/integration/targets/server_info/tasks/prepare.yml
+++ b/tests/integration/targets/server_info/tasks/prepare.yml
@@ -2,8 +2,8 @@
 - name: Create test_server
   hetzner.hcloud.server:
     name: "{{ hcloud_server_name }}"
-    server_type: cax11
-    image: ubuntu-22.04
+    server_type: "{{ hcloud_server_type }}"
+    image: "{{ hcloud_image }}"
     state: stopped
     labels:
       key: value
@@ -12,8 +12,8 @@
 - name: Create test_server2 (stopped + without ip)
   hetzner.hcloud.server:
     name: "{{ hcloud_server_name }}2"
-    server_type: cax11
-    image: ubuntu-22.04
+    server_type: "{{ hcloud_server_type }}"
+    image: "{{ hcloud_image }}"
     state: stopped
     labels:
       key: value

--- a/tests/integration/targets/server_network/defaults/main/common.yml
+++ b/tests/integration/targets/server_network/defaults/main/common.yml
@@ -10,3 +10,18 @@ hcloud_prefix: "tests"
 hcloud_run_ns: "{{ hcloud_prefix | md5 }}"
 hcloud_role_ns: "{{ role_name | split('_') | map('batch', 2) | map('first') | flatten() | join() }}"
 hcloud_ns: "ansible-{{ hcloud_run_ns }}-{{ hcloud_role_ns }}"
+
+# Used to easily update the server types and images across all our tests.
+hcloud_server_type: cax11
+hcloud_server_type_id: 45
+
+hcloud_server_type_upgrade: cax21
+hcloud_server_type_upgrade_id: 93
+
+hcloud_image: debian-12
+hcloud_image_id: 114690389 # architecture=arm
+
+hcloud_location: hel1
+hcloud_location_id: 3
+hcloud_datacenter: hel1-dc2
+hcloud_datacenter_id: 3

--- a/tests/integration/targets/server_network/defaults/main/common.yml
+++ b/tests/integration/targets/server_network/defaults/main/common.yml
@@ -12,16 +12,16 @@ hcloud_role_ns: "{{ role_name | split('_') | map('batch', 2) | map('first') | fl
 hcloud_ns: "ansible-{{ hcloud_run_ns }}-{{ hcloud_role_ns }}"
 
 # Used to easily update the server types and images across all our tests.
-hcloud_server_type: cax11
+hcloud_server_type_name: cax11
 hcloud_server_type_id: 45
 
-hcloud_server_type_upgrade: cax21
+hcloud_server_type_upgrade_name: cax21
 hcloud_server_type_upgrade_id: 93
 
-hcloud_image: debian-12
+hcloud_image_name: debian-12
 hcloud_image_id: 114690389 # architecture=arm
 
-hcloud_location: hel1
+hcloud_location_name: hel1
 hcloud_location_id: 3
-hcloud_datacenter: hel1-dc2
+hcloud_datacenter_name: hel1-dc2
 hcloud_datacenter_id: 3

--- a/tests/integration/targets/server_network/tasks/prepare.yml
+++ b/tests/integration/targets/server_network/tasks/prepare.yml
@@ -18,7 +18,7 @@
 - name: Create test_server
   hetzner.hcloud.server:
     name: "{{ hcloud_server_name }}"
-    server_type: cax11
-    image: ubuntu-22.04
+    server_type: "{{ hcloud_server_type }}"
+    image: "{{ hcloud_image }}"
     state: stopped
   register: test_server

--- a/tests/integration/targets/server_network/tasks/prepare.yml
+++ b/tests/integration/targets/server_network/tasks/prepare.yml
@@ -18,7 +18,7 @@
 - name: Create test_server
   hetzner.hcloud.server:
     name: "{{ hcloud_server_name }}"
-    server_type: "{{ hcloud_server_type }}"
-    image: "{{ hcloud_image }}"
+    server_type: "{{ hcloud_server_type_name }}"
+    image: "{{ hcloud_image_name }}"
     state: stopped
   register: test_server

--- a/tests/integration/targets/server_type_info/defaults/main/common.yml
+++ b/tests/integration/targets/server_type_info/defaults/main/common.yml
@@ -10,3 +10,18 @@ hcloud_prefix: "tests"
 hcloud_run_ns: "{{ hcloud_prefix | md5 }}"
 hcloud_role_ns: "{{ role_name | split('_') | map('batch', 2) | map('first') | flatten() | join() }}"
 hcloud_ns: "ansible-{{ hcloud_run_ns }}-{{ hcloud_role_ns }}"
+
+# Used to easily update the server types and images across all our tests.
+hcloud_server_type: cax11
+hcloud_server_type_id: 45
+
+hcloud_server_type_upgrade: cax21
+hcloud_server_type_upgrade_id: 93
+
+hcloud_image: debian-12
+hcloud_image_id: 114690389 # architecture=arm
+
+hcloud_location: hel1
+hcloud_location_id: 3
+hcloud_datacenter: hel1-dc2
+hcloud_datacenter_id: 3

--- a/tests/integration/targets/server_type_info/defaults/main/common.yml
+++ b/tests/integration/targets/server_type_info/defaults/main/common.yml
@@ -12,16 +12,16 @@ hcloud_role_ns: "{{ role_name | split('_') | map('batch', 2) | map('first') | fl
 hcloud_ns: "ansible-{{ hcloud_run_ns }}-{{ hcloud_role_ns }}"
 
 # Used to easily update the server types and images across all our tests.
-hcloud_server_type: cax11
+hcloud_server_type_name: cax11
 hcloud_server_type_id: 45
 
-hcloud_server_type_upgrade: cax21
+hcloud_server_type_upgrade_name: cax21
 hcloud_server_type_upgrade_id: 93
 
-hcloud_image: debian-12
+hcloud_image_name: debian-12
 hcloud_image_id: 114690389 # architecture=arm
 
-hcloud_location: hel1
+hcloud_location_name: hel1
 hcloud_location_id: 3
-hcloud_datacenter: hel1-dc2
+hcloud_datacenter_name: hel1-dc2
 hcloud_datacenter_id: 3

--- a/tests/integration/targets/server_type_info/defaults/main/main.yml
+++ b/tests/integration/targets/server_type_info/defaults/main/main.yml
@@ -1,7 +1,4 @@
 # Copyright: (c) 2019, Hetzner Cloud GmbH <info@hetzner-cloud.de>
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 ---
-hcloud_server_type_name: cax11
-hcloud_server_type_id: 45
-
 hcloud_server_type_id_deprecated: 2 # cx11-ceph

--- a/tests/integration/targets/server_type_info/tasks/test.yml
+++ b/tests/integration/targets/server_type_info/tasks/test.yml
@@ -40,7 +40,7 @@
 
 - name: Gather hcloud_server_type_info with correct name
   hetzner.hcloud.server_type_info:
-    name: "{{ hcloud_server_type_name }}"
+    name: "{{ hcloud_server_type }}"
   register: result
 - name: Verify hcloud_server_type_info with correct name
   ansible.builtin.assert:
@@ -49,7 +49,7 @@
 
 - name: Gather hcloud_server_type_info with wrong name
   hetzner.hcloud.server_type_info:
-    name: "{{ hcloud_server_type_name }}-invalid"
+    name: "{{ hcloud_server_type }}-invalid"
   register: result
 - name: Verify hcloud_server_type_info with wrong name
   ansible.builtin.assert:

--- a/tests/integration/targets/server_type_info/tasks/test.yml
+++ b/tests/integration/targets/server_type_info/tasks/test.yml
@@ -40,7 +40,7 @@
 
 - name: Gather hcloud_server_type_info with correct name
   hetzner.hcloud.server_type_info:
-    name: "{{ hcloud_server_type }}"
+    name: "{{ hcloud_server_type_name }}"
   register: result
 - name: Verify hcloud_server_type_info with correct name
   ansible.builtin.assert:
@@ -49,7 +49,7 @@
 
 - name: Gather hcloud_server_type_info with wrong name
   hetzner.hcloud.server_type_info:
-    name: "{{ hcloud_server_type }}-invalid"
+    name: "{{ hcloud_server_type_name }}-invalid"
   register: result
 - name: Verify hcloud_server_type_info with wrong name
   ansible.builtin.assert:

--- a/tests/integration/targets/ssh_key/defaults/main/common.yml
+++ b/tests/integration/targets/ssh_key/defaults/main/common.yml
@@ -10,3 +10,18 @@ hcloud_prefix: "tests"
 hcloud_run_ns: "{{ hcloud_prefix | md5 }}"
 hcloud_role_ns: "{{ role_name | split('_') | map('batch', 2) | map('first') | flatten() | join() }}"
 hcloud_ns: "ansible-{{ hcloud_run_ns }}-{{ hcloud_role_ns }}"
+
+# Used to easily update the server types and images across all our tests.
+hcloud_server_type: cax11
+hcloud_server_type_id: 45
+
+hcloud_server_type_upgrade: cax21
+hcloud_server_type_upgrade_id: 93
+
+hcloud_image: debian-12
+hcloud_image_id: 114690389 # architecture=arm
+
+hcloud_location: hel1
+hcloud_location_id: 3
+hcloud_datacenter: hel1-dc2
+hcloud_datacenter_id: 3

--- a/tests/integration/targets/ssh_key/defaults/main/common.yml
+++ b/tests/integration/targets/ssh_key/defaults/main/common.yml
@@ -12,16 +12,16 @@ hcloud_role_ns: "{{ role_name | split('_') | map('batch', 2) | map('first') | fl
 hcloud_ns: "ansible-{{ hcloud_run_ns }}-{{ hcloud_role_ns }}"
 
 # Used to easily update the server types and images across all our tests.
-hcloud_server_type: cax11
+hcloud_server_type_name: cax11
 hcloud_server_type_id: 45
 
-hcloud_server_type_upgrade: cax21
+hcloud_server_type_upgrade_name: cax21
 hcloud_server_type_upgrade_id: 93
 
-hcloud_image: debian-12
+hcloud_image_name: debian-12
 hcloud_image_id: 114690389 # architecture=arm
 
-hcloud_location: hel1
+hcloud_location_name: hel1
 hcloud_location_id: 3
-hcloud_datacenter: hel1-dc2
+hcloud_datacenter_name: hel1-dc2
 hcloud_datacenter_id: 3

--- a/tests/integration/targets/ssh_key/tasks/test.yml
+++ b/tests/integration/targets/ssh_key/tasks/test.yml
@@ -112,8 +112,8 @@
 - name: test create server with ssh key
   hetzner.hcloud.server:
     name: "{{ hcloud_server_name }}"
-    server_type: cax11
-    image: "ubuntu-22.04"
+    server_type: "{{ hcloud_server_type }}"
+    image: "{{ hcloud_image }}"
     ssh_keys:
       - "{{ hcloud_ssh_key_name }}"
     state: started

--- a/tests/integration/targets/ssh_key/tasks/test.yml
+++ b/tests/integration/targets/ssh_key/tasks/test.yml
@@ -112,8 +112,8 @@
 - name: test create server with ssh key
   hetzner.hcloud.server:
     name: "{{ hcloud_server_name }}"
-    server_type: "{{ hcloud_server_type }}"
-    image: "{{ hcloud_image }}"
+    server_type: "{{ hcloud_server_type_name }}"
+    image: "{{ hcloud_image_name }}"
     ssh_keys:
       - "{{ hcloud_ssh_key_name }}"
     state: started

--- a/tests/integration/targets/ssh_key_info/defaults/main/common.yml
+++ b/tests/integration/targets/ssh_key_info/defaults/main/common.yml
@@ -10,3 +10,18 @@ hcloud_prefix: "tests"
 hcloud_run_ns: "{{ hcloud_prefix | md5 }}"
 hcloud_role_ns: "{{ role_name | split('_') | map('batch', 2) | map('first') | flatten() | join() }}"
 hcloud_ns: "ansible-{{ hcloud_run_ns }}-{{ hcloud_role_ns }}"
+
+# Used to easily update the server types and images across all our tests.
+hcloud_server_type: cax11
+hcloud_server_type_id: 45
+
+hcloud_server_type_upgrade: cax21
+hcloud_server_type_upgrade_id: 93
+
+hcloud_image: debian-12
+hcloud_image_id: 114690389 # architecture=arm
+
+hcloud_location: hel1
+hcloud_location_id: 3
+hcloud_datacenter: hel1-dc2
+hcloud_datacenter_id: 3

--- a/tests/integration/targets/ssh_key_info/defaults/main/common.yml
+++ b/tests/integration/targets/ssh_key_info/defaults/main/common.yml
@@ -12,16 +12,16 @@ hcloud_role_ns: "{{ role_name | split('_') | map('batch', 2) | map('first') | fl
 hcloud_ns: "ansible-{{ hcloud_run_ns }}-{{ hcloud_role_ns }}"
 
 # Used to easily update the server types and images across all our tests.
-hcloud_server_type: cax11
+hcloud_server_type_name: cax11
 hcloud_server_type_id: 45
 
-hcloud_server_type_upgrade: cax21
+hcloud_server_type_upgrade_name: cax21
 hcloud_server_type_upgrade_id: 93
 
-hcloud_image: debian-12
+hcloud_image_name: debian-12
 hcloud_image_id: 114690389 # architecture=arm
 
-hcloud_location: hel1
+hcloud_location_name: hel1
 hcloud_location_id: 3
-hcloud_datacenter: hel1-dc2
+hcloud_datacenter_name: hel1-dc2
 hcloud_datacenter_id: 3

--- a/tests/integration/targets/subnetwork/defaults/main/common.yml
+++ b/tests/integration/targets/subnetwork/defaults/main/common.yml
@@ -10,3 +10,18 @@ hcloud_prefix: "tests"
 hcloud_run_ns: "{{ hcloud_prefix | md5 }}"
 hcloud_role_ns: "{{ role_name | split('_') | map('batch', 2) | map('first') | flatten() | join() }}"
 hcloud_ns: "ansible-{{ hcloud_run_ns }}-{{ hcloud_role_ns }}"
+
+# Used to easily update the server types and images across all our tests.
+hcloud_server_type: cax11
+hcloud_server_type_id: 45
+
+hcloud_server_type_upgrade: cax21
+hcloud_server_type_upgrade_id: 93
+
+hcloud_image: debian-12
+hcloud_image_id: 114690389 # architecture=arm
+
+hcloud_location: hel1
+hcloud_location_id: 3
+hcloud_datacenter: hel1-dc2
+hcloud_datacenter_id: 3

--- a/tests/integration/targets/subnetwork/defaults/main/common.yml
+++ b/tests/integration/targets/subnetwork/defaults/main/common.yml
@@ -12,16 +12,16 @@ hcloud_role_ns: "{{ role_name | split('_') | map('batch', 2) | map('first') | fl
 hcloud_ns: "ansible-{{ hcloud_run_ns }}-{{ hcloud_role_ns }}"
 
 # Used to easily update the server types and images across all our tests.
-hcloud_server_type: cax11
+hcloud_server_type_name: cax11
 hcloud_server_type_id: 45
 
-hcloud_server_type_upgrade: cax21
+hcloud_server_type_upgrade_name: cax21
 hcloud_server_type_upgrade_id: 93
 
-hcloud_image: debian-12
+hcloud_image_name: debian-12
 hcloud_image_id: 114690389 # architecture=arm
 
-hcloud_location: hel1
+hcloud_location_name: hel1
 hcloud_location_id: 3
-hcloud_datacenter: hel1-dc2
+hcloud_datacenter_name: hel1-dc2
 hcloud_datacenter_id: 3

--- a/tests/integration/targets/volume/defaults/main/common.yml
+++ b/tests/integration/targets/volume/defaults/main/common.yml
@@ -10,3 +10,18 @@ hcloud_prefix: "tests"
 hcloud_run_ns: "{{ hcloud_prefix | md5 }}"
 hcloud_role_ns: "{{ role_name | split('_') | map('batch', 2) | map('first') | flatten() | join() }}"
 hcloud_ns: "ansible-{{ hcloud_run_ns }}-{{ hcloud_role_ns }}"
+
+# Used to easily update the server types and images across all our tests.
+hcloud_server_type: cax11
+hcloud_server_type_id: 45
+
+hcloud_server_type_upgrade: cax21
+hcloud_server_type_upgrade_id: 93
+
+hcloud_image: debian-12
+hcloud_image_id: 114690389 # architecture=arm
+
+hcloud_location: hel1
+hcloud_location_id: 3
+hcloud_datacenter: hel1-dc2
+hcloud_datacenter_id: 3

--- a/tests/integration/targets/volume/defaults/main/common.yml
+++ b/tests/integration/targets/volume/defaults/main/common.yml
@@ -12,16 +12,16 @@ hcloud_role_ns: "{{ role_name | split('_') | map('batch', 2) | map('first') | fl
 hcloud_ns: "ansible-{{ hcloud_run_ns }}-{{ hcloud_role_ns }}"
 
 # Used to easily update the server types and images across all our tests.
-hcloud_server_type: cax11
+hcloud_server_type_name: cax11
 hcloud_server_type_id: 45
 
-hcloud_server_type_upgrade: cax21
+hcloud_server_type_upgrade_name: cax21
 hcloud_server_type_upgrade_id: 93
 
-hcloud_image: debian-12
+hcloud_image_name: debian-12
 hcloud_image_id: 114690389 # architecture=arm
 
-hcloud_location: hel1
+hcloud_location_name: hel1
 hcloud_location_id: 3
-hcloud_datacenter: hel1-dc2
+hcloud_datacenter_name: hel1-dc2
 hcloud_datacenter_id: 3

--- a/tests/integration/targets/volume/tasks/test.yml
+++ b/tests/integration/targets/volume/tasks/test.yml
@@ -4,10 +4,10 @@
 - name: setup server
   hetzner.hcloud.server:
     name: "{{hcloud_server_name}}"
-    server_type: "{{ hcloud_server_type }}"
-    image: "{{ hcloud_image }}"
+    server_type: "{{ hcloud_server_type_name }}"
+    image: "{{ hcloud_image_name }}"
     state: stopped
-    location: "{{ hcloud_location }}"
+    location: "{{ hcloud_location_name }}"
   register: vol_server
 - name: verify setup server
   assert:
@@ -30,7 +30,7 @@
   hetzner.hcloud.volume:
     name: "{{hcloud_volume_name}}"
     size: 10
-    location: "{{ hcloud_location }}"
+    location: "{{ hcloud_location_name }}"
   register: result
   check_mode: true
 - name: verify create Volume with check mode result
@@ -42,14 +42,14 @@
   hetzner.hcloud.volume:
     name: "{{hcloud_volume_name}}"
     size: 10
-    location: "{{ hcloud_location }}"
+    location: "{{ hcloud_location_name }}"
   register: volume
 - name: verify test create Volume
   assert:
     that:
       - volume is changed
       - volume.hcloud_volume.name == hcloud_volume_name
-      - volume.hcloud_volume.location == hcloud_location
+      - volume.hcloud_volume.location == hcloud_location_name
       - volume.hcloud_volume.size == 10
       - volume.hcloud_volume.server != hcloud_server_name
       - volume.hcloud_volume.linux_device is defined
@@ -58,7 +58,7 @@
   hetzner.hcloud.volume:
     name: "{{hcloud_volume_name}}"
     size: 10
-    location: "{{ hcloud_location }}"
+    location: "{{ hcloud_location_name }}"
   register: volume
 - name: verify test create Volume
   assert:
@@ -118,7 +118,7 @@
   assert:
     that:
       - volume is changed
-      - volume.hcloud_volume.location == hcloud_location
+      - volume.hcloud_volume.location == hcloud_location_name
       - volume.hcloud_volume.server != hcloud_server_name
 
 - name: test update Volume label
@@ -236,7 +236,7 @@
   hetzner.hcloud.volume:
     name: "{{hcloud_volume_name}}"
     size: 10
-    location: "{{ hcloud_location }}"
+    location: "{{ hcloud_location_name }}"
     delete_protection: true
   register: volume
 - name: verify create Volume with delete protection

--- a/tests/integration/targets/volume/tasks/test.yml
+++ b/tests/integration/targets/volume/tasks/test.yml
@@ -4,10 +4,10 @@
 - name: setup server
   hetzner.hcloud.server:
     name: "{{hcloud_server_name}}"
-    server_type: cax11
-    image: ubuntu-22.04
+    server_type: "{{ hcloud_server_type }}"
+    image: "{{ hcloud_image }}"
     state: stopped
-    location: "fsn1"
+    location: "{{ hcloud_location }}"
   register: vol_server
 - name: verify setup server
   assert:
@@ -30,7 +30,7 @@
   hetzner.hcloud.volume:
     name: "{{hcloud_volume_name}}"
     size: 10
-    location: "fsn1"
+    location: "{{ hcloud_location }}"
   register: result
   check_mode: true
 - name: verify create Volume with check mode result
@@ -42,14 +42,14 @@
   hetzner.hcloud.volume:
     name: "{{hcloud_volume_name}}"
     size: 10
-    location: "fsn1"
+    location: "{{ hcloud_location }}"
   register: volume
 - name: verify test create Volume
   assert:
     that:
       - volume is changed
       - volume.hcloud_volume.name == hcloud_volume_name
-      - volume.hcloud_volume.location == "fsn1"
+      - volume.hcloud_volume.location == hcloud_location
       - volume.hcloud_volume.size == 10
       - volume.hcloud_volume.server != hcloud_server_name
       - volume.hcloud_volume.linux_device is defined
@@ -58,7 +58,7 @@
   hetzner.hcloud.volume:
     name: "{{hcloud_volume_name}}"
     size: 10
-    location: "fsn1"
+    location: "{{ hcloud_location }}"
   register: volume
 - name: verify test create Volume
   assert:
@@ -118,7 +118,7 @@
   assert:
     that:
       - volume is changed
-      - volume.hcloud_volume.location == "fsn1"
+      - volume.hcloud_volume.location == hcloud_location
       - volume.hcloud_volume.server != hcloud_server_name
 
 - name: test update Volume label
@@ -236,7 +236,7 @@
   hetzner.hcloud.volume:
     name: "{{hcloud_volume_name}}"
     size: 10
-    location: "fsn1"
+    location: "{{ hcloud_location }}"
     delete_protection: true
   register: volume
 - name: verify create Volume with delete protection

--- a/tests/integration/targets/volume_info/defaults/main/common.yml
+++ b/tests/integration/targets/volume_info/defaults/main/common.yml
@@ -10,3 +10,18 @@ hcloud_prefix: "tests"
 hcloud_run_ns: "{{ hcloud_prefix | md5 }}"
 hcloud_role_ns: "{{ role_name | split('_') | map('batch', 2) | map('first') | flatten() | join() }}"
 hcloud_ns: "ansible-{{ hcloud_run_ns }}-{{ hcloud_role_ns }}"
+
+# Used to easily update the server types and images across all our tests.
+hcloud_server_type: cax11
+hcloud_server_type_id: 45
+
+hcloud_server_type_upgrade: cax21
+hcloud_server_type_upgrade_id: 93
+
+hcloud_image: debian-12
+hcloud_image_id: 114690389 # architecture=arm
+
+hcloud_location: hel1
+hcloud_location_id: 3
+hcloud_datacenter: hel1-dc2
+hcloud_datacenter_id: 3

--- a/tests/integration/targets/volume_info/defaults/main/common.yml
+++ b/tests/integration/targets/volume_info/defaults/main/common.yml
@@ -12,16 +12,16 @@ hcloud_role_ns: "{{ role_name | split('_') | map('batch', 2) | map('first') | fl
 hcloud_ns: "ansible-{{ hcloud_run_ns }}-{{ hcloud_role_ns }}"
 
 # Used to easily update the server types and images across all our tests.
-hcloud_server_type: cax11
+hcloud_server_type_name: cax11
 hcloud_server_type_id: 45
 
-hcloud_server_type_upgrade: cax21
+hcloud_server_type_upgrade_name: cax21
 hcloud_server_type_upgrade_id: 93
 
-hcloud_image: debian-12
+hcloud_image_name: debian-12
 hcloud_image_id: 114690389 # architecture=arm
 
-hcloud_location: hel1
+hcloud_location_name: hel1
 hcloud_location_id: 3
-hcloud_datacenter: hel1-dc2
+hcloud_datacenter_name: hel1-dc2
 hcloud_datacenter_id: 3

--- a/tests/integration/targets/volume_info/tasks/prepare.yml
+++ b/tests/integration/targets/volume_info/tasks/prepare.yml
@@ -3,7 +3,7 @@
   hetzner.hcloud.volume:
     name: "{{ hcloud_volume_name }}"
     size: 10
-    location: fsn1
+    location: "{{ hcloud_location }}"
     labels:
       key: value
   register: test_volume

--- a/tests/integration/targets/volume_info/tasks/prepare.yml
+++ b/tests/integration/targets/volume_info/tasks/prepare.yml
@@ -3,7 +3,7 @@
   hetzner.hcloud.volume:
     name: "{{ hcloud_volume_name }}"
     size: 10
-    location: "{{ hcloud_location }}"
+    location: "{{ hcloud_location_name }}"
     labels:
       key: value
   register: test_volume

--- a/tests/integration/targets/volume_info/tasks/test.yml
+++ b/tests/integration/targets/volume_info/tasks/test.yml
@@ -27,7 +27,7 @@
     that:
       - result.hcloud_volume_info | list | count == 1
       - result.hcloud_volume_info[0].name == hcloud_volume_name
-      - result.hcloud_volume_info[0].location == 'fsn1'
+      - result.hcloud_volume_info[0].location == hcloud_location_name
       - result.hcloud_volume_info[0].size == 10
       - result.hcloud_volume_info[0].linux_device is defined
 


### PR DESCRIPTION
##### SUMMARY

Use shared variables to store information about which server type, image or location to use for our integrations tests.

- The location was changed from FSN to HEL.
- The image was changed from ubuntu-22.04 to debian-12.

