### PR TITLE
test: extract ansible-lint to ci job

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -23,3 +23,12 @@ jobs:
 
       - name: Lint docs
         run: make lint-docs
+
+  ansible-lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: ansible/ansible-lint@v25.11.0
+        env:
+          HCLOUD_TOKEN: ""

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -50,17 +50,6 @@ repos:
       - id: antsibull-changelog-lint-changelog-yaml
         args: [--strict]
 
-  - repo: https://github.com/ansible/ansible-lint
-    rev: v25.11.0
-    hooks:
-      - id: ansible-lint
-        name: ansible-lint
-        entry: env HCLOUD_TOKEN= python3 -m ansiblelint -v --force-color
-        args: [--offline]
-        additional_dependencies:
-          - ansible-core>=2.18
-          - netaddr
-
   - repo: local
     hooks:
       - id: shfmt


### PR DESCRIPTION
##### SUMMARY

Extract ansible-lint to a CI job to speed up pre-commit.
