### PR TITLE
feat!: drop support for ansible-core 2.17

### DIFF
--- a/.azure-pipelines/azure-pipelines.yml
+++ b/.azure-pipelines/azure-pipelines.yml
@@ -67,16 +67,6 @@ stages:
             - name: Sanity
               test: 2.18/sanity
 
-  - stage: Sanity_2_17
-    displayName: Sanity 2.17
-    dependsOn: []
-    jobs:
-      - template: templates/matrix.yml
-        parameters:
-          targets:
-            - name: Sanity
-              test: 2.17/sanity
-
   ### Units
   - stage: Units_devel
     displayName: Units devel
@@ -107,16 +97,6 @@ stages:
           targets:
             - name: (py3.11)
               test: 2.18/units/3.11
-
-  - stage: Units_2_17
-    displayName: Units 2.17
-    dependsOn: []
-    jobs:
-      - template: templates/matrix.yml
-        parameters:
-          targets:
-            - name: (py3.10)
-              test: 2.17/units/3.10
 
   ## Integration
   - stage: Integration_devel
@@ -152,17 +132,6 @@ stages:
             - name: (py3.11)
               test: 2.18/integration/3.11
 
-  - stage: Integration_2_17
-    displayName: Integration 2.17
-    dependsOn: []
-    jobs:
-      - template: templates/matrix.yml
-        parameters:
-          groups: [1, 2, 3]
-          targets:
-            - name: (py3.10)
-              test: 2.17/integration/3.10
-
   ### Finally
   - stage: Summary
     condition: succeededOrFailed()
@@ -170,14 +139,11 @@ stages:
       - Sanity_devel
       - Sanity_2_19
       - Sanity_2_18
-      - Sanity_2_17
       - Units_devel
       - Units_2_19
       - Units_2_18
-      - Units_2_17
       - Integration_devel
       - Integration_2_19
       - Integration_2_18
-      - Integration_2_17
     jobs:
       - template: templates/coverage.yml

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -58,7 +58,7 @@ repos:
         entry: env HCLOUD_TOKEN= python3 -m ansiblelint -v --force-color
         args: [--offline]
         additional_dependencies:
-          - ansible-core>=2.17
+          - ansible-core>=2.18
           - netaddr
 
   - repo: local

--- a/changelogs/fragments/drop-ansible-core-2.17.yml
+++ b/changelogs/fragments/drop-ansible-core-2.17.yml
@@ -1,0 +1,2 @@
+breaking_changes:
+  - Drop support for ansible-core 2.17

--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -1,4 +1,4 @@
-requires_ansible: ">=2.17.0"
+requires_ansible: ">=2.18.0"
 
 action_groups:
   all:

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,4 @@
-ansible-core>=2.17
+ansible-core>=2.18
 
 # Third party collections requirements
 netaddr


### PR DESCRIPTION
##### SUMMARY

Drop support for ansible-core 2.17 which will be EOL in November 2025.

https://docs.ansible.com/ansible/devel/reference_appendices/release_and_maintenance.html#ansible-core-support-matrix