### PR TITLE
test: improve `load_balancer_target` integration using new framework

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -8,7 +8,6 @@ exclude_paths:
   - examples/
   - tests/integration/targets/certificate
   - tests/integration/targets/floating_ip
-  - tests/integration/targets/load_balancer_target
   - tests/integration/targets/placement_group
   - tests/integration/targets/primary_ip
   - tests/integration/targets/route

--- a/tests/integration/targets/load_balancer_target/tasks/cleanup.yml
+++ b/tests/integration/targets/load_balancer_target/tasks/cleanup.yml
@@ -1,0 +1,10 @@
+---
+- name: Cleanup test_load_balancer
+  hetzner.hcloud.load_balancer:
+    name: "{{ hcloud_load_balancer_name }}"
+    state: absent
+
+- name: Cleanup test_server
+  hetzner.hcloud.server:
+    name: "{{ hcloud_server_name }}"
+    state: absent

--- a/tests/integration/targets/load_balancer_target/tasks/prepare.yml
+++ b/tests/integration/targets/load_balancer_target/tasks/prepare.yml
@@ -1,0 +1,18 @@
+---
+- name: Create test_server
+  hetzner.hcloud.server:
+    name: "{{ hcloud_server_name }}"
+    server_type: "{{ hcloud_server_type_name }}"
+    image: "{{ hcloud_image_name }}"
+    location: "{{ hcloud_location_name }}"
+    state: stopped
+  register: test_server
+
+- name: Create test_load_balancer
+  hetzner.hcloud.load_balancer:
+    name: "{{ hcloud_load_balancer_name }}"
+    load_balancer_type: lb11
+    network_zone: "{{ hcloud_network_zone_name }}"
+    labels:
+      key: value
+  register: test_load_balancer

--- a/tests/integration/targets/load_balancer_target/tasks/test.yml
+++ b/tests/integration/targets/load_balancer_target/tasks/test.yml
@@ -1,154 +1,174 @@
 # Copyright: (c) 2019, Hetzner Cloud GmbH <info@hetzner-cloud.de>
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 ---
-- name: setup server
-  hetzner.hcloud.server:
-    name: "{{hcloud_server_name}}"
-    server_type: "{{ hcloud_server_type_name }}"
-    image: "{{ hcloud_image_name }}"
-    location: "{{ hcloud_location_name }}"
-    state: stopped
-  register: server
-- name: verify setup server
-  assert:
-    that:
-      - server is success
-
-- name: setup load_balancer
-  hetzner.hcloud.load_balancer:
-    name: "{{hcloud_load_balancer_name}}"
-    load_balancer_type: lb11
-    state: present
-    location: "{{ hcloud_location_name }}"
-  register: load_balancer
-- name: verify setup load_balancer
-  assert:
-    that:
-      - load_balancer is success
-
-- name: test fail load balancer does not exist
+- name: Test missing required parameters
   hetzner.hcloud.load_balancer_target:
+    state: present
+  ignore_errors: true
+  register: result
+- name: Verify missing required parameters
+  ansible.builtin.assert:
+    that:
+      - result is failed
+      - 'result.msg == "missing required arguments: load_balancer, type"'
+
+- name: Test create with not existing load_balancer
+  hetzner.hcloud.load_balancer_target:
+    load_balancer: not-existing
     type: server
-    load_balancer: does-not-exist
     server: "{{ hcloud_server_name }}"
-  register: result
-  ignore_errors: true
-- name: verify test fail load_balancer does not exist
-  assert:
-    that:
-      - result is failed
-      - "result.msg == 'resource (load_balancer) does not exist: does-not-exist'"
-
-- name: test fail server does not exist
-  hetzner.hcloud.load_balancer_target:
-    type: server
-    load_balancer: "{{ hcloud_load_balancer_name }}"
-    server: does-not-exist
-  register: result
-  ignore_errors: true
-- name: verify test fail server does not exist
-  assert:
-    that:
-      - result is failed
-      - "result.msg == 'resource (server) does not exist: does-not-exist'"
-
-- name: test create load_balancer target with checkmode
-  hetzner.hcloud.load_balancer_target:
-    type: "server"
-    load_balancer: "{{hcloud_load_balancer_name}}"
-    server: "{{hcloud_server_name}}"
     state: present
+  ignore_errors: true
   register: result
+- name: Verify create with not existing load_balancer
+  ansible.builtin.assert:
+    that:
+      - result is failed
+      - 'result.msg == "resource (load_balancer) does not exist: not-existing"'
+
+- name: Test create with not existing server
+  hetzner.hcloud.load_balancer_target:
+    load_balancer: "{{ hcloud_load_balancer_name }}"
+    type: server
+    server: not-existing
+    state: present
+  ignore_errors: true
+  register: result
+- name: Verify create with not existing server
+  ansible.builtin.assert:
+    that:
+      - result is failed
+      - 'result.msg == "resource (server) does not exist: not-existing"'
+
+- name: Test create with checkmode
+  hetzner.hcloud.load_balancer_target:
+    load_balancer: "{{ hcloud_load_balancer_name }}"
+    type: server
+    server: "{{ hcloud_server_name }}"
+    state: present
   check_mode: true
-- name: verify test create load_balancer target with checkmode
-  assert:
+  register: result
+- name: Verify create with checkmode
+  ansible.builtin.assert:
     that:
       - result is changed
 
-- name: test create load_balancer target
+- name: Test create with server
   hetzner.hcloud.load_balancer_target:
-    type: "server"
-    load_balancer: "{{hcloud_load_balancer_name}}"
-    server: "{{hcloud_server_name}}"
+    load_balancer: "{{ hcloud_load_balancer_name }}"
+    type: server
+    server: "{{ hcloud_server_name }}"
     state: present
-  register: load_balancer_target
-- name: verify create load_balancer target
-  assert:
+  register: result
+- name: Verify create with server
+  ansible.builtin.assert:
     that:
-      - load_balancer_target is changed
-      - load_balancer_target.hcloud_load_balancer_target.type == "server"
-      - load_balancer_target.hcloud_load_balancer_target.server == hcloud_server_name
-      - load_balancer_target.hcloud_load_balancer_target.load_balancer == hcloud_load_balancer_name
+      - result is changed
+      - result.hcloud_load_balancer_target.load_balancer == hcloud_load_balancer_name
+      - result.hcloud_load_balancer_target.type == "server"
+      - result.hcloud_load_balancer_target.server == hcloud_server_name
+      - result.hcloud_load_balancer_target.use_private_ip == false
 
-- name: test create load_balancer target idempotency
+- name: Test create with server idempotency
   hetzner.hcloud.load_balancer_target:
-    type: "server"
-    load_balancer: "{{hcloud_load_balancer_name}}"
-    server: "{{hcloud_server_name}}"
+    load_balancer: "{{ hcloud_load_balancer_name }}"
+    type: server
+    server: "{{ hcloud_server_name }}"
     state: present
-  register: load_balancer_target
-- name: verify create load_balancer target idempotency
-  assert:
+  register: result
+- name: Verify create with server idempotency
+  ansible.builtin.assert:
     that:
-      - load_balancer_target is not changed
+      - result is not changed
 
-- name: test absent load_balancer target
+- name: Test delete with server
   hetzner.hcloud.load_balancer_target:
-    type: "server"
-    load_balancer: "{{hcloud_load_balancer_name}}"
-    server: "{{hcloud_server_name}}"
+    load_balancer: "{{ hcloud_load_balancer_name }}"
+    type: server
+    server: "{{ hcloud_server_name }}"
     state: absent
   register: result
-- name: verify test absent load_balancer target
-  assert:
+- name: Verify delete with server
+  ansible.builtin.assert:
     that:
       - result is changed
 
-- name: test create label_selector target
+- name: Test create with label_selector
   hetzner.hcloud.load_balancer_target:
-    type: "label_selector"
-    load_balancer: "{{hcloud_load_balancer_name}}"
-    label_selector: "application=backend"
-    state: present
-  register: load_balancer_target
-- name: verify create label_selector target
-  assert:
-    that:
-      - load_balancer_target is changed
-      - load_balancer_target.hcloud_load_balancer_target.type == "label_selector"
-      - load_balancer_target.hcloud_load_balancer_target.label_selector == "application=backend"
-      - load_balancer_target.hcloud_load_balancer_target.load_balancer == hcloud_load_balancer_name
-
-- name: test create ip target
-  hetzner.hcloud.load_balancer_target:
-    type: "ip"
     load_balancer: "{{ hcloud_load_balancer_name }}"
+    type: label_selector
+    label_selector: application=backend
+    state: present
+  register: result
+- name: Verify create with label_selector
+  ansible.builtin.assert:
+    that:
+      - result is changed
+      - result.hcloud_load_balancer_target.load_balancer == hcloud_load_balancer_name
+      - result.hcloud_load_balancer_target.type == "label_selector"
+      - result.hcloud_load_balancer_target.label_selector == "application=backend"
+      - result.hcloud_load_balancer_target.use_private_ip == false
+
+- name: Test create with label_selector idempotency
+  hetzner.hcloud.load_balancer_target:
+    load_balancer: "{{ hcloud_load_balancer_name }}"
+    type: label_selector
+    label_selector: application=backend
+    state: present
+  register: result
+- name: Verify create with label_selector idempotency
+  ansible.builtin.assert:
+    that:
+      - result is not changed
+
+- name: Test delete with label_selector
+  hetzner.hcloud.load_balancer_target:
+    load_balancer: "{{ hcloud_load_balancer_name }}"
+    type: label_selector
+    label_selector: application=backend
+    state: absent
+  register: result
+- name: Verify delete with label_selector
+  ansible.builtin.assert:
+    that:
+      - result is changed
+
+- name: Test create with ip
+  hetzner.hcloud.load_balancer_target:
+    load_balancer: "{{ hcloud_load_balancer_name }}"
+    type: ip
     ip: "{{ hetzner_server_ip }}"
     state: present
-  register: load_balancer_target
-- name: verify create ip target
-  assert:
+  register: result
+- name: Verify create with ip
+  ansible.builtin.assert:
     that:
-      - load_balancer_target is changed
-      - load_balancer_target.hcloud_load_balancer_target.type == "ip"
-      - load_balancer_target.hcloud_load_balancer_target.ip == hetzner_server_ip
-      - load_balancer_target.hcloud_load_balancer_target.load_balancer == hcloud_load_balancer_name
+      - result is changed
+      - result.hcloud_load_balancer_target.load_balancer == hcloud_load_balancer_name
+      - result.hcloud_load_balancer_target.type == "ip"
+      - result.hcloud_load_balancer_target.ip == hetzner_server_ip
+      - result.hcloud_load_balancer_target.use_private_ip == none
 
-- name: cleanup load_balancer
-  hetzner.hcloud.load_balancer:
-    name: "{{ hcloud_load_balancer_name }}"
+- name: Test create with ip idempotency
+  hetzner.hcloud.load_balancer_target:
+    load_balancer: "{{ hcloud_load_balancer_name }}"
+    type: ip
+    ip: "{{ hetzner_server_ip }}"
+    state: present
+  register: result
+- name: Verify create with ip idempotency
+  ansible.builtin.assert:
+    that:
+      - result is not changed
+
+- name: Test delete with ip
+  hetzner.hcloud.load_balancer_target:
+    load_balancer: "{{ hcloud_load_balancer_name }}"
+    type: ip
+    ip: "{{ hetzner_server_ip }}"
     state: absent
   register: result
-  until: result is not failed
-  retries: 5
-  delay: 2
-
-- name: cleanup
-  hetzner.hcloud.server:
-    name: "{{hcloud_server_name}}"
-    state: absent
-  register: result
-- name: verify cleanup
-  assert:
+- name: Verify delete with ip
+  ansible.builtin.assert:
     that:
-      - result is success
+      - result is changed


### PR DESCRIPTION
##### SUMMARY

Use the new testing framework for the load_balancer_target integration tests.

Depends on #546
