### PR TITLE
docs: add note that server.user_data is used by cloud-init

### DIFF
--- a/plugins/modules/server.py
+++ b/plugins/modules/server.py
@@ -124,7 +124,8 @@ options:
         default: false
     user_data:
         description:
-            - cloud-init user data to be passed to the server on creation.
+            - User Data to be passed to the server on creation.
+            - C(cloud-init), C(ignition) or similar provisioning tools may retrieve user configuration from the Server's C(user_data).
             - Only used during the server creation.
         type: str
     rescue_mode:


### PR DESCRIPTION
##### SUMMARY
I was looking for "cloud" or "cloud-init" within the documentation without any luck. Maybe this will help someone else finding the appropriate option.

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
`hetzner.hcloud.server`
