### PR TITLE
docs: fix `firewall_resource` examples input parameters

### DIFF
--- a/plugins/modules/firewall_resource.py
+++ b/plugins/modules/firewall_resource.py
@@ -48,7 +48,7 @@ extends_documentation_fragment:
 EXAMPLES = """
 - name: Apply a firewall to a list of servers
   hetzner.hcloud.firewall_resource:
-    name: my-firewall
+    firewall: my-firewall
     servers:
       - my-server
       - 3456789
@@ -56,7 +56,7 @@ EXAMPLES = """
 
 - name: Remove a firewall from a list of servers
   hetzner.hcloud.firewall_resource:
-    name: my-firewall
+    firewall: my-firewall
     servers:
       - my-server
       - 3456789
@@ -64,14 +64,14 @@ EXAMPLES = """
 
 - name: Apply a firewall to resources using label selectors
   hetzner.hcloud.firewall_resource:
-    name: my-firewall
+    firewall: my-firewall
     label_selectors:
       - env=prod
     state: present
 
 - name: Remove a firewall from resources using label selectors
   hetzner.hcloud.firewall_resource:
-    name: my-firewall
+    firewall: my-firewall
     label_selectors:
       - env=prod
     state: absent


### PR DESCRIPTION
In the example, we should use `firewall` instead of `name` as per the options described at the top of the documentation.

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
I had an error on my VSCode when I used `name` as it was showing in the example. Looking at the documentation, it says I should be using `firewall` instead. 
I haven't explicitly tested to see if it would have failed, but I thought replacing `name` with `firewall` was the right thing to do, as it works fine like this.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Docs Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
firewall_resource
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
