### PR TITLE
feat: use exponential backoff algorithm when polling actions

### DIFF
--- a/changelogs/fragments/exponential-actions-polling-interval.yml
+++ b/changelogs/fragments/exponential-actions-polling-interval.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - Use a truncated exponential backoff algorithm when polling actions from the API.

--- a/plugins/module_utils/client.py
+++ b/plugins/module_utils/client.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from contextlib import contextmanager
+from random import random
 
 from ansible.module_utils.basic import missing_required_lib
 
@@ -106,3 +107,22 @@ class Client(ClientBase):
             yield
         finally:
             self._requests_session = requests.Session()
+
+
+def exponential_backoff_poll_interval(*, base: float, multiplier: int, cap: float, jitter: float):
+    """
+    Return a poll interval function, implementing a truncated exponential backoff with jitter.
+
+    :param base: Base for the exponential backoff algorithm.
+    :param multiplier: Multiplier for the exponential backoff algorithm.
+    :param cap: Value at which the interval is truncated.
+    :param jitter: Proportion of the interval to add as random jitter.
+    """
+
+    def func(retries: int) -> float:
+        interval = base * multiplier**retries  # Exponential backoff
+        interval = min(cap, interval)  # Cap backoff
+        interval += random() * interval * jitter  # Add jitter
+        return interval
+
+    return func

--- a/plugins/module_utils/hcloud.py
+++ b/plugins/module_utils/hcloud.py
@@ -15,7 +15,12 @@ from ansible.module_utils.common.validation import (
     check_required_one_of,
 )
 
-from .client import ClientException, client_check_required_lib, client_get_by_name_or_id
+from .client import (
+    ClientException,
+    client_check_required_lib,
+    client_get_by_name_or_id,
+    exponential_backoff_poll_interval,
+)
 from .vendor.hcloud import APIException, Client, HCloudException
 from .vendor.hcloud.actions import ActionException
 from .version import version
@@ -81,6 +86,9 @@ class AnsibleHCloud:
             api_endpoint=self.module.params["api_endpoint"],
             application_name="ansible-module",
             application_version=version,
+            # Total waiting time before timeout is > 112.0
+            poll_interval=exponential_backoff_poll_interval(base=1.0, multiplier=2, cap=5.0, jitter=0.5),
+            poll_max_retries=24,
         )
 
     def _client_get_by_name_or_id(self, resource: str, param: str | int):

--- a/plugins/module_utils/hcloud.py
+++ b/plugins/module_utils/hcloud.py
@@ -86,7 +86,7 @@ class AnsibleHCloud:
             api_endpoint=self.module.params["api_endpoint"],
             application_name="ansible-module",
             application_version=version,
-            # Total waiting time before timeout is > 112.0
+            # Total waiting time before timeout is > 117.0
             poll_interval=exponential_backoff_poll_interval(base=1.0, multiplier=2, cap=5.0, jitter=0.5),
             poll_max_retries=25,
         )

--- a/plugins/module_utils/hcloud.py
+++ b/plugins/module_utils/hcloud.py
@@ -88,7 +88,7 @@ class AnsibleHCloud:
             application_version=version,
             # Total waiting time before timeout is > 112.0
             poll_interval=exponential_backoff_poll_interval(base=1.0, multiplier=2, cap=5.0, jitter=0.5),
-            poll_max_retries=24,
+            poll_max_retries=25,
         )
 
     def _client_get_by_name_or_id(self, resource: str, param: str | int):

--- a/plugins/modules/certificate.py
+++ b/plugins/modules/certificate.py
@@ -204,7 +204,7 @@ class AnsibleHCloudCertificate(AnsibleHCloud):
                     resp = self.client.certificates.create_managed(**params)
                     # Action should take 60 to 90 seconds on average, wait for 5m to
                     # allow DNS or Let's Encrypt slowdowns.
-                    resp.action.wait_until_finished(max_retries=300)
+                    resp.action.wait_until_finished(max_retries=62)  # 62 retries >= 302 seconds
                 except HCloudException as exception:
                     self.fail_json_hcloud(exception)
 

--- a/tests/unit/module_utils/test_client.py
+++ b/tests/unit/module_utils/test_client.py
@@ -1,0 +1,14 @@
+from __future__ import annotations
+
+from ansible_collections.hetzner.hcloud.plugins.module_utils.client import (
+    exponential_backoff_poll_interval,
+)
+
+
+def test_exponential_backoff_poll_interval():
+    poll_interval = exponential_backoff_poll_interval(base=1.0, multiplier=2, cap=5.0, jitter=0.0)
+    poll_max_retries = 24
+
+    results = [poll_interval(i) for i in range(poll_max_retries)]
+    assert sum(results) == 112.0
+    assert results[:6] == [1.0, 2.0, 4.0, 5.0, 5.0, 5.0]

--- a/tests/unit/module_utils/test_client.py
+++ b/tests/unit/module_utils/test_client.py
@@ -7,8 +7,8 @@ from ansible_collections.hetzner.hcloud.plugins.module_utils.client import (
 
 def test_exponential_backoff_poll_interval():
     poll_interval = exponential_backoff_poll_interval(base=1.0, multiplier=2, cap=5.0, jitter=0.0)
-    poll_max_retries = 24
+    poll_max_retries = 25
 
     results = [poll_interval(i) for i in range(poll_max_retries)]
-    assert sum(results) == 112.0
+    assert sum(results) == 117.0
     assert results[:6] == [1.0, 2.0, 4.0, 5.0, 5.0, 5.0]


### PR DESCRIPTION
##### SUMMARY

Replace the constant poll interval of 1 second, with a truncated exponential back off algorithm with jitter.

Below is a suite of poll interval (in seconds) generated by the new algorithm:
```
1.49
2.14
5.46
6.51
6.57
5.57
5.98
7.13
6.59
7.10
5.54
5.03
6.56
5.96
6.72
7.21
7.05
5.31
5.60
6.33
6.82
5.42
6.08
6.60
TOTAL: 140.77
```
