### PR TITLE
docs: add missing changelog fragment for #647

### DIFF
--- a/changelogs/fragments/server-placement-group-id-idempotency.yml
+++ b/changelogs/fragments/server-placement-group-id-idempotency.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - server - The ``placement_group`` argument now correctly handles placement group IDs during updates.


### PR DESCRIPTION
##### SUMMARY

A changelog fragment was missing when we fixed the bug #647.
