### PR TITLE
test: ensure location is used for tests

### DIFF
--- a/tests/integration/targets/firewall/tasks/prepare.yml
+++ b/tests/integration/targets/firewall/tasks/prepare.yml
@@ -4,5 +4,6 @@
     name: "{{ hcloud_server_name }}"
     server_type: "{{ hcloud_server_type_name }}"
     image: "{{ hcloud_image_name }}"
+    location: "{{ hcloud_location_name }}"
     state: stopped
   register: test_server

--- a/tests/integration/targets/firewall_info/tasks/prepare.yml
+++ b/tests/integration/targets/firewall_info/tasks/prepare.yml
@@ -4,6 +4,7 @@
     name: "{{ hcloud_server_name }}"
     server_type: "{{ hcloud_server_type_name }}"
     image: "{{ hcloud_image_name }}"
+    location: "{{ hcloud_location_name }}"
     labels:
       firewall: "{{ hcloud_firewall_name }}"
     state: stopped

--- a/tests/integration/targets/firewall_resource/tasks/prepare.yml
+++ b/tests/integration/targets/firewall_resource/tasks/prepare.yml
@@ -4,6 +4,7 @@
     name: "{{ hcloud_server_name }}"
     server_type: "{{ hcloud_server_type_name }}"
     image: "{{ hcloud_image_name }}"
+    location: "{{ hcloud_location_name }}"
     labels:
       key: value
     state: stopped

--- a/tests/integration/targets/floating_ip/tasks/test.yml
+++ b/tests/integration/targets/floating_ip/tasks/test.yml
@@ -21,8 +21,8 @@
     name: "{{ hcloud_server_name }}"
     server_type: "{{ hcloud_server_type_name }}"
     image: "{{ hcloud_image_name }}"
-    state: stopped
     location: "{{ hcloud_location_name }}"
+    state: stopped
   register: main_server
 - name: verify setup server
   assert:
@@ -34,6 +34,7 @@
     name: "{{ hcloud_server_name }}2"
     server_type: "{{ hcloud_server_type_name }}"
     image: "{{ hcloud_image_name }}"
+    location: "{{ hcloud_location_name }}"
     state: stopped
   register: main_server2
 - name: verify setup another server

--- a/tests/integration/targets/image_info/tasks/prepare.yml
+++ b/tests/integration/targets/image_info/tasks/prepare.yml
@@ -4,6 +4,7 @@
     name: "{{ hcloud_server_name }}"
     server_type: "{{ hcloud_server_type_name }}"
     image: "{{ hcloud_image_name }}"
+    location: "{{ hcloud_location_name }}"
     state: stopped
   register: test_server
 

--- a/tests/integration/targets/load_balancer_info/tasks/prepare.yml
+++ b/tests/integration/targets/load_balancer_info/tasks/prepare.yml
@@ -4,6 +4,7 @@
     name: "{{ hcloud_server_name }}"
     server_type: "{{ hcloud_server_type_name }}"
     image: "{{ hcloud_image_name }}"
+    location: "{{ hcloud_location_name }}"
     state: stopped
   register: test_server
 

--- a/tests/integration/targets/load_balancer_target/tasks/test.yml
+++ b/tests/integration/targets/load_balancer_target/tasks/test.yml
@@ -6,8 +6,8 @@
     name: "{{hcloud_server_name}}"
     server_type: "{{ hcloud_server_type_name }}"
     image: "{{ hcloud_image_name }}"
-    state: stopped
     location: "{{ hcloud_location_name }}"
+    state: stopped
   register: server
 - name: verify setup server
   assert:

--- a/tests/integration/targets/primary_ip/tasks/prepare.yml
+++ b/tests/integration/targets/primary_ip/tasks/prepare.yml
@@ -4,6 +4,7 @@
     name: "{{ hcloud_server_name }}"
     server_type: "{{ hcloud_server_type_name }}"
     image: "{{ hcloud_image_name }}"
+    location: "{{ hcloud_location_name }}"
     state: stopped
     enable_ipv4: false
     enable_ipv6: false

--- a/tests/integration/targets/rdns/tasks/prepare.yml
+++ b/tests/integration/targets/rdns/tasks/prepare.yml
@@ -4,6 +4,7 @@
     name: "{{ hcloud_server_name }}"
     server_type: "{{ hcloud_server_type_name }}"
     image: "{{ hcloud_image_name }}"
+    location: "{{ hcloud_location_name }}"
     state: present
   register: test_server
 

--- a/tests/integration/targets/server/tasks/test_basic.yml
+++ b/tests/integration/targets/server/tasks/test_basic.yml
@@ -3,6 +3,7 @@
     name: "{{ hcloud_server_name }}"
     server_type: "{{ hcloud_server_type_name }}"
     image: "{{ hcloud_image_name }}"
+    location: "{{ hcloud_location_name }}"
     state: present
   register: result
   check_mode: true
@@ -16,6 +17,7 @@
     name: "{{ hcloud_server_name}}"
     server_type: "{{ hcloud_server_type_name }}"
     image: "{{ hcloud_image_name }}"
+    location: "{{ hcloud_location_name }}"
     enable_ipv6: False
     state: started
   register: main_server
@@ -441,6 +443,7 @@
     name: "{{ hcloud_server_name}}"
     server_type: "{{ hcloud_server_type_name }}"
     image: "{{ hcloud_image_name }}"
+    location: "{{ hcloud_location_name }}"
     ssh_keys:
       - "{{ hcloud_ssh_key_name }}"
     rescue_mode: "linux64"
@@ -470,6 +473,7 @@
     name: "{{ hcloud_server_name}}"
     server_type: "{{ hcloud_server_type_name }}"
     image: "{{ hcloud_image_name }}"
+    location: "{{ hcloud_location_name }}"
     ssh_keys:
       - "{{ hcloud_ssh_key_name }}"
     labels:
@@ -563,6 +567,7 @@
     rebuild_protection: true
     server_type: "{{ hcloud_server_type_name }}"
     image: "{{ hcloud_image_name }}"
+    location: "{{ hcloud_location_name }}"
     ssh_keys:
       - "{{ hcloud_ssh_key_name }}"
     state: present

--- a/tests/integration/targets/server_info/tasks/prepare.yml
+++ b/tests/integration/targets/server_info/tasks/prepare.yml
@@ -4,6 +4,7 @@
     name: "{{ hcloud_server_name }}"
     server_type: "{{ hcloud_server_type_name }}"
     image: "{{ hcloud_image_name }}"
+    location: "{{ hcloud_location_name }}"
     state: stopped
     labels:
       key: value
@@ -14,6 +15,7 @@
     name: "{{ hcloud_server_name }}2"
     server_type: "{{ hcloud_server_type_name }}"
     image: "{{ hcloud_image_name }}"
+    location: "{{ hcloud_location_name }}"
     state: stopped
     labels:
       key: value

--- a/tests/integration/targets/server_network/tasks/prepare.yml
+++ b/tests/integration/targets/server_network/tasks/prepare.yml
@@ -20,5 +20,6 @@
     name: "{{ hcloud_server_name }}"
     server_type: "{{ hcloud_server_type_name }}"
     image: "{{ hcloud_image_name }}"
+    location: "{{ hcloud_location_name }}"
     state: stopped
   register: test_server

--- a/tests/integration/targets/ssh_key/tasks/test.yml
+++ b/tests/integration/targets/ssh_key/tasks/test.yml
@@ -114,6 +114,7 @@
     name: "{{ hcloud_server_name }}"
     server_type: "{{ hcloud_server_type_name }}"
     image: "{{ hcloud_image_name }}"
+    location: "{{ hcloud_location_name }}"
     ssh_keys:
       - "{{ hcloud_ssh_key_name }}"
     state: started


### PR DESCRIPTION
##### SUMMARY

Make sure that the tests uses the `hcloud_location_name` variable for the tests.
