### PR TITLE
test: ensure ansible-lint do not fail for missing api_token

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -54,6 +54,7 @@ repos:
     hooks:
       - id: ansible-lint
         name: ansible-lint
+        entry: env HCLOUD_TOKEN= python3 -m ansiblelint -v --force-color
         args: [--offline]
         additional_dependencies:
           - ansible-core>=2.15


### PR DESCRIPTION
##### SUMMARY

Ansible lint has a rule to check for missing required parameter. This ensure the `api_token` parameter is always set.
