### PR TITLE
test: server placement group idempotency using id

### DIFF
--- a/tests/integration/targets/placement_group/tasks/test.yml
+++ b/tests/integration/targets/placement_group/tasks/test.yml
@@ -103,14 +103,28 @@
       - result.hcloud_server.placement_group == hcloud_placement_group_name
       - result.hcloud_server.status == "running"
 
-- name: test add server to placement group idempotence
+- name: test add server to placement group by name idempotence
   hetzner.hcloud.server:
     name: "{{ hcloud_server_name }}"
     placement_group: "{{ hcloud_placement_group_name }}"
     force: True
     state: present
   register: result
-- name: verify add server to placement group idempotence
+- name: verify add server to placement group by name idempotence
+  assert:
+    that:
+      - result is not changed
+      - result.hcloud_server.placement_group == hcloud_placement_group_name
+      - result.hcloud_server.status == "running"
+
+- name: test add server to placement group by id idempotence
+  hetzner.hcloud.server:
+    name: "{{ hcloud_server_name }}"
+    placement_group: "{{ placement_group.hcloud_placement_group.id}}"
+    force: True
+    state: present
+  register: result
+- name: verify add server to placement group by id idempotence
   assert:
     that:
       - result is not changed


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

Add a test that adding a placement group to a server by ID is idempotent.

Verifies fix for #647

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
server

##### ADDITIONAL INFORMATION

Will pass when the changes introduced in https://github.com/hetznercloud/hcloud-python/pull/504 are available in this module.