### PR TITLE
feat: add name to Storage Box Subaccount

### DIFF
--- a/changelogs/fragments/storage-box-subaccount-api-name.yml
+++ b/changelogs/fragments/storage-box-subaccount-api-name.yml
@@ -1,0 +1,3 @@
+minor_changes:
+  - storage_box_subaccount - Replace the label based name workaround, with the new Storage Box Subaccount name property in the API.
+  - storage_box_subaccount_info - Replace the label based name workaround, with the new Storage Box Subaccount name property in the API.

--- a/plugins/module_utils/_storage_box_subaccount.py
+++ b/plugins/module_utils/_storage_box_subaccount.py
@@ -11,26 +11,23 @@ from ._vendor.hcloud.storage_boxes import (
 NAME_LABEL_KEY = "ansible-name"
 
 
-def get_by_name(storage_box: BoundStorageBox, name: str):
-    if not name:
-        raise ValueError(f"invalid storage box subaccount name: '{name}'")
-
+def get_by_label_name(storage_box: BoundStorageBox, name: str):
+    """
+    Kept for backward compatible upgrade from label based name.
+    """
     result = storage_box.get_subaccount_list(
         label_selector=f"{NAME_LABEL_KEY}={name}",
     )
-    if len(result.subaccounts) == 0:
-        return None
     if len(result.subaccounts) == 1:
         return result.subaccounts[0]
+    return None
 
-    raise ValueError(f"found multiple storage box subaccount with the same name: {name}")
 
-
-def prepare_result(o: BoundStorageBoxSubaccount, name: str):
+def prepare_result(o: BoundStorageBoxSubaccount):
     return {
         "storage_box": o.storage_box.id,
         "id": o.id,
-        "name": name,
+        "name": o.name,
         "description": o.description,
         "username": o.username,
         "home_directory": o.home_directory,


### PR DESCRIPTION
##### SUMMARY

Replaces the label based name workaround for Storage Box Subaccounts, with the new Storage Box Subaccount name property managed in the API.

##### ISSUE TYPE

- Feature Pull Request


##### COMPONENT NAME

- `storage_box_subaccount`
- `storage_box_subaccount_info`
