### PR TITLE
fix(server): timeout in server creation when waiting on next actions

### DIFF
--- a/changelogs/fragments/server-create-next-actions.yml
+++ b/changelogs/fragments/server-create-next-actions.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - server - Wait up to 30 minutes for every action returned from server create

--- a/plugins/modules/server.py
+++ b/plugins/modules/server.py
@@ -478,7 +478,7 @@ class AnsibleHCloudServer(AnsibleHCloud):
                     # This waits up to 30minutes for each action in series, but in the background
                     # the actions are mostly running in parallel, so after the first one the other
                     # actions are usually completed already.
-                    action.wait_until_finished(max_retries=362) # 362 retries >= 1802 seconds
+                    action.wait_until_finished(max_retries=362)  # 362 retries >= 1802 seconds
 
                 rescue_mode = self.module.params.get("rescue_mode")
                 if rescue_mode:

--- a/plugins/modules/server.py
+++ b/plugins/modules/server.py
@@ -473,7 +473,12 @@ class AnsibleHCloudServer(AnsibleHCloud):
                 # server from a custom images
                 resp.action.wait_until_finished(max_retries=362)  # 362 retries >= 1802 seconds
                 for action in resp.next_actions:
-                    action.wait_until_finished()
+                    # Starting the server or attaching to the network might take a few minutes,
+                    # depending on the current activity in the project.
+                    # This waits up to 30minutes for each action in series, but in the background
+                    # the actions are mostly running in parallel, so after the first one the other
+                    # actions are usually completed already.
+                    action.wait_until_finished(max_retries=362) # 362 retries >= 1802 seconds
 
                 rescue_mode = self.module.params.get("rescue_mode")
                 if rescue_mode:


### PR DESCRIPTION
##### SUMMARY

While we wait a long time on the `create_server` actions, we only wait 2 minutes on any follow up actions like `start_server` or `attach_network`. This is sometimes not enough. This PR adds a longer wait timeout for the `next_actions` returned after creating the server.

##### ISSUE TYPE
- Bugfix Pull Request


##### COMPONENT NAME

- `hcloud.server` module

##### ADDITIONAL INFORMATION

PR originally by @mmontesi
Replaces #558
