### PR TITLE
chore: allow checking if a param was defined by the user

### DIFF
--- a/plugins/module_utils/hcloud.py
+++ b/plugins/module_utils/hcloud.py
@@ -27,7 +27,6 @@ from .vendor.hcloud.actions import ActionException
 from .version import version
 
 
-# Provide typing definitions to the AnsibleModule class
 class AnsibleModule(AnsibleModuleBase):
     params: dict
     params_raw: dict


### PR DESCRIPTION

##### SUMMARY

Use `self.module.param_is_defined("key")` to check if the parameter was defined by the user, useful when null values have a meaning.

