### PR TITLE
ci: spread integration test over 5 groups

### DIFF
--- a/.azure-pipelines/azure-pipelines.yml
+++ b/.azure-pipelines/azure-pipelines.yml
@@ -125,7 +125,7 @@ stages:
     jobs:
       - template: templates/matrix.yml
         parameters:
-          groups: [1, 2, 3]
+          groups: [1, 2, 3, 4, 5]
           targets:
             - name: (py3.14)
               test: devel/integration/3.14
@@ -136,7 +136,7 @@ stages:
     jobs:
       - template: templates/matrix.yml
         parameters:
-          groups: [1, 2, 3]
+          groups: [1, 2, 3, 4, 5]
           targets:
             - name: (py3.12)
               test: 2.20/integration/3.12
@@ -147,7 +147,7 @@ stages:
     jobs:
       - template: templates/matrix.yml
         parameters:
-          groups: [1, 2, 3]
+          groups: [1, 2, 3, 4, 5]
           targets:
             - name: (py3.11)
               test: 2.19/integration/3.11
@@ -158,7 +158,7 @@ stages:
     jobs:
       - template: templates/matrix.yml
         parameters:
-          groups: [1, 2, 3]
+          groups: [1, 2, 3, 4, 5]
           targets:
             - name: (py3.11)
               test: 2.18/integration/3.11

--- a/tests/integration/targets/certificate/aliases
+++ b/tests/integration/targets/certificate/aliases
@@ -1,3 +1,3 @@
 cloud/hcloud
 gather_facts/no
-azp/group2
+azp/group1

--- a/tests/integration/targets/certificate_info/aliases
+++ b/tests/integration/targets/certificate_info/aliases
@@ -1,3 +1,3 @@
 cloud/hcloud
 gather_facts/no
-azp/group2
+azp/group1

--- a/tests/integration/targets/datacenter_info/aliases
+++ b/tests/integration/targets/datacenter_info/aliases
@@ -1,3 +1,3 @@
 cloud/hcloud
 gather_facts/no
-azp/group2
+azp/group3

--- a/tests/integration/targets/filter_all/aliases
+++ b/tests/integration/targets/filter_all/aliases
@@ -1,3 +1,3 @@
 cloud/hcloud
 gather_facts/no
-azp/group2
+azp/group3

--- a/tests/integration/targets/firewall/aliases
+++ b/tests/integration/targets/firewall/aliases
@@ -1,3 +1,3 @@
 cloud/hcloud
 gather_facts/no
-azp/group2
+azp/group4

--- a/tests/integration/targets/firewall_info/aliases
+++ b/tests/integration/targets/firewall_info/aliases
@@ -1,3 +1,3 @@
 cloud/hcloud
 gather_facts/no
-azp/group2
+azp/group4

--- a/tests/integration/targets/firewall_resource/aliases
+++ b/tests/integration/targets/firewall_resource/aliases
@@ -1,3 +1,3 @@
 cloud/hcloud
 gather_facts/no
-azp/group1
+azp/group4

--- a/tests/integration/targets/image_info/aliases
+++ b/tests/integration/targets/image_info/aliases
@@ -1,3 +1,3 @@
 cloud/hcloud
 gather_facts/no
-azp/group2
+azp/group4

--- a/tests/integration/targets/iso_info/aliases
+++ b/tests/integration/targets/iso_info/aliases
@@ -1,3 +1,3 @@
 cloud/hcloud
 gather_facts/no
-azp/group3
+azp/group5

--- a/tests/integration/targets/load_balancer/aliases
+++ b/tests/integration/targets/load_balancer/aliases
@@ -1,3 +1,3 @@
 cloud/hcloud
 gather_facts/no
-azp/group1
+azp/group2

--- a/tests/integration/targets/load_balancer_info/aliases
+++ b/tests/integration/targets/load_balancer_info/aliases
@@ -1,3 +1,3 @@
 cloud/hcloud
 gather_facts/no
-azp/group1
+azp/group2

--- a/tests/integration/targets/load_balancer_network/aliases
+++ b/tests/integration/targets/load_balancer_network/aliases
@@ -1,3 +1,3 @@
 cloud/hcloud
 gather_facts/no
-azp/group1
+azp/group2

--- a/tests/integration/targets/load_balancer_service/aliases
+++ b/tests/integration/targets/load_balancer_service/aliases
@@ -1,3 +1,3 @@
 cloud/hcloud
 gather_facts/no
-azp/group1
+azp/group2

--- a/tests/integration/targets/load_balancer_target/aliases
+++ b/tests/integration/targets/load_balancer_target/aliases
@@ -1,3 +1,3 @@
 cloud/hcloud
 gather_facts/no
-azp/group1
+azp/group2

--- a/tests/integration/targets/network/aliases
+++ b/tests/integration/targets/network/aliases
@@ -1,3 +1,3 @@
 cloud/hcloud
 gather_facts/no
-azp/group1
+azp/group3

--- a/tests/integration/targets/network_info/aliases
+++ b/tests/integration/targets/network_info/aliases
@@ -1,3 +1,3 @@
 cloud/hcloud
 gather_facts/no
-azp/group1
+azp/group3

--- a/tests/integration/targets/placement_group/aliases
+++ b/tests/integration/targets/placement_group/aliases
@@ -1,3 +1,3 @@
 cloud/hcloud
 gather_facts/no
-azp/group2
+azp/group4

--- a/tests/integration/targets/rdns/aliases
+++ b/tests/integration/targets/rdns/aliases
@@ -1,3 +1,3 @@
 cloud/hcloud
 gather_facts/no
-azp/group1
+azp/group3

--- a/tests/integration/targets/route/aliases
+++ b/tests/integration/targets/route/aliases
@@ -1,3 +1,3 @@
 cloud/hcloud
 gather_facts/no
-azp/group1
+azp/group3

--- a/tests/integration/targets/server/aliases
+++ b/tests/integration/targets/server/aliases
@@ -1,3 +1,3 @@
 cloud/hcloud
 gather_facts/no
-azp/group3
+azp/group4

--- a/tests/integration/targets/server_info/aliases
+++ b/tests/integration/targets/server_info/aliases
@@ -1,3 +1,3 @@
 cloud/hcloud
 gather_facts/no
-azp/group2
+azp/group4

--- a/tests/integration/targets/server_network/aliases
+++ b/tests/integration/targets/server_network/aliases
@@ -1,3 +1,3 @@
 cloud/hcloud
 gather_facts/no
-azp/group2
+azp/group4

--- a/tests/integration/targets/server_type_info/aliases
+++ b/tests/integration/targets/server_type_info/aliases
@@ -1,3 +1,3 @@
 cloud/hcloud
 gather_facts/no
-azp/group2
+azp/group4

--- a/tests/integration/targets/ssh_key/aliases
+++ b/tests/integration/targets/ssh_key/aliases
@@ -1,3 +1,3 @@
 cloud/hcloud
 gather_facts/no
-azp/group2
+azp/group4

--- a/tests/integration/targets/ssh_key_info/aliases
+++ b/tests/integration/targets/ssh_key_info/aliases
@@ -1,3 +1,3 @@
 cloud/hcloud
 gather_facts/no
-azp/group2
+azp/group4

--- a/tests/integration/targets/storage_box/aliases
+++ b/tests/integration/targets/storage_box/aliases
@@ -1,3 +1,3 @@
 cloud/hcloud
 gather_facts/no
-azp/group2
+azp/group5

--- a/tests/integration/targets/storage_box_info/aliases
+++ b/tests/integration/targets/storage_box_info/aliases
@@ -1,3 +1,3 @@
 cloud/hcloud
 gather_facts/no
-azp/group2
+azp/group5

--- a/tests/integration/targets/storage_box_snapshot/aliases
+++ b/tests/integration/targets/storage_box_snapshot/aliases
@@ -1,3 +1,3 @@
 cloud/hcloud
 gather_facts/no
-azp/group2
+azp/group5

--- a/tests/integration/targets/storage_box_snapshot_info/aliases
+++ b/tests/integration/targets/storage_box_snapshot_info/aliases
@@ -1,3 +1,3 @@
 cloud/hcloud
 gather_facts/no
-azp/group2
+azp/group5

--- a/tests/integration/targets/storage_box_subaccount/aliases
+++ b/tests/integration/targets/storage_box_subaccount/aliases
@@ -1,3 +1,3 @@
 cloud/hcloud
 gather_facts/no
-azp/group2
+azp/group5

--- a/tests/integration/targets/storage_box_subaccount_info/aliases
+++ b/tests/integration/targets/storage_box_subaccount_info/aliases
@@ -1,3 +1,3 @@
 cloud/hcloud
 gather_facts/no
-azp/group2
+azp/group5

--- a/tests/integration/targets/storage_box_type_info/aliases
+++ b/tests/integration/targets/storage_box_type_info/aliases
@@ -1,3 +1,3 @@
 cloud/hcloud
 gather_facts/no
-azp/group2
+azp/group5

--- a/tests/integration/targets/volume/aliases
+++ b/tests/integration/targets/volume/aliases
@@ -1,3 +1,3 @@
 cloud/hcloud
 gather_facts/no
-azp/group2
+azp/group5

--- a/tests/integration/targets/volume_attachment/aliases
+++ b/tests/integration/targets/volume_attachment/aliases
@@ -1,3 +1,3 @@
 cloud/hcloud
 gather_facts/no
-azp/group2
+azp/group5

--- a/tests/integration/targets/volume_info/aliases
+++ b/tests/integration/targets/volume_info/aliases
@@ -1,3 +1,3 @@
 cloud/hcloud
 gather_facts/no
-azp/group2
+azp/group5

--- a/tests/integration/targets/zone/aliases
+++ b/tests/integration/targets/zone/aliases
@@ -1,3 +1,3 @@
 cloud/hcloud
 gather_facts/no
-azp/group2
+azp/group1

--- a/tests/integration/targets/zone_info/aliases
+++ b/tests/integration/targets/zone_info/aliases
@@ -1,3 +1,3 @@
 cloud/hcloud
 gather_facts/no
-azp/group2
+azp/group1

--- a/tests/integration/targets/zone_rrset/aliases
+++ b/tests/integration/targets/zone_rrset/aliases
@@ -1,3 +1,3 @@
 cloud/hcloud
 gather_facts/no
-azp/group2
+azp/group1

--- a/tests/integration/targets/zone_rrset_info/aliases
+++ b/tests/integration/targets/zone_rrset_info/aliases
@@ -1,3 +1,3 @@
 cloud/hcloud
 gather_facts/no
-azp/group2
+azp/group1


### PR DESCRIPTION
##### SUMMARY

:rocket: Increase the number of groups from 3 to 5 to increase concurrency. And re-shuffle the tests in different groups.
