### PR TITLE
test: enable --strict on changelog yaml lint

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -48,6 +48,7 @@ repos:
     hooks:
       - id: antsibull-changelog-lint
       - id: antsibull-changelog-lint-changelog-yaml
+        args: [--strict]
 
   - repo: https://github.com/ansible/ansible-lint
     rev: v25.1.3


### PR DESCRIPTION
##### SUMMARY

Enable strict mode when linting the changelog yaml.
