### PR TITLE
feat(primary-ip): assignee_type is optional when creating a primary ip

### DIFF
--- a/changelogs/fragments/primary-ip-assignee-type.yml
+++ b/changelogs/fragments/primary-ip-assignee-type.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - primary_ip - Support different Primary IP ``assignee_type`` values.

--- a/changelogs/fragments/primary-ip-assignee-type.yml
+++ b/changelogs/fragments/primary-ip-assignee-type.yml
@@ -1,2 +1,2 @@
 minor_changes:
-  - primary_ip - Support different Primary IP ``assignee_type`` values.
+  - primary_ip - Primary IP support upcoming ``assignee_type`` behavior change.

--- a/changelogs/fragments/release-summary.yml
+++ b/changelogs/fragments/release-summary.yml
@@ -1,25 +1,23 @@
 release_summary: |
-  Server Types availability and recommendation details moved
-  ----------------------------------------------------------
+  **Server Types availability and recommendation details moved**
 
   Server Types availability and recommendation details moved from the
   ``datacenter_info`` module to the ``server_type_info`` module.
 
-  See the `changelog <https://docs.hetzner.cloud/changelog#2026-04-01-datacenter-deprecations>`_ for more details.
+  See the `changelog <https://docs.hetzner.cloud/changelog#2026-04-01-datacenter-deprecations>`__ for more details.
 
-  Primary IPs ``assignee_type`` behavior change
-  ---------------------------------------------
+  **Primary IPs ``assignee_type`` behavior change**
 
   As of 1 August 2026, the behavior of the Primary IP ``assignee_type`` property
   will change, and will return ``unassigned`` when the Primary IP is not assigned
-  (when ``assignee_id`` is `null`). The goal is to eventually assign Primary IPs to
+  (when ``assignee_id`` is ``null``). The goal is to eventually assign Primary IPs to
   other resource types, not only to ``server``.
 
-  See the `changelog <https://docs.hetzner.cloud/changelog#2026-04-27-primary-ips-will-return-unassigned>`_ for more details.
+  See the `changelog <https://docs.hetzner.cloud/changelog#2026-04-27-primary-ips-will-return-unassigned>`__ for more details.
 
   In addition, the Primary IP request body ``assignee_type`` property of the operation
-  ```POST /v1/primary_ips`` <https://docs.hetzner.cloud/reference/cloud#tag/primary-ips/create_primary_ip>`_ is
+  `POST /v1/primary_ips <https://docs.hetzner.cloud/reference/cloud#tag/primary-ips/create_primary_ip>`__ is
   now optional. Primary IPs created without ``assignee_type`` return ``server`` until 1 August 2026, after this date,
   its value will be ``unassigned``.
 
-  See the `changelog <https://docs.hetzner.cloud/changelog#2026-04-27-primary-ips-make-assignee_type-optional>`_ for more details.
+  See the `changelog <https://docs.hetzner.cloud/changelog#2026-04-27-primary-ips-make-assignee_type-optional>`__ for more details.

--- a/changelogs/fragments/release-summary.yml
+++ b/changelogs/fragments/release-summary.yml
@@ -1,0 +1,25 @@
+release_summary: |
+  Server Types availability and recommendation details moved
+  ----------------------------------------------------------
+
+  Server Types availability and recommendation details moved from the
+  ``datacenter_info`` module to the ``server_type_info`` module.
+
+  See the `changelog <https://docs.hetzner.cloud/changelog#2026-04-01-datacenter-deprecations>`_ for more details.
+
+  Primary IPs ``assignee_type`` behavior change
+  ---------------------------------------------
+
+  As of 1 August 2026, the behavior of the Primary IP ``assignee_type`` property
+  will change, and will return ``unassigned`` when the Primary IP is not assigned
+  (when ``assignee_id`` is `null`). The goal is to eventually assign Primary IPs to
+  other resource types, not only to ``server``.
+
+  See the `changelog <https://docs.hetzner.cloud/changelog#2026-04-27-primary-ips-will-return-unassigned>`_ for more details.
+
+  In addition, the Primary IP request body ``assignee_type`` property of the operation
+  ```POST /v1/primary_ips`` <https://docs.hetzner.cloud/reference/cloud#tag/primary-ips/create_primary_ip>`_ is
+  now optional. Primary IPs created without ``assignee_type`` return ``server`` until 1 August 2026, after this date,
+  its value will be ``unassigned``.
+
+  See the `changelog <https://docs.hetzner.cloud/changelog#2026-04-27-primary-ips-make-assignee_type-optional>`_ for more details.

--- a/changelogs/fragments/server-type-available-recommended.yml
+++ b/changelogs/fragments/server-type-available-recommended.yml
@@ -5,10 +5,3 @@ deprecated_features:
   - datacenter_info - The ``hcloud_datacenter_info[].server_types`` return value
     is deprecated and will be removed after 1 October 2026. Please use the ``hcloud_server_type_info[].locations[].available``
     return value instead.
-release_summary: |
-  Server Types availability and recommendation details moved from the
-  ``datacenter_info`` module to the ``server_type_info`` module.
-
-  See our `changelog`_ for more details.
-
-  .. _changelog: https://docs.hetzner.cloud/changelog#2026-04-01-datacenter-deprecations

--- a/plugins/modules/primary_ip.py
+++ b/plugins/modules/primary_ip.py
@@ -178,14 +178,14 @@ hcloud_primary_ip:
                 key: value
                 mylabel: 123
         assignee_id:
-            description: ID of the resource the Primary IP is assigned to, null if it is not assigned.
+            description: ID of the resource where the Primary IP is assigned to, none if unassigned.
+            returned: always
             type: int
-            returned: always
-            sample: 1937415
+            sample: 19584637
         assignee_type:
-            description: Resource type the Primary IP can be assigned to.
-            type: str
+            description: Type of the resource where the Primary IP is assigned to.
             returned: always
+            type: str
             sample: server
         auto_delete:
             description: Delete the Primary IP when the resource it is assigned to is deleted.
@@ -247,6 +247,7 @@ class AnsiblePrimaryIP(AnsibleHCloud):
         elif (value := self.module.params.get("server")) is not None:
             server: BoundServer = self._client_get_by_name_or_id("servers", value)
             params["assignee_id"] = server.id
+            params["assignee_type"] = "server"
 
         if (value := self.module.params.get("auto_delete")) is not None:
             params["auto_delete"] = value
@@ -285,7 +286,11 @@ class AnsiblePrimaryIP(AnsibleHCloud):
             if (value := self.module.params.get("server")) is not None:
                 server: BoundServer = self._client_get_by_name_or_id("servers", value)
 
-                if self.primary_ip.assignee_id is None or self.primary_ip.assignee_id != server.id:
+                if (
+                    self.primary_ip.assignee_type != "server"
+                    or self.primary_ip.assignee_id is None
+                    or self.primary_ip.assignee_id != server.id
+                ):
                     if self.primary_ip.assignee_id is not None:
                         if not self.module.check_mode:
                             action = self.primary_ip.unassign()

--- a/plugins/modules/primary_ip_info.py
+++ b/plugins/modules/primary_ip_info.py
@@ -90,12 +90,12 @@ hcloud_primary_ip_info:
             type: str
             sample: ipv4
         assignee_id:
-            description: Numeric identifier of the ressource where the Primary IP is assigned to.
+            description: ID of the resource where the Primary IP is assigned to, none if unassigned.
             returned: always
             type: int
             sample: 19584637
         assignee_type:
-            description: Name of the type where the Primary IP is assigned to.
+            description: Type of the resource where the Primary IP is assigned to.
             returned: always
             type: str
             sample: server


### PR DESCRIPTION
#### Primary IPs `assignee_type` behavior change

As of 1 August 2026, the behavior of the Primary IP `assignee_type` property will change, and will return `unassigned` when the Primary IP is not assigned (when `assignee_id` is `null`). The goal is to eventually assign Primary IPs to other resource types, not only to `server`.

See the [changelog](https://docs.hetzner.cloud/changelog#2026-04-27-primary-ips-will-return-unassigned) for more details.

In addition, the Primary IP request body `assignee_type` property of the operation [`POST /v1/primary_ips`](https://docs.hetzner.cloud/reference/cloud#tag/primary-ips/create_primary_ip) is now optional. Primary IPs created without `assignee_type` return `server` until 1 August 2026, after this date, its value will be `unassigned`.

See the [changelog](https://docs.hetzner.cloud/changelog#2026-04-27-primary-ips-make-assignee_type-optional) for more details.
