### PR TITLE
test: change cax to cpx server types

### DIFF
--- a/tests/integration/common/defaults/main/common.yml
+++ b/tests/integration/common/defaults/main/common.yml
@@ -9,8 +9,8 @@ hcloud_role_ns: "{{ role_name | split('_') | map('batch', 2) | map('first') | fl
 hcloud_ns: "ansible-{{ hcloud_run_ns }}-{{ hcloud_role_ns }}"
 
 # Used to easily update the server types and images across all our tests.
-hcloud_server_type_name: cax11
-hcloud_server_type_id: 45
+hcloud_server_type_name: cpx22
+hcloud_server_type_id: 109
 
 hcloud_server_type_upgrade_name: cax21
 hcloud_server_type_upgrade_id: 93

--- a/tests/integration/common/defaults/main/common.yml
+++ b/tests/integration/common/defaults/main/common.yml
@@ -12,8 +12,8 @@ hcloud_ns: "ansible-{{ hcloud_run_ns }}-{{ hcloud_role_ns }}"
 hcloud_server_type_name: cpx22
 hcloud_server_type_id: 109
 
-hcloud_server_type_upgrade_name: cax21
-hcloud_server_type_upgrade_id: 93
+hcloud_server_type_upgrade_name: cpx32
+hcloud_server_type_upgrade_id: 110
 
 hcloud_image_name: debian-12
 hcloud_image_id: 114690389 # architecture=arm

--- a/tests/integration/targets/certificate/defaults/main/common.yml
+++ b/tests/integration/targets/certificate/defaults/main/common.yml
@@ -15,8 +15,8 @@ hcloud_ns: "ansible-{{ hcloud_run_ns }}-{{ hcloud_role_ns }}"
 hcloud_server_type_name: cpx22
 hcloud_server_type_id: 109
 
-hcloud_server_type_upgrade_name: cax21
-hcloud_server_type_upgrade_id: 93
+hcloud_server_type_upgrade_name: cpx32
+hcloud_server_type_upgrade_id: 110
 
 hcloud_image_name: debian-12
 hcloud_image_id: 114690389 # architecture=arm

--- a/tests/integration/targets/certificate/defaults/main/common.yml
+++ b/tests/integration/targets/certificate/defaults/main/common.yml
@@ -12,8 +12,8 @@ hcloud_role_ns: "{{ role_name | split('_') | map('batch', 2) | map('first') | fl
 hcloud_ns: "ansible-{{ hcloud_run_ns }}-{{ hcloud_role_ns }}"
 
 # Used to easily update the server types and images across all our tests.
-hcloud_server_type_name: cax11
-hcloud_server_type_id: 45
+hcloud_server_type_name: cpx22
+hcloud_server_type_id: 109
 
 hcloud_server_type_upgrade_name: cax21
 hcloud_server_type_upgrade_id: 93

--- a/tests/integration/targets/certificate_info/defaults/main/common.yml
+++ b/tests/integration/targets/certificate_info/defaults/main/common.yml
@@ -15,8 +15,8 @@ hcloud_ns: "ansible-{{ hcloud_run_ns }}-{{ hcloud_role_ns }}"
 hcloud_server_type_name: cpx22
 hcloud_server_type_id: 109
 
-hcloud_server_type_upgrade_name: cax21
-hcloud_server_type_upgrade_id: 93
+hcloud_server_type_upgrade_name: cpx32
+hcloud_server_type_upgrade_id: 110
 
 hcloud_image_name: debian-12
 hcloud_image_id: 114690389 # architecture=arm

--- a/tests/integration/targets/certificate_info/defaults/main/common.yml
+++ b/tests/integration/targets/certificate_info/defaults/main/common.yml
@@ -12,8 +12,8 @@ hcloud_role_ns: "{{ role_name | split('_') | map('batch', 2) | map('first') | fl
 hcloud_ns: "ansible-{{ hcloud_run_ns }}-{{ hcloud_role_ns }}"
 
 # Used to easily update the server types and images across all our tests.
-hcloud_server_type_name: cax11
-hcloud_server_type_id: 45
+hcloud_server_type_name: cpx22
+hcloud_server_type_id: 109
 
 hcloud_server_type_upgrade_name: cax21
 hcloud_server_type_upgrade_id: 93

--- a/tests/integration/targets/datacenter_info/defaults/main/common.yml
+++ b/tests/integration/targets/datacenter_info/defaults/main/common.yml
@@ -15,8 +15,8 @@ hcloud_ns: "ansible-{{ hcloud_run_ns }}-{{ hcloud_role_ns }}"
 hcloud_server_type_name: cpx22
 hcloud_server_type_id: 109
 
-hcloud_server_type_upgrade_name: cax21
-hcloud_server_type_upgrade_id: 93
+hcloud_server_type_upgrade_name: cpx32
+hcloud_server_type_upgrade_id: 110
 
 hcloud_image_name: debian-12
 hcloud_image_id: 114690389 # architecture=arm

--- a/tests/integration/targets/datacenter_info/defaults/main/common.yml
+++ b/tests/integration/targets/datacenter_info/defaults/main/common.yml
@@ -12,8 +12,8 @@ hcloud_role_ns: "{{ role_name | split('_') | map('batch', 2) | map('first') | fl
 hcloud_ns: "ansible-{{ hcloud_run_ns }}-{{ hcloud_role_ns }}"
 
 # Used to easily update the server types and images across all our tests.
-hcloud_server_type_name: cax11
-hcloud_server_type_id: 45
+hcloud_server_type_name: cpx22
+hcloud_server_type_id: 109
 
 hcloud_server_type_upgrade_name: cax21
 hcloud_server_type_upgrade_id: 93

--- a/tests/integration/targets/filter_all/defaults/main/common.yml
+++ b/tests/integration/targets/filter_all/defaults/main/common.yml
@@ -15,8 +15,8 @@ hcloud_ns: "ansible-{{ hcloud_run_ns }}-{{ hcloud_role_ns }}"
 hcloud_server_type_name: cpx22
 hcloud_server_type_id: 109
 
-hcloud_server_type_upgrade_name: cax21
-hcloud_server_type_upgrade_id: 93
+hcloud_server_type_upgrade_name: cpx32
+hcloud_server_type_upgrade_id: 110
 
 hcloud_image_name: debian-12
 hcloud_image_id: 114690389 # architecture=arm

--- a/tests/integration/targets/filter_all/defaults/main/common.yml
+++ b/tests/integration/targets/filter_all/defaults/main/common.yml
@@ -12,8 +12,8 @@ hcloud_role_ns: "{{ role_name | split('_') | map('batch', 2) | map('first') | fl
 hcloud_ns: "ansible-{{ hcloud_run_ns }}-{{ hcloud_role_ns }}"
 
 # Used to easily update the server types and images across all our tests.
-hcloud_server_type_name: cax11
-hcloud_server_type_id: 45
+hcloud_server_type_name: cpx22
+hcloud_server_type_id: 109
 
 hcloud_server_type_upgrade_name: cax21
 hcloud_server_type_upgrade_id: 93

--- a/tests/integration/targets/firewall/defaults/main/common.yml
+++ b/tests/integration/targets/firewall/defaults/main/common.yml
@@ -15,8 +15,8 @@ hcloud_ns: "ansible-{{ hcloud_run_ns }}-{{ hcloud_role_ns }}"
 hcloud_server_type_name: cpx22
 hcloud_server_type_id: 109
 
-hcloud_server_type_upgrade_name: cax21
-hcloud_server_type_upgrade_id: 93
+hcloud_server_type_upgrade_name: cpx32
+hcloud_server_type_upgrade_id: 110
 
 hcloud_image_name: debian-12
 hcloud_image_id: 114690389 # architecture=arm

--- a/tests/integration/targets/firewall/defaults/main/common.yml
+++ b/tests/integration/targets/firewall/defaults/main/common.yml
@@ -12,8 +12,8 @@ hcloud_role_ns: "{{ role_name | split('_') | map('batch', 2) | map('first') | fl
 hcloud_ns: "ansible-{{ hcloud_run_ns }}-{{ hcloud_role_ns }}"
 
 # Used to easily update the server types and images across all our tests.
-hcloud_server_type_name: cax11
-hcloud_server_type_id: 45
+hcloud_server_type_name: cpx22
+hcloud_server_type_id: 109
 
 hcloud_server_type_upgrade_name: cax21
 hcloud_server_type_upgrade_id: 93

--- a/tests/integration/targets/firewall_info/defaults/main/common.yml
+++ b/tests/integration/targets/firewall_info/defaults/main/common.yml
@@ -15,8 +15,8 @@ hcloud_ns: "ansible-{{ hcloud_run_ns }}-{{ hcloud_role_ns }}"
 hcloud_server_type_name: cpx22
 hcloud_server_type_id: 109
 
-hcloud_server_type_upgrade_name: cax21
-hcloud_server_type_upgrade_id: 93
+hcloud_server_type_upgrade_name: cpx32
+hcloud_server_type_upgrade_id: 110
 
 hcloud_image_name: debian-12
 hcloud_image_id: 114690389 # architecture=arm

--- a/tests/integration/targets/firewall_info/defaults/main/common.yml
+++ b/tests/integration/targets/firewall_info/defaults/main/common.yml
@@ -12,8 +12,8 @@ hcloud_role_ns: "{{ role_name | split('_') | map('batch', 2) | map('first') | fl
 hcloud_ns: "ansible-{{ hcloud_run_ns }}-{{ hcloud_role_ns }}"
 
 # Used to easily update the server types and images across all our tests.
-hcloud_server_type_name: cax11
-hcloud_server_type_id: 45
+hcloud_server_type_name: cpx22
+hcloud_server_type_id: 109
 
 hcloud_server_type_upgrade_name: cax21
 hcloud_server_type_upgrade_id: 93

--- a/tests/integration/targets/firewall_resource/defaults/main/common.yml
+++ b/tests/integration/targets/firewall_resource/defaults/main/common.yml
@@ -15,8 +15,8 @@ hcloud_ns: "ansible-{{ hcloud_run_ns }}-{{ hcloud_role_ns }}"
 hcloud_server_type_name: cpx22
 hcloud_server_type_id: 109
 
-hcloud_server_type_upgrade_name: cax21
-hcloud_server_type_upgrade_id: 93
+hcloud_server_type_upgrade_name: cpx32
+hcloud_server_type_upgrade_id: 110
 
 hcloud_image_name: debian-12
 hcloud_image_id: 114690389 # architecture=arm

--- a/tests/integration/targets/firewall_resource/defaults/main/common.yml
+++ b/tests/integration/targets/firewall_resource/defaults/main/common.yml
@@ -12,8 +12,8 @@ hcloud_role_ns: "{{ role_name | split('_') | map('batch', 2) | map('first') | fl
 hcloud_ns: "ansible-{{ hcloud_run_ns }}-{{ hcloud_role_ns }}"
 
 # Used to easily update the server types and images across all our tests.
-hcloud_server_type_name: cax11
-hcloud_server_type_id: 45
+hcloud_server_type_name: cpx22
+hcloud_server_type_id: 109
 
 hcloud_server_type_upgrade_name: cax21
 hcloud_server_type_upgrade_id: 93

--- a/tests/integration/targets/floating_ip/defaults/main/common.yml
+++ b/tests/integration/targets/floating_ip/defaults/main/common.yml
@@ -15,8 +15,8 @@ hcloud_ns: "ansible-{{ hcloud_run_ns }}-{{ hcloud_role_ns }}"
 hcloud_server_type_name: cpx22
 hcloud_server_type_id: 109
 
-hcloud_server_type_upgrade_name: cax21
-hcloud_server_type_upgrade_id: 93
+hcloud_server_type_upgrade_name: cpx32
+hcloud_server_type_upgrade_id: 110
 
 hcloud_image_name: debian-12
 hcloud_image_id: 114690389 # architecture=arm

--- a/tests/integration/targets/floating_ip/defaults/main/common.yml
+++ b/tests/integration/targets/floating_ip/defaults/main/common.yml
@@ -12,8 +12,8 @@ hcloud_role_ns: "{{ role_name | split('_') | map('batch', 2) | map('first') | fl
 hcloud_ns: "ansible-{{ hcloud_run_ns }}-{{ hcloud_role_ns }}"
 
 # Used to easily update the server types and images across all our tests.
-hcloud_server_type_name: cax11
-hcloud_server_type_id: 45
+hcloud_server_type_name: cpx22
+hcloud_server_type_id: 109
 
 hcloud_server_type_upgrade_name: cax21
 hcloud_server_type_upgrade_id: 93

--- a/tests/integration/targets/floating_ip_info/defaults/main/common.yml
+++ b/tests/integration/targets/floating_ip_info/defaults/main/common.yml
@@ -15,8 +15,8 @@ hcloud_ns: "ansible-{{ hcloud_run_ns }}-{{ hcloud_role_ns }}"
 hcloud_server_type_name: cpx22
 hcloud_server_type_id: 109
 
-hcloud_server_type_upgrade_name: cax21
-hcloud_server_type_upgrade_id: 93
+hcloud_server_type_upgrade_name: cpx32
+hcloud_server_type_upgrade_id: 110
 
 hcloud_image_name: debian-12
 hcloud_image_id: 114690389 # architecture=arm

--- a/tests/integration/targets/floating_ip_info/defaults/main/common.yml
+++ b/tests/integration/targets/floating_ip_info/defaults/main/common.yml
@@ -12,8 +12,8 @@ hcloud_role_ns: "{{ role_name | split('_') | map('batch', 2) | map('first') | fl
 hcloud_ns: "ansible-{{ hcloud_run_ns }}-{{ hcloud_role_ns }}"
 
 # Used to easily update the server types and images across all our tests.
-hcloud_server_type_name: cax11
-hcloud_server_type_id: 45
+hcloud_server_type_name: cpx22
+hcloud_server_type_id: 109
 
 hcloud_server_type_upgrade_name: cax21
 hcloud_server_type_upgrade_id: 93

--- a/tests/integration/targets/image_info/defaults/main/common.yml
+++ b/tests/integration/targets/image_info/defaults/main/common.yml
@@ -15,8 +15,8 @@ hcloud_ns: "ansible-{{ hcloud_run_ns }}-{{ hcloud_role_ns }}"
 hcloud_server_type_name: cpx22
 hcloud_server_type_id: 109
 
-hcloud_server_type_upgrade_name: cax21
-hcloud_server_type_upgrade_id: 93
+hcloud_server_type_upgrade_name: cpx32
+hcloud_server_type_upgrade_id: 110
 
 hcloud_image_name: debian-12
 hcloud_image_id: 114690389 # architecture=arm

--- a/tests/integration/targets/image_info/defaults/main/common.yml
+++ b/tests/integration/targets/image_info/defaults/main/common.yml
@@ -12,8 +12,8 @@ hcloud_role_ns: "{{ role_name | split('_') | map('batch', 2) | map('first') | fl
 hcloud_ns: "ansible-{{ hcloud_run_ns }}-{{ hcloud_role_ns }}"
 
 # Used to easily update the server types and images across all our tests.
-hcloud_server_type_name: cax11
-hcloud_server_type_id: 45
+hcloud_server_type_name: cpx22
+hcloud_server_type_id: 109
 
 hcloud_server_type_upgrade_name: cax21
 hcloud_server_type_upgrade_id: 93

--- a/tests/integration/targets/iso_info/defaults/main/common.yml
+++ b/tests/integration/targets/iso_info/defaults/main/common.yml
@@ -15,8 +15,8 @@ hcloud_ns: "ansible-{{ hcloud_run_ns }}-{{ hcloud_role_ns }}"
 hcloud_server_type_name: cpx22
 hcloud_server_type_id: 109
 
-hcloud_server_type_upgrade_name: cax21
-hcloud_server_type_upgrade_id: 93
+hcloud_server_type_upgrade_name: cpx32
+hcloud_server_type_upgrade_id: 110
 
 hcloud_image_name: debian-12
 hcloud_image_id: 114690389 # architecture=arm

--- a/tests/integration/targets/iso_info/defaults/main/common.yml
+++ b/tests/integration/targets/iso_info/defaults/main/common.yml
@@ -12,8 +12,8 @@ hcloud_role_ns: "{{ role_name | split('_') | map('batch', 2) | map('first') | fl
 hcloud_ns: "ansible-{{ hcloud_run_ns }}-{{ hcloud_role_ns }}"
 
 # Used to easily update the server types and images across all our tests.
-hcloud_server_type_name: cax11
-hcloud_server_type_id: 45
+hcloud_server_type_name: cpx22
+hcloud_server_type_id: 109
 
 hcloud_server_type_upgrade_name: cax21
 hcloud_server_type_upgrade_id: 93

--- a/tests/integration/targets/load_balancer/defaults/main/common.yml
+++ b/tests/integration/targets/load_balancer/defaults/main/common.yml
@@ -15,8 +15,8 @@ hcloud_ns: "ansible-{{ hcloud_run_ns }}-{{ hcloud_role_ns }}"
 hcloud_server_type_name: cpx22
 hcloud_server_type_id: 109
 
-hcloud_server_type_upgrade_name: cax21
-hcloud_server_type_upgrade_id: 93
+hcloud_server_type_upgrade_name: cpx32
+hcloud_server_type_upgrade_id: 110
 
 hcloud_image_name: debian-12
 hcloud_image_id: 114690389 # architecture=arm

--- a/tests/integration/targets/load_balancer/defaults/main/common.yml
+++ b/tests/integration/targets/load_balancer/defaults/main/common.yml
@@ -12,8 +12,8 @@ hcloud_role_ns: "{{ role_name | split('_') | map('batch', 2) | map('first') | fl
 hcloud_ns: "ansible-{{ hcloud_run_ns }}-{{ hcloud_role_ns }}"
 
 # Used to easily update the server types and images across all our tests.
-hcloud_server_type_name: cax11
-hcloud_server_type_id: 45
+hcloud_server_type_name: cpx22
+hcloud_server_type_id: 109
 
 hcloud_server_type_upgrade_name: cax21
 hcloud_server_type_upgrade_id: 93

--- a/tests/integration/targets/load_balancer_info/defaults/main/common.yml
+++ b/tests/integration/targets/load_balancer_info/defaults/main/common.yml
@@ -15,8 +15,8 @@ hcloud_ns: "ansible-{{ hcloud_run_ns }}-{{ hcloud_role_ns }}"
 hcloud_server_type_name: cpx22
 hcloud_server_type_id: 109
 
-hcloud_server_type_upgrade_name: cax21
-hcloud_server_type_upgrade_id: 93
+hcloud_server_type_upgrade_name: cpx32
+hcloud_server_type_upgrade_id: 110
 
 hcloud_image_name: debian-12
 hcloud_image_id: 114690389 # architecture=arm

--- a/tests/integration/targets/load_balancer_info/defaults/main/common.yml
+++ b/tests/integration/targets/load_balancer_info/defaults/main/common.yml
@@ -12,8 +12,8 @@ hcloud_role_ns: "{{ role_name | split('_') | map('batch', 2) | map('first') | fl
 hcloud_ns: "ansible-{{ hcloud_run_ns }}-{{ hcloud_role_ns }}"
 
 # Used to easily update the server types and images across all our tests.
-hcloud_server_type_name: cax11
-hcloud_server_type_id: 45
+hcloud_server_type_name: cpx22
+hcloud_server_type_id: 109
 
 hcloud_server_type_upgrade_name: cax21
 hcloud_server_type_upgrade_id: 93

--- a/tests/integration/targets/load_balancer_network/defaults/main/common.yml
+++ b/tests/integration/targets/load_balancer_network/defaults/main/common.yml
@@ -15,8 +15,8 @@ hcloud_ns: "ansible-{{ hcloud_run_ns }}-{{ hcloud_role_ns }}"
 hcloud_server_type_name: cpx22
 hcloud_server_type_id: 109
 
-hcloud_server_type_upgrade_name: cax21
-hcloud_server_type_upgrade_id: 93
+hcloud_server_type_upgrade_name: cpx32
+hcloud_server_type_upgrade_id: 110
 
 hcloud_image_name: debian-12
 hcloud_image_id: 114690389 # architecture=arm

--- a/tests/integration/targets/load_balancer_network/defaults/main/common.yml
+++ b/tests/integration/targets/load_balancer_network/defaults/main/common.yml
@@ -12,8 +12,8 @@ hcloud_role_ns: "{{ role_name | split('_') | map('batch', 2) | map('first') | fl
 hcloud_ns: "ansible-{{ hcloud_run_ns }}-{{ hcloud_role_ns }}"
 
 # Used to easily update the server types and images across all our tests.
-hcloud_server_type_name: cax11
-hcloud_server_type_id: 45
+hcloud_server_type_name: cpx22
+hcloud_server_type_id: 109
 
 hcloud_server_type_upgrade_name: cax21
 hcloud_server_type_upgrade_id: 93

--- a/tests/integration/targets/load_balancer_service/defaults/main/common.yml
+++ b/tests/integration/targets/load_balancer_service/defaults/main/common.yml
@@ -15,8 +15,8 @@ hcloud_ns: "ansible-{{ hcloud_run_ns }}-{{ hcloud_role_ns }}"
 hcloud_server_type_name: cpx22
 hcloud_server_type_id: 109
 
-hcloud_server_type_upgrade_name: cax21
-hcloud_server_type_upgrade_id: 93
+hcloud_server_type_upgrade_name: cpx32
+hcloud_server_type_upgrade_id: 110
 
 hcloud_image_name: debian-12
 hcloud_image_id: 114690389 # architecture=arm

--- a/tests/integration/targets/load_balancer_service/defaults/main/common.yml
+++ b/tests/integration/targets/load_balancer_service/defaults/main/common.yml
@@ -12,8 +12,8 @@ hcloud_role_ns: "{{ role_name | split('_') | map('batch', 2) | map('first') | fl
 hcloud_ns: "ansible-{{ hcloud_run_ns }}-{{ hcloud_role_ns }}"
 
 # Used to easily update the server types and images across all our tests.
-hcloud_server_type_name: cax11
-hcloud_server_type_id: 45
+hcloud_server_type_name: cpx22
+hcloud_server_type_id: 109
 
 hcloud_server_type_upgrade_name: cax21
 hcloud_server_type_upgrade_id: 93

--- a/tests/integration/targets/load_balancer_target/defaults/main/common.yml
+++ b/tests/integration/targets/load_balancer_target/defaults/main/common.yml
@@ -15,8 +15,8 @@ hcloud_ns: "ansible-{{ hcloud_run_ns }}-{{ hcloud_role_ns }}"
 hcloud_server_type_name: cpx22
 hcloud_server_type_id: 109
 
-hcloud_server_type_upgrade_name: cax21
-hcloud_server_type_upgrade_id: 93
+hcloud_server_type_upgrade_name: cpx32
+hcloud_server_type_upgrade_id: 110
 
 hcloud_image_name: debian-12
 hcloud_image_id: 114690389 # architecture=arm

--- a/tests/integration/targets/load_balancer_target/defaults/main/common.yml
+++ b/tests/integration/targets/load_balancer_target/defaults/main/common.yml
@@ -12,8 +12,8 @@ hcloud_role_ns: "{{ role_name | split('_') | map('batch', 2) | map('first') | fl
 hcloud_ns: "ansible-{{ hcloud_run_ns }}-{{ hcloud_role_ns }}"
 
 # Used to easily update the server types and images across all our tests.
-hcloud_server_type_name: cax11
-hcloud_server_type_id: 45
+hcloud_server_type_name: cpx22
+hcloud_server_type_id: 109
 
 hcloud_server_type_upgrade_name: cax21
 hcloud_server_type_upgrade_id: 93

--- a/tests/integration/targets/load_balancer_type_info/defaults/main/common.yml
+++ b/tests/integration/targets/load_balancer_type_info/defaults/main/common.yml
@@ -15,8 +15,8 @@ hcloud_ns: "ansible-{{ hcloud_run_ns }}-{{ hcloud_role_ns }}"
 hcloud_server_type_name: cpx22
 hcloud_server_type_id: 109
 
-hcloud_server_type_upgrade_name: cax21
-hcloud_server_type_upgrade_id: 93
+hcloud_server_type_upgrade_name: cpx32
+hcloud_server_type_upgrade_id: 110
 
 hcloud_image_name: debian-12
 hcloud_image_id: 114690389 # architecture=arm

--- a/tests/integration/targets/load_balancer_type_info/defaults/main/common.yml
+++ b/tests/integration/targets/load_balancer_type_info/defaults/main/common.yml
@@ -12,8 +12,8 @@ hcloud_role_ns: "{{ role_name | split('_') | map('batch', 2) | map('first') | fl
 hcloud_ns: "ansible-{{ hcloud_run_ns }}-{{ hcloud_role_ns }}"
 
 # Used to easily update the server types and images across all our tests.
-hcloud_server_type_name: cax11
-hcloud_server_type_id: 45
+hcloud_server_type_name: cpx22
+hcloud_server_type_id: 109
 
 hcloud_server_type_upgrade_name: cax21
 hcloud_server_type_upgrade_id: 93

--- a/tests/integration/targets/location_info/defaults/main/common.yml
+++ b/tests/integration/targets/location_info/defaults/main/common.yml
@@ -15,8 +15,8 @@ hcloud_ns: "ansible-{{ hcloud_run_ns }}-{{ hcloud_role_ns }}"
 hcloud_server_type_name: cpx22
 hcloud_server_type_id: 109
 
-hcloud_server_type_upgrade_name: cax21
-hcloud_server_type_upgrade_id: 93
+hcloud_server_type_upgrade_name: cpx32
+hcloud_server_type_upgrade_id: 110
 
 hcloud_image_name: debian-12
 hcloud_image_id: 114690389 # architecture=arm

--- a/tests/integration/targets/location_info/defaults/main/common.yml
+++ b/tests/integration/targets/location_info/defaults/main/common.yml
@@ -12,8 +12,8 @@ hcloud_role_ns: "{{ role_name | split('_') | map('batch', 2) | map('first') | fl
 hcloud_ns: "ansible-{{ hcloud_run_ns }}-{{ hcloud_role_ns }}"
 
 # Used to easily update the server types and images across all our tests.
-hcloud_server_type_name: cax11
-hcloud_server_type_id: 45
+hcloud_server_type_name: cpx22
+hcloud_server_type_id: 109
 
 hcloud_server_type_upgrade_name: cax21
 hcloud_server_type_upgrade_id: 93

--- a/tests/integration/targets/network/defaults/main/common.yml
+++ b/tests/integration/targets/network/defaults/main/common.yml
@@ -15,8 +15,8 @@ hcloud_ns: "ansible-{{ hcloud_run_ns }}-{{ hcloud_role_ns }}"
 hcloud_server_type_name: cpx22
 hcloud_server_type_id: 109
 
-hcloud_server_type_upgrade_name: cax21
-hcloud_server_type_upgrade_id: 93
+hcloud_server_type_upgrade_name: cpx32
+hcloud_server_type_upgrade_id: 110
 
 hcloud_image_name: debian-12
 hcloud_image_id: 114690389 # architecture=arm

--- a/tests/integration/targets/network/defaults/main/common.yml
+++ b/tests/integration/targets/network/defaults/main/common.yml
@@ -12,8 +12,8 @@ hcloud_role_ns: "{{ role_name | split('_') | map('batch', 2) | map('first') | fl
 hcloud_ns: "ansible-{{ hcloud_run_ns }}-{{ hcloud_role_ns }}"
 
 # Used to easily update the server types and images across all our tests.
-hcloud_server_type_name: cax11
-hcloud_server_type_id: 45
+hcloud_server_type_name: cpx22
+hcloud_server_type_id: 109
 
 hcloud_server_type_upgrade_name: cax21
 hcloud_server_type_upgrade_id: 93

--- a/tests/integration/targets/network_info/defaults/main/common.yml
+++ b/tests/integration/targets/network_info/defaults/main/common.yml
@@ -15,8 +15,8 @@ hcloud_ns: "ansible-{{ hcloud_run_ns }}-{{ hcloud_role_ns }}"
 hcloud_server_type_name: cpx22
 hcloud_server_type_id: 109
 
-hcloud_server_type_upgrade_name: cax21
-hcloud_server_type_upgrade_id: 93
+hcloud_server_type_upgrade_name: cpx32
+hcloud_server_type_upgrade_id: 110
 
 hcloud_image_name: debian-12
 hcloud_image_id: 114690389 # architecture=arm

--- a/tests/integration/targets/network_info/defaults/main/common.yml
+++ b/tests/integration/targets/network_info/defaults/main/common.yml
@@ -12,8 +12,8 @@ hcloud_role_ns: "{{ role_name | split('_') | map('batch', 2) | map('first') | fl
 hcloud_ns: "ansible-{{ hcloud_run_ns }}-{{ hcloud_role_ns }}"
 
 # Used to easily update the server types and images across all our tests.
-hcloud_server_type_name: cax11
-hcloud_server_type_id: 45
+hcloud_server_type_name: cpx22
+hcloud_server_type_id: 109
 
 hcloud_server_type_upgrade_name: cax21
 hcloud_server_type_upgrade_id: 93

--- a/tests/integration/targets/placement_group/defaults/main/common.yml
+++ b/tests/integration/targets/placement_group/defaults/main/common.yml
@@ -15,8 +15,8 @@ hcloud_ns: "ansible-{{ hcloud_run_ns }}-{{ hcloud_role_ns }}"
 hcloud_server_type_name: cpx22
 hcloud_server_type_id: 109
 
-hcloud_server_type_upgrade_name: cax21
-hcloud_server_type_upgrade_id: 93
+hcloud_server_type_upgrade_name: cpx32
+hcloud_server_type_upgrade_id: 110
 
 hcloud_image_name: debian-12
 hcloud_image_id: 114690389 # architecture=arm

--- a/tests/integration/targets/placement_group/defaults/main/common.yml
+++ b/tests/integration/targets/placement_group/defaults/main/common.yml
@@ -12,8 +12,8 @@ hcloud_role_ns: "{{ role_name | split('_') | map('batch', 2) | map('first') | fl
 hcloud_ns: "ansible-{{ hcloud_run_ns }}-{{ hcloud_role_ns }}"
 
 # Used to easily update the server types and images across all our tests.
-hcloud_server_type_name: cax11
-hcloud_server_type_id: 45
+hcloud_server_type_name: cpx22
+hcloud_server_type_id: 109
 
 hcloud_server_type_upgrade_name: cax21
 hcloud_server_type_upgrade_id: 93

--- a/tests/integration/targets/primary_ip/defaults/main/common.yml
+++ b/tests/integration/targets/primary_ip/defaults/main/common.yml
@@ -15,8 +15,8 @@ hcloud_ns: "ansible-{{ hcloud_run_ns }}-{{ hcloud_role_ns }}"
 hcloud_server_type_name: cpx22
 hcloud_server_type_id: 109
 
-hcloud_server_type_upgrade_name: cax21
-hcloud_server_type_upgrade_id: 93
+hcloud_server_type_upgrade_name: cpx32
+hcloud_server_type_upgrade_id: 110
 
 hcloud_image_name: debian-12
 hcloud_image_id: 114690389 # architecture=arm

--- a/tests/integration/targets/primary_ip/defaults/main/common.yml
+++ b/tests/integration/targets/primary_ip/defaults/main/common.yml
@@ -12,8 +12,8 @@ hcloud_role_ns: "{{ role_name | split('_') | map('batch', 2) | map('first') | fl
 hcloud_ns: "ansible-{{ hcloud_run_ns }}-{{ hcloud_role_ns }}"
 
 # Used to easily update the server types and images across all our tests.
-hcloud_server_type_name: cax11
-hcloud_server_type_id: 45
+hcloud_server_type_name: cpx22
+hcloud_server_type_id: 109
 
 hcloud_server_type_upgrade_name: cax21
 hcloud_server_type_upgrade_id: 93

--- a/tests/integration/targets/primary_ip_info/defaults/main/common.yml
+++ b/tests/integration/targets/primary_ip_info/defaults/main/common.yml
@@ -15,8 +15,8 @@ hcloud_ns: "ansible-{{ hcloud_run_ns }}-{{ hcloud_role_ns }}"
 hcloud_server_type_name: cpx22
 hcloud_server_type_id: 109
 
-hcloud_server_type_upgrade_name: cax21
-hcloud_server_type_upgrade_id: 93
+hcloud_server_type_upgrade_name: cpx32
+hcloud_server_type_upgrade_id: 110
 
 hcloud_image_name: debian-12
 hcloud_image_id: 114690389 # architecture=arm

--- a/tests/integration/targets/primary_ip_info/defaults/main/common.yml
+++ b/tests/integration/targets/primary_ip_info/defaults/main/common.yml
@@ -12,8 +12,8 @@ hcloud_role_ns: "{{ role_name | split('_') | map('batch', 2) | map('first') | fl
 hcloud_ns: "ansible-{{ hcloud_run_ns }}-{{ hcloud_role_ns }}"
 
 # Used to easily update the server types and images across all our tests.
-hcloud_server_type_name: cax11
-hcloud_server_type_id: 45
+hcloud_server_type_name: cpx22
+hcloud_server_type_id: 109
 
 hcloud_server_type_upgrade_name: cax21
 hcloud_server_type_upgrade_id: 93

--- a/tests/integration/targets/rdns/defaults/main/common.yml
+++ b/tests/integration/targets/rdns/defaults/main/common.yml
@@ -15,8 +15,8 @@ hcloud_ns: "ansible-{{ hcloud_run_ns }}-{{ hcloud_role_ns }}"
 hcloud_server_type_name: cpx22
 hcloud_server_type_id: 109
 
-hcloud_server_type_upgrade_name: cax21
-hcloud_server_type_upgrade_id: 93
+hcloud_server_type_upgrade_name: cpx32
+hcloud_server_type_upgrade_id: 110
 
 hcloud_image_name: debian-12
 hcloud_image_id: 114690389 # architecture=arm

--- a/tests/integration/targets/rdns/defaults/main/common.yml
+++ b/tests/integration/targets/rdns/defaults/main/common.yml
@@ -12,8 +12,8 @@ hcloud_role_ns: "{{ role_name | split('_') | map('batch', 2) | map('first') | fl
 hcloud_ns: "ansible-{{ hcloud_run_ns }}-{{ hcloud_role_ns }}"
 
 # Used to easily update the server types and images across all our tests.
-hcloud_server_type_name: cax11
-hcloud_server_type_id: 45
+hcloud_server_type_name: cpx22
+hcloud_server_type_id: 109
 
 hcloud_server_type_upgrade_name: cax21
 hcloud_server_type_upgrade_id: 93

--- a/tests/integration/targets/route/defaults/main/common.yml
+++ b/tests/integration/targets/route/defaults/main/common.yml
@@ -15,8 +15,8 @@ hcloud_ns: "ansible-{{ hcloud_run_ns }}-{{ hcloud_role_ns }}"
 hcloud_server_type_name: cpx22
 hcloud_server_type_id: 109
 
-hcloud_server_type_upgrade_name: cax21
-hcloud_server_type_upgrade_id: 93
+hcloud_server_type_upgrade_name: cpx32
+hcloud_server_type_upgrade_id: 110
 
 hcloud_image_name: debian-12
 hcloud_image_id: 114690389 # architecture=arm

--- a/tests/integration/targets/route/defaults/main/common.yml
+++ b/tests/integration/targets/route/defaults/main/common.yml
@@ -12,8 +12,8 @@ hcloud_role_ns: "{{ role_name | split('_') | map('batch', 2) | map('first') | fl
 hcloud_ns: "ansible-{{ hcloud_run_ns }}-{{ hcloud_role_ns }}"
 
 # Used to easily update the server types and images across all our tests.
-hcloud_server_type_name: cax11
-hcloud_server_type_id: 45
+hcloud_server_type_name: cpx22
+hcloud_server_type_id: 109
 
 hcloud_server_type_upgrade_name: cax21
 hcloud_server_type_upgrade_id: 93

--- a/tests/integration/targets/server/defaults/main/common.yml
+++ b/tests/integration/targets/server/defaults/main/common.yml
@@ -15,8 +15,8 @@ hcloud_ns: "ansible-{{ hcloud_run_ns }}-{{ hcloud_role_ns }}"
 hcloud_server_type_name: cpx22
 hcloud_server_type_id: 109
 
-hcloud_server_type_upgrade_name: cax21
-hcloud_server_type_upgrade_id: 93
+hcloud_server_type_upgrade_name: cpx32
+hcloud_server_type_upgrade_id: 110
 
 hcloud_image_name: debian-12
 hcloud_image_id: 114690389 # architecture=arm

--- a/tests/integration/targets/server/defaults/main/common.yml
+++ b/tests/integration/targets/server/defaults/main/common.yml
@@ -12,8 +12,8 @@ hcloud_role_ns: "{{ role_name | split('_') | map('batch', 2) | map('first') | fl
 hcloud_ns: "ansible-{{ hcloud_run_ns }}-{{ hcloud_role_ns }}"
 
 # Used to easily update the server types and images across all our tests.
-hcloud_server_type_name: cax11
-hcloud_server_type_id: 45
+hcloud_server_type_name: cpx22
+hcloud_server_type_id: 109
 
 hcloud_server_type_upgrade_name: cax21
 hcloud_server_type_upgrade_id: 93

--- a/tests/integration/targets/server_info/defaults/main/common.yml
+++ b/tests/integration/targets/server_info/defaults/main/common.yml
@@ -15,8 +15,8 @@ hcloud_ns: "ansible-{{ hcloud_run_ns }}-{{ hcloud_role_ns }}"
 hcloud_server_type_name: cpx22
 hcloud_server_type_id: 109
 
-hcloud_server_type_upgrade_name: cax21
-hcloud_server_type_upgrade_id: 93
+hcloud_server_type_upgrade_name: cpx32
+hcloud_server_type_upgrade_id: 110
 
 hcloud_image_name: debian-12
 hcloud_image_id: 114690389 # architecture=arm

--- a/tests/integration/targets/server_info/defaults/main/common.yml
+++ b/tests/integration/targets/server_info/defaults/main/common.yml
@@ -12,8 +12,8 @@ hcloud_role_ns: "{{ role_name | split('_') | map('batch', 2) | map('first') | fl
 hcloud_ns: "ansible-{{ hcloud_run_ns }}-{{ hcloud_role_ns }}"
 
 # Used to easily update the server types and images across all our tests.
-hcloud_server_type_name: cax11
-hcloud_server_type_id: 45
+hcloud_server_type_name: cpx22
+hcloud_server_type_id: 109
 
 hcloud_server_type_upgrade_name: cax21
 hcloud_server_type_upgrade_id: 93

--- a/tests/integration/targets/server_network/defaults/main/common.yml
+++ b/tests/integration/targets/server_network/defaults/main/common.yml
@@ -15,8 +15,8 @@ hcloud_ns: "ansible-{{ hcloud_run_ns }}-{{ hcloud_role_ns }}"
 hcloud_server_type_name: cpx22
 hcloud_server_type_id: 109
 
-hcloud_server_type_upgrade_name: cax21
-hcloud_server_type_upgrade_id: 93
+hcloud_server_type_upgrade_name: cpx32
+hcloud_server_type_upgrade_id: 110
 
 hcloud_image_name: debian-12
 hcloud_image_id: 114690389 # architecture=arm

--- a/tests/integration/targets/server_network/defaults/main/common.yml
+++ b/tests/integration/targets/server_network/defaults/main/common.yml
@@ -12,8 +12,8 @@ hcloud_role_ns: "{{ role_name | split('_') | map('batch', 2) | map('first') | fl
 hcloud_ns: "ansible-{{ hcloud_run_ns }}-{{ hcloud_role_ns }}"
 
 # Used to easily update the server types and images across all our tests.
-hcloud_server_type_name: cax11
-hcloud_server_type_id: 45
+hcloud_server_type_name: cpx22
+hcloud_server_type_id: 109
 
 hcloud_server_type_upgrade_name: cax21
 hcloud_server_type_upgrade_id: 93

--- a/tests/integration/targets/server_type_info/defaults/main/common.yml
+++ b/tests/integration/targets/server_type_info/defaults/main/common.yml
@@ -15,8 +15,8 @@ hcloud_ns: "ansible-{{ hcloud_run_ns }}-{{ hcloud_role_ns }}"
 hcloud_server_type_name: cpx22
 hcloud_server_type_id: 109
 
-hcloud_server_type_upgrade_name: cax21
-hcloud_server_type_upgrade_id: 93
+hcloud_server_type_upgrade_name: cpx32
+hcloud_server_type_upgrade_id: 110
 
 hcloud_image_name: debian-12
 hcloud_image_id: 114690389 # architecture=arm

--- a/tests/integration/targets/server_type_info/defaults/main/common.yml
+++ b/tests/integration/targets/server_type_info/defaults/main/common.yml
@@ -12,8 +12,8 @@ hcloud_role_ns: "{{ role_name | split('_') | map('batch', 2) | map('first') | fl
 hcloud_ns: "ansible-{{ hcloud_run_ns }}-{{ hcloud_role_ns }}"
 
 # Used to easily update the server types and images across all our tests.
-hcloud_server_type_name: cax11
-hcloud_server_type_id: 45
+hcloud_server_type_name: cpx22
+hcloud_server_type_id: 109
 
 hcloud_server_type_upgrade_name: cax21
 hcloud_server_type_upgrade_id: 93

--- a/tests/integration/targets/server_type_info/tasks/test.yml
+++ b/tests/integration/targets/server_type_info/tasks/test.yml
@@ -26,7 +26,7 @@
   ansible.builtin.assert:
     that:
       - result.hcloud_server_type_info | list | count == 1
-      - result.hcloud_server_type_info[0].deprecation is none # fails if cax11 is ever deprecated
+      - result.hcloud_server_type_info[0].deprecation is none # fails if cpx22 is ever deprecated
 
 - name: Gather hcloud_server_type_info with wrong id
   hetzner.hcloud.server_type_info:

--- a/tests/integration/targets/ssh_key/defaults/main/common.yml
+++ b/tests/integration/targets/ssh_key/defaults/main/common.yml
@@ -15,8 +15,8 @@ hcloud_ns: "ansible-{{ hcloud_run_ns }}-{{ hcloud_role_ns }}"
 hcloud_server_type_name: cpx22
 hcloud_server_type_id: 109
 
-hcloud_server_type_upgrade_name: cax21
-hcloud_server_type_upgrade_id: 93
+hcloud_server_type_upgrade_name: cpx32
+hcloud_server_type_upgrade_id: 110
 
 hcloud_image_name: debian-12
 hcloud_image_id: 114690389 # architecture=arm

--- a/tests/integration/targets/ssh_key/defaults/main/common.yml
+++ b/tests/integration/targets/ssh_key/defaults/main/common.yml
@@ -12,8 +12,8 @@ hcloud_role_ns: "{{ role_name | split('_') | map('batch', 2) | map('first') | fl
 hcloud_ns: "ansible-{{ hcloud_run_ns }}-{{ hcloud_role_ns }}"
 
 # Used to easily update the server types and images across all our tests.
-hcloud_server_type_name: cax11
-hcloud_server_type_id: 45
+hcloud_server_type_name: cpx22
+hcloud_server_type_id: 109
 
 hcloud_server_type_upgrade_name: cax21
 hcloud_server_type_upgrade_id: 93

--- a/tests/integration/targets/ssh_key_info/defaults/main/common.yml
+++ b/tests/integration/targets/ssh_key_info/defaults/main/common.yml
@@ -15,8 +15,8 @@ hcloud_ns: "ansible-{{ hcloud_run_ns }}-{{ hcloud_role_ns }}"
 hcloud_server_type_name: cpx22
 hcloud_server_type_id: 109
 
-hcloud_server_type_upgrade_name: cax21
-hcloud_server_type_upgrade_id: 93
+hcloud_server_type_upgrade_name: cpx32
+hcloud_server_type_upgrade_id: 110
 
 hcloud_image_name: debian-12
 hcloud_image_id: 114690389 # architecture=arm

--- a/tests/integration/targets/ssh_key_info/defaults/main/common.yml
+++ b/tests/integration/targets/ssh_key_info/defaults/main/common.yml
@@ -12,8 +12,8 @@ hcloud_role_ns: "{{ role_name | split('_') | map('batch', 2) | map('first') | fl
 hcloud_ns: "ansible-{{ hcloud_run_ns }}-{{ hcloud_role_ns }}"
 
 # Used to easily update the server types and images across all our tests.
-hcloud_server_type_name: cax11
-hcloud_server_type_id: 45
+hcloud_server_type_name: cpx22
+hcloud_server_type_id: 109
 
 hcloud_server_type_upgrade_name: cax21
 hcloud_server_type_upgrade_id: 93

--- a/tests/integration/targets/storage_box/defaults/main/common.yml
+++ b/tests/integration/targets/storage_box/defaults/main/common.yml
@@ -15,8 +15,8 @@ hcloud_ns: "ansible-{{ hcloud_run_ns }}-{{ hcloud_role_ns }}"
 hcloud_server_type_name: cpx22
 hcloud_server_type_id: 109
 
-hcloud_server_type_upgrade_name: cax21
-hcloud_server_type_upgrade_id: 93
+hcloud_server_type_upgrade_name: cpx32
+hcloud_server_type_upgrade_id: 110
 
 hcloud_image_name: debian-12
 hcloud_image_id: 114690389 # architecture=arm

--- a/tests/integration/targets/storage_box/defaults/main/common.yml
+++ b/tests/integration/targets/storage_box/defaults/main/common.yml
@@ -12,8 +12,8 @@ hcloud_role_ns: "{{ role_name | split('_') | map('batch', 2) | map('first') | fl
 hcloud_ns: "ansible-{{ hcloud_run_ns }}-{{ hcloud_role_ns }}"
 
 # Used to easily update the server types and images across all our tests.
-hcloud_server_type_name: cax11
-hcloud_server_type_id: 45
+hcloud_server_type_name: cpx22
+hcloud_server_type_id: 109
 
 hcloud_server_type_upgrade_name: cax21
 hcloud_server_type_upgrade_id: 93

--- a/tests/integration/targets/storage_box_info/defaults/main/common.yml
+++ b/tests/integration/targets/storage_box_info/defaults/main/common.yml
@@ -15,8 +15,8 @@ hcloud_ns: "ansible-{{ hcloud_run_ns }}-{{ hcloud_role_ns }}"
 hcloud_server_type_name: cpx22
 hcloud_server_type_id: 109
 
-hcloud_server_type_upgrade_name: cax21
-hcloud_server_type_upgrade_id: 93
+hcloud_server_type_upgrade_name: cpx32
+hcloud_server_type_upgrade_id: 110
 
 hcloud_image_name: debian-12
 hcloud_image_id: 114690389 # architecture=arm

--- a/tests/integration/targets/storage_box_info/defaults/main/common.yml
+++ b/tests/integration/targets/storage_box_info/defaults/main/common.yml
@@ -12,8 +12,8 @@ hcloud_role_ns: "{{ role_name | split('_') | map('batch', 2) | map('first') | fl
 hcloud_ns: "ansible-{{ hcloud_run_ns }}-{{ hcloud_role_ns }}"
 
 # Used to easily update the server types and images across all our tests.
-hcloud_server_type_name: cax11
-hcloud_server_type_id: 45
+hcloud_server_type_name: cpx22
+hcloud_server_type_id: 109
 
 hcloud_server_type_upgrade_name: cax21
 hcloud_server_type_upgrade_id: 93

--- a/tests/integration/targets/storage_box_snapshot/defaults/main/common.yml
+++ b/tests/integration/targets/storage_box_snapshot/defaults/main/common.yml
@@ -15,8 +15,8 @@ hcloud_ns: "ansible-{{ hcloud_run_ns }}-{{ hcloud_role_ns }}"
 hcloud_server_type_name: cpx22
 hcloud_server_type_id: 109
 
-hcloud_server_type_upgrade_name: cax21
-hcloud_server_type_upgrade_id: 93
+hcloud_server_type_upgrade_name: cpx32
+hcloud_server_type_upgrade_id: 110
 
 hcloud_image_name: debian-12
 hcloud_image_id: 114690389 # architecture=arm

--- a/tests/integration/targets/storage_box_snapshot/defaults/main/common.yml
+++ b/tests/integration/targets/storage_box_snapshot/defaults/main/common.yml
@@ -12,8 +12,8 @@ hcloud_role_ns: "{{ role_name | split('_') | map('batch', 2) | map('first') | fl
 hcloud_ns: "ansible-{{ hcloud_run_ns }}-{{ hcloud_role_ns }}"
 
 # Used to easily update the server types and images across all our tests.
-hcloud_server_type_name: cax11
-hcloud_server_type_id: 45
+hcloud_server_type_name: cpx22
+hcloud_server_type_id: 109
 
 hcloud_server_type_upgrade_name: cax21
 hcloud_server_type_upgrade_id: 93

--- a/tests/integration/targets/storage_box_snapshot_info/defaults/main/common.yml
+++ b/tests/integration/targets/storage_box_snapshot_info/defaults/main/common.yml
@@ -15,8 +15,8 @@ hcloud_ns: "ansible-{{ hcloud_run_ns }}-{{ hcloud_role_ns }}"
 hcloud_server_type_name: cpx22
 hcloud_server_type_id: 109
 
-hcloud_server_type_upgrade_name: cax21
-hcloud_server_type_upgrade_id: 93
+hcloud_server_type_upgrade_name: cpx32
+hcloud_server_type_upgrade_id: 110
 
 hcloud_image_name: debian-12
 hcloud_image_id: 114690389 # architecture=arm

--- a/tests/integration/targets/storage_box_snapshot_info/defaults/main/common.yml
+++ b/tests/integration/targets/storage_box_snapshot_info/defaults/main/common.yml
@@ -12,8 +12,8 @@ hcloud_role_ns: "{{ role_name | split('_') | map('batch', 2) | map('first') | fl
 hcloud_ns: "ansible-{{ hcloud_run_ns }}-{{ hcloud_role_ns }}"
 
 # Used to easily update the server types and images across all our tests.
-hcloud_server_type_name: cax11
-hcloud_server_type_id: 45
+hcloud_server_type_name: cpx22
+hcloud_server_type_id: 109
 
 hcloud_server_type_upgrade_name: cax21
 hcloud_server_type_upgrade_id: 93

--- a/tests/integration/targets/storage_box_subaccount/defaults/main/common.yml
+++ b/tests/integration/targets/storage_box_subaccount/defaults/main/common.yml
@@ -15,8 +15,8 @@ hcloud_ns: "ansible-{{ hcloud_run_ns }}-{{ hcloud_role_ns }}"
 hcloud_server_type_name: cpx22
 hcloud_server_type_id: 109
 
-hcloud_server_type_upgrade_name: cax21
-hcloud_server_type_upgrade_id: 93
+hcloud_server_type_upgrade_name: cpx32
+hcloud_server_type_upgrade_id: 110
 
 hcloud_image_name: debian-12
 hcloud_image_id: 114690389 # architecture=arm

--- a/tests/integration/targets/storage_box_subaccount/defaults/main/common.yml
+++ b/tests/integration/targets/storage_box_subaccount/defaults/main/common.yml
@@ -12,8 +12,8 @@ hcloud_role_ns: "{{ role_name | split('_') | map('batch', 2) | map('first') | fl
 hcloud_ns: "ansible-{{ hcloud_run_ns }}-{{ hcloud_role_ns }}"
 
 # Used to easily update the server types and images across all our tests.
-hcloud_server_type_name: cax11
-hcloud_server_type_id: 45
+hcloud_server_type_name: cpx22
+hcloud_server_type_id: 109
 
 hcloud_server_type_upgrade_name: cax21
 hcloud_server_type_upgrade_id: 93

--- a/tests/integration/targets/storage_box_subaccount_info/defaults/main/common.yml
+++ b/tests/integration/targets/storage_box_subaccount_info/defaults/main/common.yml
@@ -15,8 +15,8 @@ hcloud_ns: "ansible-{{ hcloud_run_ns }}-{{ hcloud_role_ns }}"
 hcloud_server_type_name: cpx22
 hcloud_server_type_id: 109
 
-hcloud_server_type_upgrade_name: cax21
-hcloud_server_type_upgrade_id: 93
+hcloud_server_type_upgrade_name: cpx32
+hcloud_server_type_upgrade_id: 110
 
 hcloud_image_name: debian-12
 hcloud_image_id: 114690389 # architecture=arm

--- a/tests/integration/targets/storage_box_subaccount_info/defaults/main/common.yml
+++ b/tests/integration/targets/storage_box_subaccount_info/defaults/main/common.yml
@@ -12,8 +12,8 @@ hcloud_role_ns: "{{ role_name | split('_') | map('batch', 2) | map('first') | fl
 hcloud_ns: "ansible-{{ hcloud_run_ns }}-{{ hcloud_role_ns }}"
 
 # Used to easily update the server types and images across all our tests.
-hcloud_server_type_name: cax11
-hcloud_server_type_id: 45
+hcloud_server_type_name: cpx22
+hcloud_server_type_id: 109
 
 hcloud_server_type_upgrade_name: cax21
 hcloud_server_type_upgrade_id: 93

--- a/tests/integration/targets/storage_box_type_info/defaults/main/common.yml
+++ b/tests/integration/targets/storage_box_type_info/defaults/main/common.yml
@@ -15,8 +15,8 @@ hcloud_ns: "ansible-{{ hcloud_run_ns }}-{{ hcloud_role_ns }}"
 hcloud_server_type_name: cpx22
 hcloud_server_type_id: 109
 
-hcloud_server_type_upgrade_name: cax21
-hcloud_server_type_upgrade_id: 93
+hcloud_server_type_upgrade_name: cpx32
+hcloud_server_type_upgrade_id: 110
 
 hcloud_image_name: debian-12
 hcloud_image_id: 114690389 # architecture=arm

--- a/tests/integration/targets/storage_box_type_info/defaults/main/common.yml
+++ b/tests/integration/targets/storage_box_type_info/defaults/main/common.yml
@@ -12,8 +12,8 @@ hcloud_role_ns: "{{ role_name | split('_') | map('batch', 2) | map('first') | fl
 hcloud_ns: "ansible-{{ hcloud_run_ns }}-{{ hcloud_role_ns }}"
 
 # Used to easily update the server types and images across all our tests.
-hcloud_server_type_name: cax11
-hcloud_server_type_id: 45
+hcloud_server_type_name: cpx22
+hcloud_server_type_id: 109
 
 hcloud_server_type_upgrade_name: cax21
 hcloud_server_type_upgrade_id: 93

--- a/tests/integration/targets/subnetwork/defaults/main/common.yml
+++ b/tests/integration/targets/subnetwork/defaults/main/common.yml
@@ -15,8 +15,8 @@ hcloud_ns: "ansible-{{ hcloud_run_ns }}-{{ hcloud_role_ns }}"
 hcloud_server_type_name: cpx22
 hcloud_server_type_id: 109
 
-hcloud_server_type_upgrade_name: cax21
-hcloud_server_type_upgrade_id: 93
+hcloud_server_type_upgrade_name: cpx32
+hcloud_server_type_upgrade_id: 110
 
 hcloud_image_name: debian-12
 hcloud_image_id: 114690389 # architecture=arm

--- a/tests/integration/targets/subnetwork/defaults/main/common.yml
+++ b/tests/integration/targets/subnetwork/defaults/main/common.yml
@@ -12,8 +12,8 @@ hcloud_role_ns: "{{ role_name | split('_') | map('batch', 2) | map('first') | fl
 hcloud_ns: "ansible-{{ hcloud_run_ns }}-{{ hcloud_role_ns }}"
 
 # Used to easily update the server types and images across all our tests.
-hcloud_server_type_name: cax11
-hcloud_server_type_id: 45
+hcloud_server_type_name: cpx22
+hcloud_server_type_id: 109
 
 hcloud_server_type_upgrade_name: cax21
 hcloud_server_type_upgrade_id: 93

--- a/tests/integration/targets/volume/defaults/main/common.yml
+++ b/tests/integration/targets/volume/defaults/main/common.yml
@@ -15,8 +15,8 @@ hcloud_ns: "ansible-{{ hcloud_run_ns }}-{{ hcloud_role_ns }}"
 hcloud_server_type_name: cpx22
 hcloud_server_type_id: 109
 
-hcloud_server_type_upgrade_name: cax21
-hcloud_server_type_upgrade_id: 93
+hcloud_server_type_upgrade_name: cpx32
+hcloud_server_type_upgrade_id: 110
 
 hcloud_image_name: debian-12
 hcloud_image_id: 114690389 # architecture=arm

--- a/tests/integration/targets/volume/defaults/main/common.yml
+++ b/tests/integration/targets/volume/defaults/main/common.yml
@@ -12,8 +12,8 @@ hcloud_role_ns: "{{ role_name | split('_') | map('batch', 2) | map('first') | fl
 hcloud_ns: "ansible-{{ hcloud_run_ns }}-{{ hcloud_role_ns }}"
 
 # Used to easily update the server types and images across all our tests.
-hcloud_server_type_name: cax11
-hcloud_server_type_id: 45
+hcloud_server_type_name: cpx22
+hcloud_server_type_id: 109
 
 hcloud_server_type_upgrade_name: cax21
 hcloud_server_type_upgrade_id: 93

--- a/tests/integration/targets/volume_attachment/defaults/main/common.yml
+++ b/tests/integration/targets/volume_attachment/defaults/main/common.yml
@@ -15,8 +15,8 @@ hcloud_ns: "ansible-{{ hcloud_run_ns }}-{{ hcloud_role_ns }}"
 hcloud_server_type_name: cpx22
 hcloud_server_type_id: 109
 
-hcloud_server_type_upgrade_name: cax21
-hcloud_server_type_upgrade_id: 93
+hcloud_server_type_upgrade_name: cpx32
+hcloud_server_type_upgrade_id: 110
 
 hcloud_image_name: debian-12
 hcloud_image_id: 114690389 # architecture=arm

--- a/tests/integration/targets/volume_attachment/defaults/main/common.yml
+++ b/tests/integration/targets/volume_attachment/defaults/main/common.yml
@@ -12,8 +12,8 @@ hcloud_role_ns: "{{ role_name | split('_') | map('batch', 2) | map('first') | fl
 hcloud_ns: "ansible-{{ hcloud_run_ns }}-{{ hcloud_role_ns }}"
 
 # Used to easily update the server types and images across all our tests.
-hcloud_server_type_name: cax11
-hcloud_server_type_id: 45
+hcloud_server_type_name: cpx22
+hcloud_server_type_id: 109
 
 hcloud_server_type_upgrade_name: cax21
 hcloud_server_type_upgrade_id: 93

--- a/tests/integration/targets/volume_info/defaults/main/common.yml
+++ b/tests/integration/targets/volume_info/defaults/main/common.yml
@@ -15,8 +15,8 @@ hcloud_ns: "ansible-{{ hcloud_run_ns }}-{{ hcloud_role_ns }}"
 hcloud_server_type_name: cpx22
 hcloud_server_type_id: 109
 
-hcloud_server_type_upgrade_name: cax21
-hcloud_server_type_upgrade_id: 93
+hcloud_server_type_upgrade_name: cpx32
+hcloud_server_type_upgrade_id: 110
 
 hcloud_image_name: debian-12
 hcloud_image_id: 114690389 # architecture=arm

--- a/tests/integration/targets/volume_info/defaults/main/common.yml
+++ b/tests/integration/targets/volume_info/defaults/main/common.yml
@@ -12,8 +12,8 @@ hcloud_role_ns: "{{ role_name | split('_') | map('batch', 2) | map('first') | fl
 hcloud_ns: "ansible-{{ hcloud_run_ns }}-{{ hcloud_role_ns }}"
 
 # Used to easily update the server types and images across all our tests.
-hcloud_server_type_name: cax11
-hcloud_server_type_id: 45
+hcloud_server_type_name: cpx22
+hcloud_server_type_id: 109
 
 hcloud_server_type_upgrade_name: cax21
 hcloud_server_type_upgrade_id: 93

--- a/tests/integration/targets/zone/defaults/main/common.yml
+++ b/tests/integration/targets/zone/defaults/main/common.yml
@@ -15,8 +15,8 @@ hcloud_ns: "ansible-{{ hcloud_run_ns }}-{{ hcloud_role_ns }}"
 hcloud_server_type_name: cpx22
 hcloud_server_type_id: 109
 
-hcloud_server_type_upgrade_name: cax21
-hcloud_server_type_upgrade_id: 93
+hcloud_server_type_upgrade_name: cpx32
+hcloud_server_type_upgrade_id: 110
 
 hcloud_image_name: debian-12
 hcloud_image_id: 114690389 # architecture=arm

--- a/tests/integration/targets/zone/defaults/main/common.yml
+++ b/tests/integration/targets/zone/defaults/main/common.yml
@@ -12,8 +12,8 @@ hcloud_role_ns: "{{ role_name | split('_') | map('batch', 2) | map('first') | fl
 hcloud_ns: "ansible-{{ hcloud_run_ns }}-{{ hcloud_role_ns }}"
 
 # Used to easily update the server types and images across all our tests.
-hcloud_server_type_name: cax11
-hcloud_server_type_id: 45
+hcloud_server_type_name: cpx22
+hcloud_server_type_id: 109
 
 hcloud_server_type_upgrade_name: cax21
 hcloud_server_type_upgrade_id: 93

--- a/tests/integration/targets/zone_info/defaults/main/common.yml
+++ b/tests/integration/targets/zone_info/defaults/main/common.yml
@@ -15,8 +15,8 @@ hcloud_ns: "ansible-{{ hcloud_run_ns }}-{{ hcloud_role_ns }}"
 hcloud_server_type_name: cpx22
 hcloud_server_type_id: 109
 
-hcloud_server_type_upgrade_name: cax21
-hcloud_server_type_upgrade_id: 93
+hcloud_server_type_upgrade_name: cpx32
+hcloud_server_type_upgrade_id: 110
 
 hcloud_image_name: debian-12
 hcloud_image_id: 114690389 # architecture=arm

--- a/tests/integration/targets/zone_info/defaults/main/common.yml
+++ b/tests/integration/targets/zone_info/defaults/main/common.yml
@@ -12,8 +12,8 @@ hcloud_role_ns: "{{ role_name | split('_') | map('batch', 2) | map('first') | fl
 hcloud_ns: "ansible-{{ hcloud_run_ns }}-{{ hcloud_role_ns }}"
 
 # Used to easily update the server types and images across all our tests.
-hcloud_server_type_name: cax11
-hcloud_server_type_id: 45
+hcloud_server_type_name: cpx22
+hcloud_server_type_id: 109
 
 hcloud_server_type_upgrade_name: cax21
 hcloud_server_type_upgrade_id: 93

--- a/tests/integration/targets/zone_rrset/defaults/main/common.yml
+++ b/tests/integration/targets/zone_rrset/defaults/main/common.yml
@@ -15,8 +15,8 @@ hcloud_ns: "ansible-{{ hcloud_run_ns }}-{{ hcloud_role_ns }}"
 hcloud_server_type_name: cpx22
 hcloud_server_type_id: 109
 
-hcloud_server_type_upgrade_name: cax21
-hcloud_server_type_upgrade_id: 93
+hcloud_server_type_upgrade_name: cpx32
+hcloud_server_type_upgrade_id: 110
 
 hcloud_image_name: debian-12
 hcloud_image_id: 114690389 # architecture=arm

--- a/tests/integration/targets/zone_rrset/defaults/main/common.yml
+++ b/tests/integration/targets/zone_rrset/defaults/main/common.yml
@@ -12,8 +12,8 @@ hcloud_role_ns: "{{ role_name | split('_') | map('batch', 2) | map('first') | fl
 hcloud_ns: "ansible-{{ hcloud_run_ns }}-{{ hcloud_role_ns }}"
 
 # Used to easily update the server types and images across all our tests.
-hcloud_server_type_name: cax11
-hcloud_server_type_id: 45
+hcloud_server_type_name: cpx22
+hcloud_server_type_id: 109
 
 hcloud_server_type_upgrade_name: cax21
 hcloud_server_type_upgrade_id: 93

--- a/tests/integration/targets/zone_rrset_info/defaults/main/common.yml
+++ b/tests/integration/targets/zone_rrset_info/defaults/main/common.yml
@@ -15,8 +15,8 @@ hcloud_ns: "ansible-{{ hcloud_run_ns }}-{{ hcloud_role_ns }}"
 hcloud_server_type_name: cpx22
 hcloud_server_type_id: 109
 
-hcloud_server_type_upgrade_name: cax21
-hcloud_server_type_upgrade_id: 93
+hcloud_server_type_upgrade_name: cpx32
+hcloud_server_type_upgrade_id: 110
 
 hcloud_image_name: debian-12
 hcloud_image_id: 114690389 # architecture=arm

--- a/tests/integration/targets/zone_rrset_info/defaults/main/common.yml
+++ b/tests/integration/targets/zone_rrset_info/defaults/main/common.yml
@@ -12,8 +12,8 @@ hcloud_role_ns: "{{ role_name | split('_') | map('batch', 2) | map('first') | fl
 hcloud_ns: "ansible-{{ hcloud_run_ns }}-{{ hcloud_role_ns }}"
 
 # Used to easily update the server types and images across all our tests.
-hcloud_server_type_name: cax11
-hcloud_server_type_id: 45
+hcloud_server_type_name: cpx22
+hcloud_server_type_id: 109
 
 hcloud_server_type_upgrade_name: cax21
 hcloud_server_type_upgrade_id: 93


### PR DESCRIPTION
The CAX Server Types are currently not available. This PR changes them to CPX, which we also use for tests in our other integrations.