### PR TITLE
fix: check label_selector child targets with load_balancer_status filter

### DIFF
--- a/plugins/filter/all.py
+++ b/plugins/filter/all.py
@@ -11,29 +11,34 @@ def load_balancer_status(load_balancer: dict, *args, **kwargs) -> Literal["unkno
     """
     Return the status of a Load Balancer based on its targets.
     """
-    try:
-        result = "healthy"
-        for target in load_balancer["targets"]:
-            target_health_status = target.get("health_status")
 
-            # Report missing health status as unknown
-            if not target_health_status:
-                result = "unknown"
+    def targets_status(targets: list) -> Literal["unknown", "unhealthy", "healthy"]:
+        result = "healthy"
+
+        for target in targets:
+            # Label selector targets have child targets that must be checked
+            if target["type"] == "label_selector":
+                status = targets_status(target["targets"])
+                if status == "unhealthy":
+                    return "unhealthy"
                 continue
 
-            for health_status in target_health_status:
+            # Report missing health status as unknown
+            if not target.get("health_status"):
+                return "unknown"
+
+            for health_status in target.get("health_status"):
                 status = health_status.get("status")
-                if status == "healthy":
-                    continue
-
-                if status in (None, "unknown"):
-                    result = "unknown"
-                    continue
-
                 if status == "unhealthy":
                     return "unhealthy"
 
+                if status in (None, "unknown"):
+                    result = "unknown"
+
         return result
+
+    try:
+        return targets_status(load_balancer["targets"])
     except Exception as exc:
         raise AnsibleFilterError(f"load_balancer_status - {to_native(exc)}", orig_exc=exc) from exc
 

--- a/tests/unit/filter/test_all.py
+++ b/tests/unit/filter/test_all.py
@@ -4,39 +4,27 @@ import pytest
 
 from plugins.filter.all import load_balancer_status
 
+
+def _lb_target_server(status: str) -> dict:
+    return {"type": "server", "health_status": [{"status": status}]}
+
+
+def _lb_target_label_selector(status: str) -> dict:
+    return {"type": "label_selector", "targets": [_lb_target_server(status)]}
+
+
 LOAD_BALANCER_STATUS_TEST_CASES = (
-    ({"targets": [{"health_status": []}]}, "unknown"),
-    ({"targets": [{"health_status": [{}]}]}, "unknown"),
-    ({"targets": [{"health_status": [{"status": "unknown"}]}]}, "unknown"),
-    ({"targets": [{"health_status": [{"status": "unhealthy"}]}]}, "unhealthy"),
-    ({"targets": [{"health_status": [{"status": "healthy"}]}]}, "healthy"),
-    (
-        {
-            "targets": [
-                {"health_status": [{"status": "healthy"}]},
-                {"health_status": [{"status": "healthy"}]},
-            ]
-        },
-        "healthy",
-    ),
-    (
-        {
-            "targets": [
-                {"health_status": [{"status": "healthy"}, {"status": "unhealthy"}]},
-                {"health_status": [{"status": "healthy"}, {"status": "unknown"}]},
-            ]
-        },
-        "unhealthy",
-    ),
-    (
-        {
-            "targets": [
-                {"health_status": [{"status": "healthy"}]},
-                {"health_status": [{"status": "unhealthy"}]},
-            ]
-        },
-        "unhealthy",
-    ),
+    ({"targets": [{"type": "server", "health_status": []}]}, "unknown"),
+    ({"targets": [{"type": "server", "health_status": [{}]}]}, "unknown"),
+    ({"targets": [_lb_target_server("healthy")]}, "healthy"),
+    ({"targets": [_lb_target_server("unhealthy")]}, "unhealthy"),
+    ({"targets": [_lb_target_server("unknown")]}, "unknown"),
+    ({"targets": [_lb_target_server("healthy"), _lb_target_label_selector("healthy")]}, "healthy"),
+    ({"targets": [_lb_target_server("healthy"), _lb_target_label_selector("unhealthy")]}, "unhealthy"),
+    ({"targets": [_lb_target_server("unhealthy"), _lb_target_label_selector("healthy")]}, "unhealthy"),
+    ({"targets": [_lb_target_label_selector("healthy"), _lb_target_server("healthy")]}, "healthy"),
+    ({"targets": [_lb_target_label_selector("healthy"), _lb_target_server("unhealthy")]}, "unhealthy"),
+    ({"targets": [_lb_target_label_selector("unhealthy"), _lb_target_server("healthy")]}, "unhealthy"),
 )
 
 


### PR DESCRIPTION
##### SUMMARY

The previous implementation did not take into consideration label selectors targets, and their child targets.

This change implements a recursive function that traverse all the targets.

Related to #467 #550 

