### PR TITLE
fix: do not duplicate ansible own deprecation texts

### DIFF
--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -143,12 +143,8 @@ plugin_routing:
       redirect: hetzner.hcloud.datacenter_info
       deprecation:
         removal_date: 2026-10-01
-        warning_text: >-
-          The ``datacenter_info`` module is deprecated and will be removed after 1 Oct. 2026.
-          See https://docs.hetzner.cloud/changelog#2026-06-02-datacenters-deprecated for more details.
+        warning_text: See https://docs.hetzner.cloud/changelog#2026-06-02-datacenters-deprecated for more details.
     datacenter_info:
       deprecation:
         removal_date: 2026-10-01
-        warning_text: >-
-          The ``datacenter_info`` module is deprecated and will be removed after 1 Oct. 2026.
-          See https://docs.hetzner.cloud/changelog#2026-06-02-datacenters-deprecated for more details.
+        warning_text: See https://docs.hetzner.cloud/changelog#2026-06-02-datacenters-deprecated for more details.


### PR DESCRIPTION
##### SUMMARY
With the duplicate text removed, we now have:
```
[DEPRECATION WARNING]: hetzner.hcloud.datacenter_info has been deprecated. See https://docs.hetzner.cloud/changelog#2026-06-02-datacenters-deprecated for more details. This feature will be removed from collection 'hetzner.hcloud' in a release after 2026-10-01.
```