### PR TITLE
docs: do not use `type: complex` for return values

### DIFF
--- a/plugins/modules/certificate.py
+++ b/plugins/modules/certificate.py
@@ -105,7 +105,7 @@ RETURN = """
 hcloud_certificate:
     description: The certificate instance
     returned: Always
-    type: complex
+    type: dict
     contains:
         id:
             description: Numeric identifier of the certificate

--- a/plugins/modules/certificate_info.py
+++ b/plugins/modules/certificate_info.py
@@ -46,7 +46,7 @@ RETURN = """
 hcloud_certificate_info:
     description: The certificate instances
     returned: Always
-    type: complex
+    type: list
     contains:
         id:
             description: Numeric identifier of the certificate

--- a/plugins/modules/datacenter_info.py
+++ b/plugins/modules/datacenter_info.py
@@ -65,7 +65,7 @@ hcloud_datacenter_info:
     description:
       - The datacenter info as list
     returned: always
-    type: complex
+    type: list
     contains:
         id:
             description: Numeric identifier of the datacenter

--- a/plugins/modules/floating_ip.py
+++ b/plugins/modules/floating_ip.py
@@ -108,7 +108,7 @@ RETURN = """
 hcloud_floating_ip:
     description: The Floating IP instance
     returned: Always
-    type: complex
+    type: dict
     contains:
         id:
             description: ID of the Floating IP

--- a/plugins/modules/floating_ip_info.py
+++ b/plugins/modules/floating_ip_info.py
@@ -50,7 +50,7 @@ RETURN = """
 hcloud_floating_ip_info:
     description: The Floating ip infos as list
     returned: always
-    type: complex
+    type: list
     contains:
         id:
             description: Numeric identifier of the Floating IP

--- a/plugins/modules/image_info.py
+++ b/plugins/modules/image_info.py
@@ -63,7 +63,7 @@ RETURN = """
 hcloud_image_info:
     description: The image infos as list
     returned: always
-    type: complex
+    type: list
     contains:
         id:
             description: Numeric identifier of the image

--- a/plugins/modules/iso_info.py
+++ b/plugins/modules/iso_info.py
@@ -59,7 +59,7 @@ RETURN = """
 hcloud_iso_info:
     description: The ISO type infos as list
     returned: always
-    type: complex
+    type: list
     contains:
         id:
             description: ID of the ISO

--- a/plugins/modules/load_balancer.py
+++ b/plugins/modules/load_balancer.py
@@ -93,7 +93,7 @@ RETURN = """
 hcloud_load_balancer:
     description: The Load Balancer instance
     returned: Always
-    type: complex
+    type: dict
     contains:
         id:
             description: Numeric identifier of the Load Balancer

--- a/plugins/modules/load_balancer_info.py
+++ b/plugins/modules/load_balancer_info.py
@@ -52,7 +52,7 @@ RETURN = """
 hcloud_load_balancer_info:
     description: The load_balancer infos as list
     returned: always
-    type: complex
+    type: list
     contains:
         id:
             description: Numeric identifier of the Load Balancer
@@ -101,7 +101,7 @@ hcloud_load_balancer_info:
         targets:
             description: The targets of the Load Balancer
             returned: always
-            type: complex
+            type: list
             contains:
                 type:
                     description: Type of the Load Balancer Target
@@ -155,7 +155,7 @@ hcloud_load_balancer_info:
         services:
             description: all services from this Load Balancer
             returned: Always
-            type: complex
+            type: list
             contains:
                 listen_port:
                     description: The port the service listens on, i.e. the port users can connect to.
@@ -182,7 +182,7 @@ hcloud_load_balancer_info:
                 http:
                     description: Configuration for HTTP and HTTPS services
                     returned: always
-                    type: complex
+                    type: dict
                     contains:
                         cookie_name:
                             description: Name of the cookie which will be set when you enable sticky sessions
@@ -212,7 +212,7 @@ hcloud_load_balancer_info:
                 health_check:
                     description: Configuration for health checks
                     returned: always
-                    type: complex
+                    type: dict
                     contains:
                         protocol:
                             description: Protocol the health checks will be performed over
@@ -242,7 +242,7 @@ hcloud_load_balancer_info:
                         http:
                             description: Additional Configuration of health checks with protocol http/https
                             returned: always
-                            type: complex
+                            type: dict
                             contains:
                                 domain:
                                     description: Domain we will set within the HTTP HOST header

--- a/plugins/modules/load_balancer_network.py
+++ b/plugins/modules/load_balancer_network.py
@@ -81,7 +81,7 @@ RETURN = """
 hcloud_load_balancer_network:
     description: The relationship between a Load Balancer and a network
     returned: always
-    type: complex
+    type: dict
     contains:
         network:
             description: Name of the Network

--- a/plugins/modules/load_balancer_service.py
+++ b/plugins/modules/load_balancer_service.py
@@ -157,7 +157,7 @@ RETURN = """
 hcloud_load_balancer_service:
     description: The Load Balancer service instance
     returned: Always
-    type: complex
+    type: dict
     contains:
         load_balancer:
             description: The name of the Load Balancer where the service belongs to
@@ -189,7 +189,7 @@ hcloud_load_balancer_service:
         http:
             description: Configuration for HTTP and HTTPS services
             returned: always
-            type: complex
+            type: dict
             contains:
                 cookie_name:
                     description: Name of the cookie which will be set when you enable sticky sessions
@@ -219,7 +219,7 @@ hcloud_load_balancer_service:
         health_check:
             description: Configuration for health checks
             returned: always
-            type: complex
+            type: dict
             contains:
                 protocol:
                     description: Protocol the health checks will be performed over
@@ -249,7 +249,7 @@ hcloud_load_balancer_service:
                 http:
                     description: Additional Configuration of health checks with protocol http/https
                     returned: always
-                    type: complex
+                    type: dict
                     contains:
                         domain:
                             description: Domain we will set within the HTTP HOST header

--- a/plugins/modules/load_balancer_target.py
+++ b/plugins/modules/load_balancer_target.py
@@ -97,7 +97,7 @@ RETURN = """
 hcloud_load_balancer_target:
     description: The relationship between a Load Balancer and a network
     returned: always
-    type: complex
+    type: dict
     contains:
         type:
             description: Type of the Load Balancer Target

--- a/plugins/modules/load_balancer_type_info.py
+++ b/plugins/modules/load_balancer_type_info.py
@@ -48,7 +48,7 @@ RETURN = """
 hcloud_load_balancer_type_info:
     description: The Load Balancer type infos as list
     returned: always
-    type: complex
+    type: list
     contains:
         id:
             description: Numeric identifier of the Load Balancer type

--- a/plugins/modules/location_info.py
+++ b/plugins/modules/location_info.py
@@ -48,7 +48,7 @@ RETURN = """
 hcloud_location_info:
     description: The location infos as list
     returned: always
-    type: complex
+    type: list
     contains:
         id:
             description: Numeric identifier of the location

--- a/plugins/modules/network.py
+++ b/plugins/modules/network.py
@@ -77,7 +77,7 @@ RETURN = """
 hcloud_network:
     description: The Network
     returned: always
-    type: complex
+    type: dict
     contains:
         id:
             description: ID of the Network

--- a/plugins/modules/network_info.py
+++ b/plugins/modules/network_info.py
@@ -52,7 +52,7 @@ RETURN = """
 hcloud_network_info:
     description: The network info as list
     returned: always
-    type: complex
+    type: list
     contains:
         id:
             description: Numeric identifier of the network
@@ -72,7 +72,7 @@ hcloud_network_info:
         subnetworks:
             description: Subnetworks belonging to the network
             returned: always
-            type: complex
+            type: list
             contains:
                 type:
                     description: Type of the subnetwork.
@@ -97,7 +97,7 @@ hcloud_network_info:
         routes:
             description: Routes belonging to the network
             returned: always
-            type: complex
+            type: list
             contains:
                 ip_range:
                     description: Destination network or host of this route.
@@ -117,7 +117,7 @@ hcloud_network_info:
         servers:
             description: Servers attached to the network
             returned: always
-            type: complex
+            type: list
             contains:
                 id:
                     description: Numeric identifier of the server

--- a/plugins/modules/placement_group.py
+++ b/plugins/modules/placement_group.py
@@ -75,7 +75,7 @@ RETURN = """
 hcloud_placement_group:
     description: The placement group instance
     returned: Always
-    type: complex
+    type: dict
     contains:
         id:
             description: Numeric identifier of the placement group

--- a/plugins/modules/primary_ip.py
+++ b/plugins/modules/primary_ip.py
@@ -112,7 +112,7 @@ RETURN = """
 hcloud_primary_ip:
     description: The Primary IP instance
     returned: Always
-    type: complex
+    type: dict
     contains:
         id:
             description: ID of the Primary IP

--- a/plugins/modules/primary_ip_info.py
+++ b/plugins/modules/primary_ip_info.py
@@ -67,7 +67,7 @@ RETURN = """
 hcloud_primary_ip_info:
     description: The Primary IP infos as list
     returned: always
-    type: complex
+    type: list
     contains:
         id:
             description: Numeric identifier of the Primary IP

--- a/plugins/modules/rdns.py
+++ b/plugins/modules/rdns.py
@@ -98,7 +98,7 @@ RETURN = """
 hcloud_rdns:
     description: The reverse DNS entry
     returned: always
-    type: complex
+    type: dict
     contains:
         server:
             description: Name of the server

--- a/plugins/modules/route.py
+++ b/plugins/modules/route.py
@@ -66,7 +66,7 @@ RETURN = """
 hcloud_route:
     description: One Route of a Network
     returned: always
-    type: complex
+    type: dict
     contains:
         network:
             description: Name of the Network

--- a/plugins/modules/server.py
+++ b/plugins/modules/server.py
@@ -242,7 +242,7 @@ RETURN = """
 hcloud_server:
     description: The server instance
     returned: Always
-    type: complex
+    type: dict
     contains:
         id:
             description: Numeric identifier of the server

--- a/plugins/modules/server_info.py
+++ b/plugins/modules/server_info.py
@@ -52,7 +52,7 @@ RETURN = """
 hcloud_server_info:
     description: The server infos as list
     returned: always
-    type: complex
+    type: list
     contains:
         id:
             description: Numeric identifier of the server

--- a/plugins/modules/server_network.py
+++ b/plugins/modules/server_network.py
@@ -96,7 +96,7 @@ RETURN = """
 hcloud_server_network:
     description: The relationship between a server and a network
     returned: always
-    type: complex
+    type: dict
     contains:
         network:
             description: Name of the Network

--- a/plugins/modules/server_type_info.py
+++ b/plugins/modules/server_type_info.py
@@ -48,7 +48,7 @@ RETURN = """
 hcloud_server_type_info:
     description: The server type infos as list
     returned: always
-    type: complex
+    type: list
     contains:
         id:
             description: Numeric identifier of the server type

--- a/plugins/modules/ssh_key.py
+++ b/plugins/modules/ssh_key.py
@@ -86,7 +86,7 @@ RETURN = """
 hcloud_ssh_key:
     description: The ssh_key instance
     returned: Always
-    type: complex
+    type: dict
     contains:
         id:
             description: ID of the ssh_key

--- a/plugins/modules/ssh_key_info.py
+++ b/plugins/modules/ssh_key_info.py
@@ -50,7 +50,7 @@ RETURN = """
 hcloud_ssh_key_info:
     description: The ssh key instances
     returned: Always
-    type: complex
+    type: list
     contains:
         id:
             description: Numeric identifier of the ssh_key

--- a/plugins/modules/subnetwork.py
+++ b/plugins/modules/subnetwork.py
@@ -88,7 +88,7 @@ RETURN = """
 hcloud_subnetwork:
     description: One Subnet of a Network
     returned: always
-    type: complex
+    type: dict
     contains:
         network:
             description: Name of the Network

--- a/plugins/modules/volume.py
+++ b/plugins/modules/volume.py
@@ -111,7 +111,7 @@ RETURN = """
 hcloud_volume:
     description: The block Volume
     returned: Always
-    type: complex
+    type: dict
     contains:
         id:
             description: ID of the Volume

--- a/plugins/modules/volume_attachment.py
+++ b/plugins/modules/volume_attachment.py
@@ -68,7 +68,7 @@ RETURN = """
 hcloud_volume_attachment:
     description: The relationship between a Server and a Volume
     returned: always
-    type: complex
+    type: dict
     contains:
         volume:
             description: Name of the Volume

--- a/plugins/modules/volume_info.py
+++ b/plugins/modules/volume_info.py
@@ -50,7 +50,7 @@ RETURN = """
 hcloud_volume_info:
     description: The Volume infos as list
     returned: always
-    type: complex
+    type: list
     contains:
         id:
             description: Numeric identifier of the Volume


### PR DESCRIPTION
##### SUMMARY

Improve return documentation by documenting the real type of the return values.
