### PR TITLE
fix: zone rrset idempotency

### DIFF
--- a/changelogs/fragments/zone-rrsets-idempotency.yml
+++ b/changelogs/fragments/zone-rrsets-idempotency.yml
@@ -1,2 +1,3 @@
 bugfixes:
   - zone_rrset - Records order is not guaranteed, the module will not generate a diff if the order of records changes.
+  - zone_rrset - Records without comments will not generate a diff anymore.

--- a/plugins/modules/zone_rrset.py
+++ b/plugins/modules/zone_rrset.py
@@ -199,7 +199,7 @@ class AnsibleHCloudZoneRRSet(AnsibleHCloud):
     def _prepare_result_record(self, record: ZoneRecord):
         return {
             "value": record.value,
-            "comment": record.comment,
+            "comment": record.comment or "",  # API defaults to "", this ensure idempotency
         }
 
     def _get(self):

--- a/plugins/modules/zone_rrset_info.py
+++ b/plugins/modules/zone_rrset_info.py
@@ -154,7 +154,7 @@ class AnsibleHCloudZoneRRSetInfo(AnsibleHCloud):
     def _prepare_result_record(self, record: ZoneRecord):
         return {
             "value": record.value,
-            "comment": record.comment,
+            "comment": record.comment or "",
         }
 
     def get_zone_rrsets(self):

--- a/tests/integration/targets/zone_rrset/tasks/test.yml
+++ b/tests/integration/targets/zone_rrset/tasks/test.yml
@@ -91,6 +91,7 @@
       key: changed
       new: value
     records:
+      - value: 201.118.10.10 # No comment
       - value: 201.118.10.11
         comment: web server 1
       - value: 201.118.10.13
@@ -107,11 +108,13 @@
       - result.hcloud_zone_rrset.labels.key == "changed"
       - result.hcloud_zone_rrset.labels.new == "value"
       - result.hcloud_zone_rrset.change_protection == true
-      - result.hcloud_zone_rrset.records | count == 2
-      - result.hcloud_zone_rrset.records[0].value == "201.118.10.11"
-      - result.hcloud_zone_rrset.records[0].comment == "web server 1"
-      - result.hcloud_zone_rrset.records[1].value == "201.118.10.13"
-      - result.hcloud_zone_rrset.records[1].comment == "web server 3"
+      - result.hcloud_zone_rrset.records | count == 3
+      - result.hcloud_zone_rrset.records[0].value == "201.118.10.10"
+      - result.hcloud_zone_rrset.records[0].comment == ""
+      - result.hcloud_zone_rrset.records[1].value == "201.118.10.11"
+      - result.hcloud_zone_rrset.records[1].comment == "web server 1"
+      - result.hcloud_zone_rrset.records[2].value == "201.118.10.13"
+      - result.hcloud_zone_rrset.records[2].comment == "web server 3"
 
 - name: Test update idempotency
   hetzner.hcloud.zone_rrset:
@@ -123,6 +126,7 @@
       key: changed
       new: value
     records:
+      - value: 201.118.10.10 # No comment
       # Order is not guaranteed, should still be idempotent
       - value: 201.118.10.13
         comment: web server 3


### PR DESCRIPTION
##### SUMMARY

- The order of dns records is not guaranteed, this ensure the module is idempotent.
- The API defaults to an empty string when comments are not set, ensure the module is idempotent when no comments are given.

##### ISSUE TYPE

- Bugfix

Closes #740 
