### PR TITLE
chore: add missing dev requirements

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -5,5 +5,7 @@ netaddr
 cryptography
 
 # Development requirements
-pylint
 antsibull-docs>=2.21,<2.22
+pylint
+pytest
+pytest-xdist


### PR DESCRIPTION
##### SUMMARY

Those dependencies were missing from the venv, and are required to run `ansible-test units`
