### PR TITLE
feat!: drop support for ansible-core 2.15

### DIFF
--- a/.azure-pipelines/azure-pipelines.yml
+++ b/.azure-pipelines/azure-pipelines.yml
@@ -77,16 +77,6 @@ stages:
             - name: Sanity
               test: 2.16/sanity
 
-  - stage: Sanity_2_15
-    displayName: Sanity 2.15
-    dependsOn: []
-    jobs:
-      - template: templates/matrix.yml
-        parameters:
-          targets:
-            - name: Sanity
-              test: 2.15/sanity
-
   ### Units
   - stage: Units_devel
     displayName: Units devel
@@ -127,16 +117,6 @@ stages:
           targets:
             - name: (py3.10)
               test: 2.16/units/3.10
-
-  - stage: Units_2_15
-    displayName: Units 2.15
-    dependsOn: []
-    jobs:
-      - template: templates/matrix.yml
-        parameters:
-          targets:
-            - name: (py3.9)
-              test: 2.15/units/3.9
 
   ## Integration
   - stage: Integration_devel
@@ -183,17 +163,6 @@ stages:
             - name: (py3.10)
               test: 2.16/integration/3.10
 
-  - stage: Integration_2_15
-    displayName: Integration 2.15
-    dependsOn: []
-    jobs:
-      - template: templates/matrix.yml
-        parameters:
-          groups: [1, 2, 3]
-          targets:
-            - name: (py3.9)
-              test: 2.15/integration/3.9
-
   ### Finally
   - stage: Summary
     condition: succeededOrFailed()
@@ -201,14 +170,11 @@ stages:
       - Sanity_devel
       - Sanity_2_17
       - Sanity_2_16
-      - Sanity_2_15
       - Units_devel
       - Units_2_17
       - Units_2_16
-      - Units_2_15
       - Integration_devel
       - Integration_2_17
       - Integration_2_16
-      - Integration_2_15
     jobs:
       - template: templates/coverage.yml

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -57,7 +57,7 @@ repos:
         entry: env HCLOUD_TOKEN= python3 -m ansiblelint -v --force-color
         args: [--offline]
         additional_dependencies:
-          - ansible-core>=2.15
+          - ansible-core>=2.16
           - netaddr
 
   - repo: local

--- a/changelogs/fragments/drop-support-for-ansible-2.15.yml
+++ b/changelogs/fragments/drop-support-for-ansible-2.15.yml
@@ -1,0 +1,2 @@
+breaking_changes:
+  - Drop support for ansible-core 2.15.

--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -1,4 +1,4 @@
-requires_ansible: ">=2.15.0"
+requires_ansible: ">=2.16.0"
 
 action_groups:
   all:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-ansible-core>=2.15
+ansible-core>=2.16
 
 # Collections requirements
 netaddr

--- a/tests/sanity/ignore-2.15.txt
+++ b/tests/sanity/ignore-2.15.txt
@@ -1,1 +1,0 @@
-plugins/inventory/hcloud.py yamllint:unparsable-with-libyaml # bug in ansible-test - https://github.com/ansible/ansible/issues/82353


### PR DESCRIPTION
##### SUMMARY

ansible-core 2.15 is EOL since Nov 2024.

https://docs.ansible.com/ansible/devel/reference_appendices/release_and_maintenance.html#ansible-core-support-matrix
