### PR TITLE
feat!: drop support for ansible-core 2.16

### DIFF
--- a/.azure-pipelines/azure-pipelines.yml
+++ b/.azure-pipelines/azure-pipelines.yml
@@ -67,16 +67,6 @@ stages:
             - name: Sanity
               test: 2.17/sanity
 
-  - stage: Sanity_2_16
-    displayName: Sanity 2.16
-    dependsOn: []
-    jobs:
-      - template: templates/matrix.yml
-        parameters:
-          targets:
-            - name: Sanity
-              test: 2.16/sanity
-
   ### Units
   - stage: Units_devel
     displayName: Units devel
@@ -107,16 +97,6 @@ stages:
           targets:
             - name: (py3.10)
               test: 2.17/units/3.10
-
-  - stage: Units_2_16
-    displayName: Units 2.16
-    dependsOn: []
-    jobs:
-      - template: templates/matrix.yml
-        parameters:
-          targets:
-            - name: (py3.10)
-              test: 2.16/units/3.10
 
   ## Integration
   - stage: Integration_devel
@@ -152,29 +132,15 @@ stages:
             - name: (py3.10)
               test: 2.17/integration/3.10
 
-  - stage: Integration_2_16
-    displayName: Integration 2.16
-    dependsOn: []
-    jobs:
-      - template: templates/matrix.yml
-        parameters:
-          groups: [1, 2, 3]
-          targets:
-            - name: (py3.10)
-              test: 2.16/integration/3.10
-
   ### Finally
   - stage: Summary
     condition: succeededOrFailed()
     dependsOn:
       - Sanity_devel
       - Sanity_2_17
-      - Sanity_2_16
       - Units_devel
       - Units_2_17
-      - Units_2_16
       - Integration_devel
       - Integration_2_17
-      - Integration_2_16
     jobs:
       - template: templates/coverage.yml

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -57,7 +57,7 @@ repos:
         entry: env HCLOUD_TOKEN= python3 -m ansiblelint -v --force-color
         args: [--offline]
         additional_dependencies:
-          - ansible-core>=2.16
+          - ansible-core>=2.17
           - netaddr
 
   - repo: local

--- a/changelogs/fragments/drop-support-for-ansible-2.16.yml
+++ b/changelogs/fragments/drop-support-for-ansible-2.16.yml
@@ -1,0 +1,2 @@
+breaking_changes:
+  - Drop support for ansible-core 2.16.

--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -1,4 +1,4 @@
-requires_ansible: ">=2.16.0"
+requires_ansible: ">=2.17.0"
 
 action_groups:
   all:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-ansible-core>=2.16
+ansible-core>=2.17
 
 # Collections requirements
 netaddr

--- a/tests/sanity/ignore-2.16.txt
+++ b/tests/sanity/ignore-2.16.txt
@@ -1,1 +1,0 @@
-plugins/inventory/hcloud.py yamllint:unparsable-with-libyaml # bug in ansible-test - https://github.com/ansible/ansible/issues/82353


### PR DESCRIPTION
##### SUMMARY

ansible-core 2.16 will be EOL in May 2025.

https://docs.ansible.com/ansible/devel/reference_appendices/release_and_maintenance.html#ansible-core-support-matrix

We are dropping support for ansible-core 2.16 alongside ansible-core 2.15 to prevent cutting another major release in the next month.


