### PR TITLE
test: add server cleanup timeout workaround

### DIFF
--- a/tests/integration/targets/firewall/tasks/cleanup.yml
+++ b/tests/integration/targets/firewall/tasks/cleanup.yml
@@ -5,6 +5,10 @@
     state: absent
     force: true
 
+- name: Workaround to prevent a timeout during the server deletion
+  ansible.builtin.pause:
+    seconds: 2
+
 - name: Cleanup test_server
   hetzner.hcloud.server:
     name: "{{ hcloud_server_name }}"

--- a/tests/integration/targets/firewall_info/tasks/cleanup.yml
+++ b/tests/integration/targets/firewall_info/tasks/cleanup.yml
@@ -5,6 +5,10 @@
     state: absent
     force: true
 
+- name: Workaround to prevent a timeout during the server deletion
+  ansible.builtin.pause:
+    seconds: 2
+
 - name: Cleanup test_server
   hetzner.hcloud.server:
     name: "{{ hcloud_server_name }}"

--- a/tests/integration/targets/firewall_resource/tasks/cleanup.yml
+++ b/tests/integration/targets/firewall_resource/tasks/cleanup.yml
@@ -5,6 +5,10 @@
     state: absent
     force: true
 
+- name: Workaround to prevent a timeout during the server deletion
+  ansible.builtin.pause:
+    seconds: 2
+
 - name: Cleanup test_server
   hetzner.hcloud.server:
     name: "{{ hcloud_server_name }}"


### PR DESCRIPTION
##### SUMMARY

Prevent a timeout error when cleaning up server right after the firewall got deleted.
