### PR TITLE
test: ignore lint error for missing args in tests

### DIFF
--- a/tests/integration/targets/firewall/tasks/test.yml
+++ b/tests/integration/targets/firewall/tasks/test.yml
@@ -1,7 +1,7 @@
 # Copyright: (c) 2020, Hetzner Cloud GmbH <info@hetzner-cloud.de>
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 ---
-- name: Test missing required parameters
+- name: Test missing required parameters # noqa: args[module]
   hetzner.hcloud.firewall:
     state: present
   ignore_errors: true

--- a/tests/integration/targets/firewall_resource/tasks/test.yml
+++ b/tests/integration/targets/firewall_resource/tasks/test.yml
@@ -1,7 +1,7 @@
 # Copyright: (c) 2020, Hetzner Cloud GmbH <info@hetzner-cloud.de>
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 ---
-- name: Test missing required parameters
+- name: Test missing required parameters # noqa: args[module]
   hetzner.hcloud.firewall_resource:
     firewall: "{{ hcloud_firewall_name }}"
     state: present

--- a/tests/integration/targets/load_balancer_network/tasks/test.yml
+++ b/tests/integration/targets/load_balancer_network/tasks/test.yml
@@ -1,7 +1,7 @@
 # Copyright: (c) 2019, Hetzner Cloud GmbH <info@hetzner-cloud.de>
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 ---
-- name: Test missing required parameters
+- name: Test missing required parameters # noqa: args[module]
   hetzner.hcloud.load_balancer_network:
     state: present
   ignore_errors: true

--- a/tests/integration/targets/load_balancer_service/tasks/test.yml
+++ b/tests/integration/targets/load_balancer_service/tasks/test.yml
@@ -1,7 +1,7 @@
 # Copyright: (c) 2019, Hetzner Cloud GmbH <info@hetzner-cloud.de>
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 ---
-- name: Test missing required parameters
+- name: Test missing required parameters # noqa: args[module]
   hetzner.hcloud.load_balancer_service:
     state: present
   ignore_errors: true

--- a/tests/integration/targets/load_balancer_target/tasks/test.yml
+++ b/tests/integration/targets/load_balancer_target/tasks/test.yml
@@ -1,7 +1,7 @@
 # Copyright: (c) 2019, Hetzner Cloud GmbH <info@hetzner-cloud.de>
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 ---
-- name: Test missing required parameters
+- name: Test missing required parameters # noqa: args[module]
   hetzner.hcloud.load_balancer_target:
     state: present
   ignore_errors: true

--- a/tests/integration/targets/rdns/tasks/test.yml
+++ b/tests/integration/targets/rdns/tasks/test.yml
@@ -1,7 +1,7 @@
 # Copyright: (c) 2019, Hetzner Cloud GmbH <info@hetzner-cloud.de>
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 ---
-- name: Test missing required parameters
+- name: Test missing required parameters # noqa: args[module]
   hetzner.hcloud.rdns:
     state: present
   ignore_errors: true

--- a/tests/integration/targets/server_network/tasks/test.yml
+++ b/tests/integration/targets/server_network/tasks/test.yml
@@ -1,7 +1,7 @@
 # Copyright: (c) 2019, Hetzner Cloud GmbH <info@hetzner-cloud.de>
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 ---
-- name: Test missing required parameters
+- name: Test missing required parameters # noqa: args[module]
   hetzner.hcloud.server_network:
     state: present
   ignore_errors: true

--- a/tests/integration/targets/subnetwork/tasks/test.yml
+++ b/tests/integration/targets/subnetwork/tasks/test.yml
@@ -1,7 +1,7 @@
 # Copyright: (c) 2019, Hetzner Cloud GmbH <info@hetzner-cloud.de>
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 ---
-- name: Test missing required parameters
+- name: Test missing required parameters # noqa: args[module]
   hetzner.hcloud.subnetwork:
     network: "{{ hcloud_network_name }}"
     state: present


### PR DESCRIPTION
##### SUMMARY

We are testing that the parameters are missing, so we should ignore the linting errors.
