### PR TITLE
fix: remove deprecated force_upgrade argument

### DIFF
--- a/changelogs/fragments/remove-deprecated-argument-force_upgrade.yml
+++ b/changelogs/fragments/remove-deprecated-argument-force_upgrade.yml
@@ -1,0 +1,2 @@
+breaking_changes:
+  - server - The deprecated ``force_upgrade`` argument is removed from the server module. Please use the ``force`` argument instead.

--- a/plugins/modules/server.py
+++ b/plugins/modules/server.py
@@ -118,7 +118,6 @@ options:
             - May power off the server if update is applied.
         type: bool
         default: false
-        aliases: [force_upgrade]
     user_data:
         description:
             - User Data to be passed to the server on creation.
@@ -946,14 +945,7 @@ class AnsibleHCloudServer(AnsibleHCloud):
                 ipv4={"type": "str"},
                 ipv6={"type": "str"},
                 private_networks={"type": "list", "elements": "str", "default": None},
-                force={
-                    "type": "bool",
-                    "default": False,
-                    "aliases": ["force_upgrade"],
-                    "deprecated_aliases": [
-                        {"collection_name": "hetzner.hcloud", "name": "force_upgrade", "version": "5.0.0"}
-                    ],
-                },
+                force={"type": "bool", "default": False},
                 rescue_mode={"type": "str"},
                 delete_protection={"type": "bool"},
                 rebuild_protection={"type": "bool"},


### PR DESCRIPTION
##### SUMMARY

The alias removal was planned for the version 5.0.0, but I forgot to remove the alias before cutting the 5.0.0 release (the sanity check only failed after the release pull request was merged).

Since this is the second time I forgot to remove the deprecated alias, I will cut a patch release, including this breaking change, as soon as possible, so we still consider this part of the 5.0.0 release.

##### ISSUE TYPE

- Bugfix Pull Request


##### COMPONENT NAME

server

