### PR TITLE
feat: ssh_key force re-creation if already exists

### DIFF
--- a/tests/integration/targets/setup_ssh_keypair/tasks/main.yml
+++ b/tests/integration/targets/setup_ssh_keypair/tasks/main.yml
@@ -17,3 +17,15 @@
     path: "{{ _tmp_ssh_key_file.path }}"
     force: true
   register: test_ssh_keypair
+
+- name: Create temporary file for test_ssh_keypair_2
+  ansible.builtin.tempfile:
+    path: ~/tmp
+    suffix: "{{ hcloud_ssh_key_name }}"
+  register: _tmp_ssh_key_file_2
+
+- name: Create test_ssh_keypair_2
+  community.crypto.openssh_keypair:
+    path: "{{ _tmp_ssh_key_file_2.path }}"
+    force: true
+  register: test_ssh_keypair_2

--- a/tests/integration/targets/ssh_key/tasks/test.yml
+++ b/tests/integration/targets/ssh_key/tasks/test.yml
@@ -93,7 +93,7 @@
       key: value
       test: "val123"
   register: result
-- name: test update ssh key  with other labels
+- name: test update ssh key with other labels
   assert:
     that:
       - result is changed
@@ -135,6 +135,31 @@
     that:
       - result is failed
       - result.failure.code == "uniqueness_error"
+
+- name: test force update ssh key with new public key with check mode
+  hetzner.hcloud.ssh_key:
+    name: "{{ hcloud_ssh_key_name }}-other-name"
+    public_key: "{{ test_ssh_keypair_2.public_key }}"
+    force: true
+  register: result
+  check_mode: true
+- name: verify force update ssh key with new public key with check mode
+  assert:
+    that:
+      - result is changed
+
+- name: test force update ssh key with new public key
+  hetzner.hcloud.ssh_key:
+    name: "{{ hcloud_ssh_key_name }}-other-name"
+    public_key: "{{ test_ssh_keypair_2.public_key }}"
+    force: true
+  register: ssh_key
+- name: verify force update ssh key with new public key
+  assert:
+    that:
+      - ssh_key is changed
+      - ssh_key.hcloud_ssh_key.name == "{{ hcloud_ssh_key_name }}-other-name"
+      - ssh_key.hcloud_ssh_key.public_key == test_ssh_keypair_2.public_key
 
 - name: test delete ssh key
   hetzner.hcloud.ssh_key:


### PR DESCRIPTION
##### SUMMARY
Add force option for users to re-create keys if public key with that name already exists.

Fixes: #578 

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
`ssh_key`

##### ADDITIONAL INFORMATION
In Hetzner API, we do not have any public_key change endpoint and only updating names and labels are allowed.
For public_key The only way is removing and re-creating. `force` option allows users to do re-creation if needed. 
