### PR TITLE
fix: wait for floating ip assign action

### DIFF
--- a/changelogs/fragments/wait-floating-ip-assign-action.yml
+++ b/changelogs/fragments/wait-floating-ip-assign-action.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - floating_ip - Wait for the Floating IP assign action to complete to reduce chances of running into ``locked`` errors.

--- a/plugins/modules/floating_ip.py
+++ b/plugins/modules/floating_ip.py
@@ -242,7 +242,8 @@ class AnsibleHCloudFloatingIP(AnsibleHCloud):
             if server is not None and self.hcloud_floating_ip.server is not None:
                 if self.module.params.get("force") and server != self.hcloud_floating_ip.server.name:
                     if not self.module.check_mode:
-                        self.hcloud_floating_ip.assign(self.client.servers.get_by_name(server))
+                        action = self.hcloud_floating_ip.assign(self.client.servers.get_by_name(server))
+                        action.wait_until_finished()
                         self._mark_as_changed()
                 elif server != self.hcloud_floating_ip.server.name:
                     self.module.warn(
@@ -253,11 +254,13 @@ class AnsibleHCloudFloatingIP(AnsibleHCloud):
                     self._mark_as_changed()
             elif server is not None and self.hcloud_floating_ip.server is None:
                 if not self.module.check_mode:
-                    self.hcloud_floating_ip.assign(self.client.servers.get_by_name(server))
+                    action = self.hcloud_floating_ip.assign(self.client.servers.get_by_name(server))
+                    action.wait_until_finished()
                 self._mark_as_changed()
             elif server is None and self.hcloud_floating_ip.server is not None:
                 if not self.module.check_mode:
-                    self.hcloud_floating_ip.unassign()
+                    action = self.hcloud_floating_ip.unassign()
+                    action.wait_until_finished()
                 self._mark_as_changed()
 
             delete_protection = self.module.params.get("delete_protection")


### PR DESCRIPTION
##### SUMMARY

Wait for the floating ip assign action to complete before continuing. This reduce the chances of running into `locked` errors.


##### ISSUE TYPE

- Bugfix Pull Request


##### COMPONENT NAME
floating_ip
