### PR TITLE
test: enable unsupported-version lint rule

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -18,5 +18,3 @@ exclude_paths:
 warn_list:
   - internal-error
   - sanity[cannot-ignore]
-  # TODO: remove once unsupported ansible-core version are dropped
-  - meta-runtime[unsupported-version]


### PR DESCRIPTION
##### SUMMARY

Enable the ansible-lint unsupported-version lint rule.
