### PR TITLE
feat: deprecate `server_type_info` `included_traffic` return value

### DIFF
--- a/changelogs/fragments/deprecate-server-type-pricing.yml
+++ b/changelogs/fragments/deprecate-server-type-pricing.yml
@@ -1,2 +1,3 @@
 minor_changes:
-  - server_type_info - The 'included_traffic' return value is deprecated and will be set to 'None' on 5 August 2024. See $LINK.
+  - server_type_info - The 'included_traffic' return value is deprecated and will be set to 'None' on 5 August 2024.
+    See https://docs.hetzner.cloud/changelog#2024-07-25-cloud-api-returns-traffic-information-in-different-format.

--- a/changelogs/fragments/deprecate-server-type-pricing.yml
+++ b/changelogs/fragments/deprecate-server-type-pricing.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - server_type_info - The 'included_traffic' return value is deprecated and will be set to 'None' on 5 August 2024. See $LINK.

--- a/plugins/modules/server_type_info.py
+++ b/plugins/modules/server_type_info.py
@@ -99,7 +99,8 @@ hcloud_server_type_info:
             description: |
                 Free traffic per month in bytes
 
-                B(Deprecated): This field is deprecated and will be set to C(None) on 5 August 2024. See U($LINK).
+                B(Deprecated): This field is deprecated and will be set to C(None) on 5 August 2024.
+                See U(https://docs.hetzner.cloud/changelog#2024-07-25-cloud-api-returns-traffic-information-in-different-format).
             returned: always
             type: int
             sample: 21990232555520

--- a/plugins/modules/server_type_info.py
+++ b/plugins/modules/server_type_info.py
@@ -96,7 +96,10 @@ hcloud_server_type_info:
             type: str
             sample: x86
         included_traffic:
-            description: Free traffic per month in bytes
+            description: |
+                Free traffic per month in bytes
+
+                B(Deprecated): This field is deprecated and will be set to C(None) on 5 August 2024. See U($LINK).
             returned: always
             type: int
             sample: 21990232555520


### PR DESCRIPTION
### API Changes for Traffic Prices and Server Type Included Traffic

There will be a breaking change in the API regarding Traffic Prices and Server Type Included Traffic on 2024-08-05. This release marks the affected fields as `Deprecated`. Please check if this affects any of your code and switch to the replacement fields where necessary.

You can learn more about this change in [our changelog](https://docs.hetzner.cloud/changelog#2024-07-25-cloud-api-returns-traffic-information-in-different-format).
