### PR TITLE
feat!: drop support for Python 3.9

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -31,7 +31,7 @@ repos:
     rev: v3.21.0
     hooks:
       - id: pyupgrade
-        args: [--py39-plus]
+        args: [--py310-plus]
 
   - repo: https://github.com/pycqa/isort
     rev: 7.0.0

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ For more information about communication, see the [Ansible communication guide](
 
 ## Python version compatibility
 
-This collection depends on the [hcloud](https://github.com/hetznercloud/hcloud-python) library. Due to the [hcloud](https://github.com/hetznercloud/hcloud-python) Python Support Policy this collection requires Python 3.9 or greater.
+This collection depends on the [hcloud](https://github.com/hetznercloud/hcloud-python) library. Due to the [hcloud](https://github.com/hetznercloud/hcloud-python) Python Support Policy this collection requires Python 3.10 or greater.
 
 ## Release notes
 

--- a/changelogs/fragments/drop-python-3.9.yml
+++ b/changelogs/fragments/drop-python-3.9.yml
@@ -1,0 +1,2 @@
+breaking_changes:
+  - Drop support for Python 3.9

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ combine_as_imports = true
 add_imports = ["from __future__ import annotations"]
 
 [tool.pylint.main]
-py-version = "3.9"
+py-version = "3.10"
 recursive = true
 jobs = 0
 

--- a/tests/config.yml
+++ b/tests/config.yml
@@ -1,3 +1,3 @@
 ---
 modules:
-  python_requires: ">=3.9"
+  python_requires: ">=3.10"


### PR DESCRIPTION
##### SUMMARY

Drop support for EOL Python 3.9.

https://devguide.python.org/versions/
