### PR TITLE
feat: drop support for python 3.8

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -31,7 +31,7 @@ repos:
     rev: v3.19.1
     hooks:
       - id: pyupgrade
-        args: [--py38-plus]
+        args: [--py39-plus]
 
   - repo: https://github.com/pycqa/isort
     rev: 6.0.1

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ For more information about communication, see the [Ansible communication guide](
 
 ## Python version compatibility
 
-This collection depends on the [hcloud](https://github.com/hetznercloud/hcloud-python) library. Due to the [hcloud](https://github.com/hetznercloud/hcloud-python) Python Support Policy this collection requires Python 3.8 or greater.
+This collection depends on the [hcloud](https://github.com/hetznercloud/hcloud-python) library. Due to the [hcloud](https://github.com/hetznercloud/hcloud-python) Python Support Policy this collection requires Python 3.9 or greater.
 
 ## Release notes
 

--- a/changelogs/fragments/drop-support-for-python-3.8.yml
+++ b/changelogs/fragments/drop-support-for-python-3.8.yml
@@ -1,0 +1,2 @@
+breaking_changes:
+  - Drop support for python 3.8.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ combine_as_imports = true
 add_imports = ["from __future__ import annotations"]
 
 [tool.pylint.main]
-py-version = "3.8"
+py-version = "3.9"
 recursive = true
 jobs = 0
 

--- a/tests/config.yml
+++ b/tests/config.yml
@@ -1,3 +1,3 @@
 ---
 modules:
-  python_requires: ">=3.8"
+  python_requires: ">=3.9"


### PR DESCRIPTION
##### SUMMARY

Drop support for python 3.8 which is EOL since Oct 2024.

https://endoflife.date/python

Allow us to upgrade the hcloud-python library.
