### PR TITLE
fix: also check server type deprecation after server creation

### DIFF
--- a/changelogs/fragments/server-type-deprecation.yml
+++ b/changelogs/fragments/server-type-deprecation.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - server - Also check server type deprecation after server creation.

--- a/plugins/module_utils/deprecation.py
+++ b/plugins/module_utils/deprecation.py
@@ -18,7 +18,7 @@ def deprecated_server_type_warning(
     module: AnsibleModule,
     server_type: BoundServerType,
     location: BoundLocation | None = None,
-) -> None:
+) -> bool:
     with warnings.catch_warnings():
         warnings.simplefilter("ignore")
         if server_type.deprecation is not None:
@@ -40,7 +40,7 @@ def deprecated_server_type_warning(
                     )
                     + DEPRECATED_EXISTING_SERVERS,
                 )
-            return
+            return True
 
     deprecated_locations: list[ServerTypeLocation] = []
     unavailable_locations: list[ServerTypeLocation] = []
@@ -52,13 +52,13 @@ def deprecated_server_type_warning(
                 unavailable_locations.append(o)
 
     if not deprecated_locations:
-        return
+        return False
 
     # Warn when the server type is deprecated in the given location
     if location:
         found = [o for o in deprecated_locations if location.name == o.location.name]
         if not found:
-            return
+            return False
 
         deprecated_location = found[0]
 
@@ -83,11 +83,11 @@ def deprecated_server_type_warning(
                 + DEPRECATED_EXISTING_SERVERS,
             )
 
-        return
+        return True
 
     # No location given, only warn when all locations are deprecated
     if len(server_type.locations) != len(deprecated_locations):
-        return
+        return False
 
     if unavailable_locations:
 
@@ -122,3 +122,5 @@ def deprecated_server_type_warning(
             )
             + DEPRECATED_EXISTING_SERVERS,
         )
+
+    return True

--- a/plugins/modules/server.py
+++ b/plugins/modules/server.py
@@ -475,7 +475,7 @@ class AnsibleHCloudServer(AnsibleHCloud):
         if self.module.params.get("state") == "stopped" or self.module.params.get("state") == "created":
             params["start_after_create"] = False
 
-        deprecated_server_type_warning(
+        server_type_deprecation_printed = deprecated_server_type_warning(
             self.module,
             server_type,
             server_type_location,
@@ -484,6 +484,14 @@ class AnsibleHCloudServer(AnsibleHCloud):
         if not self.module.check_mode:
             try:
                 resp = self.client.servers.create(**params)
+
+                if not server_type_deprecation_printed:
+                    deprecated_server_type_warning(
+                        self.module,
+                        resp.server.server_type,
+                        resp.server.datacenter.location,
+                    )
+
                 self.result["root_password"] = resp.root_password
                 # Action should take 60 to 90 seconds on average, but can be >10m when creating a
                 # server from a custom images


### PR DESCRIPTION
##### SUMMARY

Because the location of a server is not mandatory for creating a server, we must also check server type deprecation after server creation. 

##### ISSUE TYPE

- Bugfix Pull Request


##### COMPONENT NAME
server


