### PR TITLE
feat(datacenter, server_type): move available and recommended to server_type

### DIFF
--- a/changelogs/fragments/server-type-available-recommended.yml
+++ b/changelogs/fragments/server-type-available-recommended.yml
@@ -1,0 +1,3 @@
+minor_changes:
+  - datacenter_info - The server_types property has been deprecated
+  - server_type_info - ``available`` and ``recommended`` properties have been added to the locations list

--- a/changelogs/fragments/server-type-available-recommended.yml
+++ b/changelogs/fragments/server-type-available-recommended.yml
@@ -1,3 +1,14 @@
 minor_changes:
-  - datacenter_info - The server_types property has been deprecated
-  - server_type_info - ``available`` and ``recommended`` properties have been added to the locations list
+  - server_type_info - Added the Server Type Location ``available`` property to the return values (``hcloud_server_type_info[].locations[].available``).
+  - server_type_info - Added the Server Type Location ``recommended`` property to the return values (``hcloud_server_type_info[].locations[].recommended``).
+deprecated_features:
+  - datacenter_info - The ``hcloud_datacenter_info[].server_types`` return value
+    is deprecated and will be removed after 1 October 2026. Please use the ``hcloud_server_type_info[].locations[].available``
+    return value instead.
+release_summary: |
+  Server Types availability and recommendation details moved from the
+  ``datacenter_info`` module to the ``server_type_info`` module.
+
+  See our `changelog`_ for more details.
+
+  .. _changelog: https://docs.hetzner.cloud/changelog#2026-04-01-datacenter-deprecations

--- a/plugins/modules/datacenter_info.py
+++ b/plugins/modules/datacenter_info.py
@@ -96,8 +96,8 @@ hcloud_datacenter_info:
             description: |
                 The Server types the Datacenter can handle
 
-                B(Deprecated:) The RV(hcloud_datacenter_info.server_types) value is deprecated and will be removed
-                after 1 October 2026. Please use the RV(server_type_info.locations) value instead.
+                B(Deprecated:) The RV(hcloud_datacenter_info[].server_types) value is deprecated and will be removed
+                after 1 October 2026. Please use the RV(hetzner.hcloud.server_type_info#module:hcloud_server_type_info[].locations) value instead.
                 See https://docs.hetzner.cloud/changelog#2026-04-01-datacenter-deprecations.
             returned: always
             type: dict

--- a/plugins/modules/datacenter_info.py
+++ b/plugins/modules/datacenter_info.py
@@ -93,7 +93,12 @@ hcloud_datacenter_info:
             type: str
             sample: fsn1
         server_types:
-            description: The Server types the Datacenter can handle
+            description: |
+                The Server types the Datacenter can handle
+
+                B(Deprecated:) The RV(hcloud_datacenter_info.server_types) value is deprecated and will be removed
+                after 1 October 2026. Please use the RV(server_type_info.locations) value instead.
+                See https://docs.hetzner.cloud/changelog#2026-04-01-datacenter-deprecations.
             returned: always
             type: dict
             contains:
@@ -136,19 +141,19 @@ class AnsibleHCloudDatacenterInfo(AnsibleHCloud):
             if datacenter is None:
                 continue
 
-            tmp.append(
-                {
-                    "id": datacenter.id,
-                    "name": datacenter.name,
-                    "description": datacenter.description,
-                    "location": datacenter.location.name,
-                    "server_types": {
-                        "available": [o.id for o in datacenter.server_types.available],
-                        "available_for_migration": [o.id for o in datacenter.server_types.available_for_migration],
-                        "supported": [o.id for o in datacenter.server_types.supported],
-                    },
+            dc: dict[str, object] = {
+                "id": datacenter.id,
+                "name": datacenter.name,
+                "description": datacenter.description,
+                "location": datacenter.location.name,
+            }
+            if datacenter.server_types is not None:
+                dc["server_types"] = {
+                    "available": [o.id for o in datacenter.server_types.available],
+                    "available_for_migration": [o.id for o in datacenter.server_types.available_for_migration],
+                    "supported": [o.id for o in datacenter.server_types.supported],
                 }
-            )
+            tmp.append(dc)
 
         return tmp
 

--- a/plugins/modules/datacenter_info.py
+++ b/plugins/modules/datacenter_info.py
@@ -94,7 +94,7 @@ hcloud_datacenter_info:
             sample: fsn1
         server_types:
             description: |
-                The Server types the Datacenter can handle
+                The Server types the Datacenter can handle.
 
                 B(Deprecated:) The RV(hcloud_datacenter_info[].server_types) value is deprecated and will be removed
                 after 1 October 2026. Please use the RV(hetzner.hcloud.server_type_info#module:hcloud_server_type_info[].locations) value instead.

--- a/plugins/modules/datacenter_info.py
+++ b/plugins/modules/datacenter_info.py
@@ -141,19 +141,19 @@ class AnsibleHCloudDatacenterInfo(AnsibleHCloud):
             if datacenter is None:
                 continue
 
-            dc: dict[str, object] = {
+            result = {
                 "id": datacenter.id,
                 "name": datacenter.name,
                 "description": datacenter.description,
                 "location": datacenter.location.name,
             }
             if datacenter.server_types is not None:
-                dc["server_types"] = {
+                result["server_types"] = {
                     "available": [o.id for o in datacenter.server_types.available],
                     "available_for_migration": [o.id for o in datacenter.server_types.available_for_migration],
                     "supported": [o.id for o in datacenter.server_types.supported],
                 }
-            tmp.append(dc)
+            tmp.append(result)
 
         return tmp
 

--- a/plugins/modules/server_type_info.py
+++ b/plugins/modules/server_type_info.py
@@ -130,6 +130,16 @@ hcloud_server_type_info:
                             returned: when deprecated
                             type: str
                             sample: "2025-12-09T09:00:00Z"
+                available:
+                    description: Whether the Server Type is available in this Location.
+                    returned: always
+                    type: bool
+                    sample: true
+                recommended:
+                    description: Whether the Server Type is recommended in this Location.
+                    returned: always
+                    type: bool
+                    sample: true
         included_traffic:
             description: |
                 Free traffic per month in bytes
@@ -208,6 +218,8 @@ class AnsibleHCloudServerTypeInfo(AnsibleHCloud):
                                 if o.deprecation is not None
                                 else None
                             ),
+                            "available": o.available,
+                            "recommended": o.recommended,
                         }
                         for o in server_type.locations or []
                     ],

--- a/tests/integration/targets/server_type_info/tasks/test.yml
+++ b/tests/integration/targets/server_type_info/tasks/test.yml
@@ -72,5 +72,5 @@
       - result.hcloud_server_type_info[0].locations[0].deprecation is not none
       - result.hcloud_server_type_info[0].locations[0].deprecation.announced == '2024-06-06T08:00:00+00:00'
       - result.hcloud_server_type_info[0].locations[0].deprecation.unavailable_after == '2024-09-06T00:00:00+00:00'
-      - result.hcloud_server_type_info[0].locations[0].available is not None
-      - result.hcloud_server_type_info[0].locations[0].recommended is not None
+      - result.hcloud_server_type_info[0].locations[0].available is not none
+      - result.hcloud_server_type_info[0].locations[0].recommended is not none

--- a/tests/integration/targets/server_type_info/tasks/test.yml
+++ b/tests/integration/targets/server_type_info/tasks/test.yml
@@ -72,5 +72,5 @@
       - result.hcloud_server_type_info[0].locations[0].deprecation is not none
       - result.hcloud_server_type_info[0].locations[0].deprecation.announced == '2024-06-06T08:00:00+00:00'
       - result.hcloud_server_type_info[0].locations[0].deprecation.unavailable_after == '2024-09-06T00:00:00+00:00'
-      - result.hcloud_server_type_info[0].locations[0].available is False
-      - result.hcloud_server_type_info[0].locations[0].recommended is False
+      - result.hcloud_server_type_info[0].locations[0].available is not None
+      - result.hcloud_server_type_info[0].locations[0].recommended is not None

--- a/tests/integration/targets/server_type_info/tasks/test.yml
+++ b/tests/integration/targets/server_type_info/tasks/test.yml
@@ -72,3 +72,5 @@
       - result.hcloud_server_type_info[0].locations[0].deprecation is not none
       - result.hcloud_server_type_info[0].locations[0].deprecation.announced == '2024-06-06T08:00:00+00:00'
       - result.hcloud_server_type_info[0].locations[0].deprecation.unavailable_after == '2024-09-06T00:00:00+00:00'
+      - result.hcloud_server_type_info[0].locations[0].available is False
+      - result.hcloud_server_type_info[0].locations[0].recommended is False


### PR DESCRIPTION
##### SUMMARY

This PR deprecates the `datacenter_info.server_types` property and adds the new `server_type_info.locations[].available` and `server_type_info.locations[].recommended` properties.

See also: https://github.com/hetznercloud/hcloud-python/pull/645