### PR TITLE
docs: add communication section with forum information

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,20 @@
 
 Ansible Hetzner Cloud Collection for controlling your Hetzner Cloud Resources.
 
-### Python version compatibility
+## Communication
+
+* Join the Ansible forum:
+  * [Get Help](https://forum.ansible.com/c/help/6): get help or help others.
+  * [POSTS TAGGED WITH 'YOUR TAG'](https://forum.ansible.com/tag/YOUR_TAG): subscribe to participate in collection-related conversations.
+  * [REFER TO YOUR FORUM GROUP HERE IF EXISTS](https://forum.ansible.com/g/): by joining the team you will automatically get subscribed to the posts tagged with [your group forum tag here](https://forum.ansible.com/tags).
+  * [Social Spaces](https://forum.ansible.com/c/chat/4): gather and interact with fellow enthusiasts.
+  * [News & Announcements](https://forum.ansible.com/c/news/5): track project-wide announcements including social events.
+
+* The Ansible [Bullhorn newsletter](https://docs.ansible.com/ansible/devel/community/communication.html#the-bullhorn): used to announce releases and important changes.
+
+For more information about communication, see the [Ansible communication guide](https://docs.ansible.com/ansible/devel/community/communication.html).
+
+## Python version compatibility
 
 This collection depends on the [hcloud](https://github.com/hetznercloud/hcloud-python) library. Due to the [hcloud](https://github.com/hetznercloud/hcloud-python) Python Support Policy this collection requires Python 3.8 or greater.
 

--- a/README.md
+++ b/README.md
@@ -12,8 +12,7 @@ Ansible Hetzner Cloud Collection for controlling your Hetzner Cloud Resources.
 - Join the Ansible forum:
 
   - [Get Help](https://forum.ansible.com/c/help/6): get help or help others.
-  - [POSTS TAGGED WITH 'YOUR TAG'](https://forum.ansible.com/tag/YOUR_TAG): subscribe to participate in collection-related conversations.
-  - [REFER TO YOUR FORUM GROUP HERE IF EXISTS](https://forum.ansible.com/g/): by joining the team you will automatically get subscribed to the posts tagged with [your group forum tag here](https://forum.ansible.com/tags).
+  - [Posts tagged with 'hcloud'](https://forum.ansible.com/tag/hcloud): subscribe to participate in collection-related conversations.
   - [Social Spaces](https://forum.ansible.com/c/chat/4): gather and interact with fellow enthusiasts.
   - [News & Announcements](https://forum.ansible.com/c/news/5): track project-wide announcements including social events.
 

--- a/README.md
+++ b/README.md
@@ -9,14 +9,15 @@ Ansible Hetzner Cloud Collection for controlling your Hetzner Cloud Resources.
 
 ## Communication
 
-* Join the Ansible forum:
-  * [Get Help](https://forum.ansible.com/c/help/6): get help or help others.
-  * [POSTS TAGGED WITH 'YOUR TAG'](https://forum.ansible.com/tag/YOUR_TAG): subscribe to participate in collection-related conversations.
-  * [REFER TO YOUR FORUM GROUP HERE IF EXISTS](https://forum.ansible.com/g/): by joining the team you will automatically get subscribed to the posts tagged with [your group forum tag here](https://forum.ansible.com/tags).
-  * [Social Spaces](https://forum.ansible.com/c/chat/4): gather and interact with fellow enthusiasts.
-  * [News & Announcements](https://forum.ansible.com/c/news/5): track project-wide announcements including social events.
+- Join the Ansible forum:
 
-* The Ansible [Bullhorn newsletter](https://docs.ansible.com/ansible/devel/community/communication.html#the-bullhorn): used to announce releases and important changes.
+  - [Get Help](https://forum.ansible.com/c/help/6): get help or help others.
+  - [POSTS TAGGED WITH 'YOUR TAG'](https://forum.ansible.com/tag/YOUR_TAG): subscribe to participate in collection-related conversations.
+  - [REFER TO YOUR FORUM GROUP HERE IF EXISTS](https://forum.ansible.com/g/): by joining the team you will automatically get subscribed to the posts tagged with [your group forum tag here](https://forum.ansible.com/tags).
+  - [Social Spaces](https://forum.ansible.com/c/chat/4): gather and interact with fellow enthusiasts.
+  - [News & Announcements](https://forum.ansible.com/c/news/5): track project-wide announcements including social events.
+
+- The Ansible [Bullhorn newsletter](https://docs.ansible.com/ansible/devel/community/communication.html#the-bullhorn): used to announce releases and important changes.
 
 For more information about communication, see the [Ansible communication guide](https://docs.ansible.com/ansible/devel/community/communication.html).
 


### PR DESCRIPTION
##### SUMMARY
Dear maintainers,
As a part of the [Consolidating Ansible discussion platforms initiative](https://forum.ansible.com/t/proposal-consolidating-ansible-discussion-platforms/6812), this PR adds the communication section template defined by the community to the README. Similar PRs are being raised across all included collections under the ansible-collection org for now.

- If you have your forum group and/or tags related to the collection, please update corresponding lines by suggesting changes to the PR.
- If the collection is not present on the Ansible forum yet, please check out the existing [tags](https://forum.ansible.com/tags) and [groups](https://forum.ansible.com/g) - use what suits your collection. If there is no appropriate tag, please [request one](https://forum.ansible.com/t/requesting-a-forum-group/503/17). You can also request a group there as a WG if needed. Then update corresponding lines by suggesting changes to the PR.
- Presence in the forum will soon likely become a part of the Collection inclusion requirements.

##### ISSUE TYPE

- Docs Pull Request

##### COMPONENT NAME
README.md