### PR TITLE
chore: split dev requirement from runtime requirements

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ vendor-check:
 
 venv:
 	python3 -m venv venv
-	venv/bin/pip install -r requirements.txt
+	venv/bin/pip install -r requirements.txt -r requirements-dev.txt
 
 lint: venv
 	venv/bin/pylint plugins

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,9 @@
+ansible-core>=2.17
+
+# Third party collections requirements
+netaddr
+cryptography
+
+# Development requirements
+pylint
+antsibull-docs>=2.17,<2.18

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,12 +1,2 @@
-ansible-core>=2.17
-
-# Collections requirements
-netaddr
-cryptography
-
 python-dateutil
 requests
-
-# Development requirements
-pylint
-antsibull-docs>=2.17,<2.18


### PR DESCRIPTION
##### SUMMARY

Some users seem to install their requirements using the file in the repository. This ensures they do not install our dev dependencies.
