### PR TITLE
fix(server): timeout in server creation when waiting on next actions

### DIFF
--- a/plugins/modules/server.py
+++ b/plugins/modules/server.py
@@ -479,7 +479,7 @@ class AnsibleHCloudServer(AnsibleHCloud):
                     self.module.warn(
                         f"Next action {action}"                    
                     )                    
-                    action.wait_until_finished()
+                    action.wait_until_finished(max_retries=1000)
 
                 rescue_mode = self.module.params.get("rescue_mode")
                 if rescue_mode:

--- a/plugins/modules/server.py
+++ b/plugins/modules/server.py
@@ -471,14 +471,8 @@ class AnsibleHCloudServer(AnsibleHCloud):
                 self.result["root_password"] = resp.root_password
                 # Action should take 60 to 90 seconds on average, but can be >10m when creating a
                 # server from a custom images
-                self.module.warn(
-                    f"Creating {image.name} server with params {params}"                    
-                )
                 resp.action.wait_until_finished(max_retries=1000)  # 362 retries >= 1802 seconds
                 for action in resp.next_actions:
-                    self.module.warn(
-                        f"Next action {action}"                    
-                    )                    
                     action.wait_until_finished(max_retries=1000)
 
                 rescue_mode = self.module.params.get("rescue_mode")

--- a/plugins/modules/server.py
+++ b/plugins/modules/server.py
@@ -471,7 +471,10 @@ class AnsibleHCloudServer(AnsibleHCloud):
                 self.result["root_password"] = resp.root_password
                 # Action should take 60 to 90 seconds on average, but can be >10m when creating a
                 # server from a custom images
-                resp.action.wait_until_finished(max_retries=362)  # 362 retries >= 1802 seconds
+                self.module.warn(
+                    f"Creating {image.name} server "                    
+                )
+                resp.action.wait_until_finished(max_retries=1000)  # 362 retries >= 1802 seconds
                 for action in resp.next_actions:
                     action.wait_until_finished(max_retries=362)
 

--- a/plugins/modules/server.py
+++ b/plugins/modules/server.py
@@ -473,7 +473,7 @@ class AnsibleHCloudServer(AnsibleHCloud):
                 # server from a custom images
                 resp.action.wait_until_finished(max_retries=362)  # 362 retries >= 1802 seconds
                 for action in resp.next_actions:
-                    action.wait_until_finished()
+                    action.wait_until_finished(max_retries=362)
 
                 rescue_mode = self.module.params.get("rescue_mode")
                 if rescue_mode:

--- a/plugins/modules/server.py
+++ b/plugins/modules/server.py
@@ -472,7 +472,7 @@ class AnsibleHCloudServer(AnsibleHCloud):
                 # Action should take 60 to 90 seconds on average, but can be >10m when creating a
                 # server from a custom images
                 self.module.warn(
-                    f"Creating {image.name} server "                    
+                    f"Creating {image.name} server with params {params}"                    
                 )
                 resp.action.wait_until_finished(max_retries=1000)  # 362 retries >= 1802 seconds
                 for action in resp.next_actions:

--- a/plugins/modules/server.py
+++ b/plugins/modules/server.py
@@ -476,7 +476,10 @@ class AnsibleHCloudServer(AnsibleHCloud):
                 )
                 resp.action.wait_until_finished(max_retries=1000)  # 362 retries >= 1802 seconds
                 for action in resp.next_actions:
-                    action.wait_until_finished(max_retries=362)
+                    self.module.warn(
+                        f"Next action {action}"                    
+                    )                    
+                    action.wait_until_finished()
 
                 rescue_mode = self.module.params.get("rescue_mode")
                 if rescue_mode:


### PR DESCRIPTION
##### SUMMARY
Timeout in server creation is insufficient when using large images (like Rocky8/9).
Random errors depending on image size and location load (server creation can take up to 5 minutes and more).

Similar to this one: https://github.com/ansible-collections/hetzner.hcloud/pull/189

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
module: server

##### ADDITIONAL INFORMATION
Error:
```
fatal: [test-master -> localhost]: FAILED! => {"changed": false, "failure": {"action": {"command": "start_server", "error": null, "finished": null, "id": 1772219884, "progress": 0, "resources": [{"id": 52912003, "type": "server"}], "started": "2024-09-10T09:30:35+00:00", "status": "running"}}, "msg": "The pending action timed out"}
An exception occurred during task execution. To see the full traceback, use -vvv. The error was: ansible_collections.hetzner.hcloud.plugins.module_utils.vendor.hcloud.actions.domain.ActionTimeoutException: The pending action timed out
```
Tested after the changes with cpx51 and rocky-9, no more errors.
