### PR TITLE
feat: deprecate `datacenter_info` module

### DIFF
--- a/changelogs/fragments/deprecate-datacenters.yml
+++ b/changelogs/fragments/deprecate-datacenters.yml
@@ -1,12 +1,2 @@
-release_summary: |
-  This release is phasing out datacenters.
-
-  The ``datacenter_info`` module is deprecated and will be removed after 1 Oct. 2026. After this date, requests to the datacenters API endpoints will return HTTP 410 Gone.
-
-  Please use the ``location_info`` module instead.
-
-  See our `changelog`_ for more details.
-
-  .. _changelog: https://docs.hetzner.cloud/changelog#2026-06-02-datacenters-deprecated
 deprecated_features:
   - datacenter_info - The ``datacenter_info`` module is deprecated and will be removed after 1 Oct. 2026. Please use the ``location_info`` module instead.

--- a/changelogs/fragments/deprecate-datacenters.yml
+++ b/changelogs/fragments/deprecate-datacenters.yml
@@ -1,0 +1,12 @@
+release_summary: |
+  This release is phasing out datacenters.
+
+  The ``datacenter_info`` module is deprecated and will be removed after 1 Oct. 2026. After this date, requests to the datacenters API endpoints will return HTTP 410 Gone.
+
+  Please use the ``location_info`` module instead.
+
+  See our `changelog`_ for more details.
+
+  .. _changelog: https://docs.hetzner.cloud/changelog#2026-06-02-datacenters-deprecated
+deprecated_features:
+  - datacenter_info - The ``datacenter_info`` module is deprecated and will be removed after 1 Oct. 2026. Please use the ``location_info`` module instead.

--- a/changelogs/fragments/release-summary.yml
+++ b/changelogs/fragments/release-summary.yml
@@ -6,3 +6,11 @@ release_summary: |
   ``http.timeout_idle`` argument on the ``load_balancer_service`` module.
 
   See the `changelog <https://docs.hetzner.cloud/changelog#2026-04-30-load-balancers-http-idle-timeout-can-now-be-configured>`__ for more details.
+
+  **Datacenters are deprecated**
+
+  The ``datacenter_info`` module is deprecated and will be removed after 1 Oct. 2026. After this date, requests to the datacenters API endpoints will return HTTP 410 Gone.
+
+  Please use the ``location_info`` module instead.
+
+  See the `changelog <https://docs.hetzner.cloud/changelog#2026-06-02-datacenters-deprecated>`__ for more details.

--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -54,8 +54,6 @@ plugin_routing:
       redirect: hetzner.hcloud.certificate_info
     hcloud_certificate:
       redirect: hetzner.hcloud.certificate
-    hcloud_datacenter_info:
-      redirect: hetzner.hcloud.datacenter_info
     hcloud_firewall:
       redirect: hetzner.hcloud.firewall
     hcloud_firewall_info:
@@ -140,3 +138,17 @@ plugin_routing:
       redirect: hetzner.hcloud.zone_rrset
     hcloud_zone_rrset_info:
       redirect: hetzner.hcloud.zone_rrset_info
+
+    hcloud_datacenter_info:
+      redirect: hetzner.hcloud.datacenter_info
+      deprecation:
+        removal_date: 2026-10-01
+        warning_text: >-
+          The ``datacenter_info`` module is deprecated and will be removed after 1 Oct. 2026.
+          See https://docs.hetzner.cloud/changelog#2026-06-02-datacenters-deprecated for more details.
+    datacenter_info:
+      deprecation:
+        removal_date: 2026-10-01
+        warning_text: >-
+          The ``datacenter_info`` module is deprecated and will be removed after 1 Oct. 2026.
+          See https://docs.hetzner.cloud/changelog#2026-06-02-datacenters-deprecated for more details.

--- a/plugins/modules/datacenter_info.py
+++ b/plugins/modules/datacenter_info.py
@@ -10,6 +10,15 @@ DOCUMENTATION = """
 ---
 module: datacenter_info
 
+deprecated:
+    removed_at_date: 2026-10-01
+    why: >-
+      The API endpoints ``GET /v1/datacenters`` and ``GET /v1/datacenters/{id}`` are now deprecated and
+      will be removed after 1 Oct. 2026. After this date, requests to these endpoints will return ``HTTP 410 Gone``.
+
+      See https://docs.hetzner.cloud/changelog#2026-06-02-datacenters-deprecated for more details.
+    alternative: Use M(hetzner.cloud.location_info) instead.
+
 short_description: Gather info about the Hetzner Cloud datacenters.
 
 description:


### PR DESCRIPTION
##### SUMMARY

The API endpoints `GET /v1/datacenters` and `GET /v1/datacenters/{id}` are now deprecated and will be removed after 1 Oct. 2026. After this date, requests to these endpoints will return `HTTP 410 Gone`.

See https://docs.hetzner.cloud/changelog#2026-06-02-datacenters-deprecated for more details.
