### PR TITLE
feat: print deprecation warning for load balancer type 

### DIFF
--- a/changelogs/fragments/load-balancer-type-deprecation.yml
+++ b/changelogs/fragments/load-balancer-type-deprecation.yml
@@ -1,0 +1,3 @@
+minor_changes:
+  - load_balancer - Print warning when creating a Load Balancer with a deprecated or unavailable Load Balancer Type.
+  - load_balancer_type_info - Added the Load Balancer Type ``deprecation`` object to the return values (``load_balancer_type_info[].deprecation``).

--- a/plugins/module_utils/_deprecation.py
+++ b/plugins/module_utils/_deprecation.py
@@ -8,6 +8,7 @@ from datetime import datetime, timezone
 
 from ansible.module_utils.basic import AnsibleModule
 
+from ._vendor.hcloud.load_balancer_types import BoundLoadBalancerType
 from ._vendor.hcloud.locations import BoundLocation
 from ._vendor.hcloud.server_types import BoundServerType, ServerTypeLocation
 
@@ -22,6 +23,11 @@ def deprecated_server_type_warning(
     server_type: BoundServerType,
     location: BoundLocation | None = None,
 ) -> bool:
+    """
+    Print a warning when the Server Type is either deprecated or unavailable. Returns
+    whether any warning was printed. Without location, some deprecation cannot be
+    checked.
+    """
     with warnings.catch_warnings():
         warnings.simplefilter("ignore")
         if server_type.deprecation is not None:
@@ -127,3 +133,33 @@ def deprecated_server_type_warning(
         )
 
     return True
+
+
+def deprecated_load_balancer_type_warning(
+    module: AnsibleModule,
+    load_balancer_type: BoundLoadBalancerType,
+) -> bool:
+    """
+    Print a warning when the Load Balancer Type is either deprecated or unavailable.
+    Returns whether any warning was printed.
+    """
+    if load_balancer_type.deprecation is not None:
+        if load_balancer_type.deprecation.unavailable_after < datetime.now(timezone.utc):
+            module.warn(
+                str.format(
+                    "Load Balancer type {load_balancer_type} is unavailable and can no longer be ordered.",
+                    load_balancer_type=load_balancer_type.name,
+                ),
+            )
+        else:
+            module.warn(
+                str.format(
+                    "Load Balancer type {load_balancer_type} is deprecated and will no longer be available "
+                    "for order as of {unavailable_after}.",
+                    load_balancer_type=load_balancer_type.name,
+                    unavailable_after=load_balancer_type.deprecation.unavailable_after.strftime("%Y-%m-%d"),
+                ),
+            )
+        return True
+
+    return False

--- a/plugins/modules/load_balancer.py
+++ b/plugins/modules/load_balancer.py
@@ -150,6 +150,7 @@ hcloud_load_balancer:
 from ansible.module_utils.basic import AnsibleModule
 
 from ..module_utils._base import AnsibleHCloud
+from ..module_utils._deprecation import deprecated_load_balancer_type_warning
 from ..module_utils._vendor.hcloud import HCloudException
 from ..module_utils._vendor.hcloud.load_balancers import (
     BoundLoadBalancer,
@@ -191,14 +192,18 @@ class AnsibleHCloudLoadBalancer(AnsibleHCloud):
     def _create_load_balancer(self):
         self.module.fail_on_missing_params(required_params=["name", "load_balancer_type"])
         try:
+            load_balancer_type = self.client.load_balancer_types.get_by_name(
+                self.module.params.get("load_balancer_type")
+            )
+
             params = {
                 "name": self.module.params.get("name"),
                 "algorithm": LoadBalancerAlgorithm(type=self.module.params.get("algorithm", "round_robin")),
-                "load_balancer_type": self.client.load_balancer_types.get_by_name(
-                    self.module.params.get("load_balancer_type")
-                ),
+                "load_balancer_type": load_balancer_type,
                 "labels": self.module.params.get("labels"),
             }
+
+            deprecated_load_balancer_type_warning(self.module, load_balancer_type)
 
             if self.module.params.get("location") is None and self.module.params.get("network_zone") is None:
                 self.module.fail_json(msg="one of the following is required: location, network_zone")

--- a/plugins/modules/load_balancer_type_info.py
+++ b/plugins/modules/load_balancer_type_info.py
@@ -85,6 +85,26 @@ hcloud_load_balancer_type_info:
             returned: always
             type: int
             sample: 5
+        deprecation:
+            description: |
+              Describes if, when & how the resources was deprecated.
+              If this field is set to None the resource is not deprecated. If it has a value, it is considered deprecated.
+            returned: when deprecated
+            type: dict
+            contains:
+                announced:
+                    description: Date of when the deprecation was announced.
+                    returned: when deprecated
+                    type: str
+                    sample: "2026-03-09T09:00:00Z"
+                unavailable_after:
+                    description: |
+                      After the time in this field, the resource will not be available from the general listing
+                      endpoint of the resource type, and it can not be used in new resources. For example, if this is
+                      an image, you can not create new servers with this image after the mentioned date.
+                    returned: when deprecated
+                    type: str
+                    sample: "2026-06-09T09:00:00Z"
 """
 
 from ansible.module_utils.basic import AnsibleModule
@@ -115,6 +135,14 @@ class AnsibleHCloudLoadBalancerTypeInfo(AnsibleHCloud):
                     "max_services": load_balancer_type.max_services,
                     "max_targets": load_balancer_type.max_targets,
                     "max_assigned_certificates": load_balancer_type.max_assigned_certificates,
+                    "deprecation": (
+                        {
+                            "announced": load_balancer_type.deprecation.announced.isoformat(),
+                            "unavailable_after": load_balancer_type.deprecation.unavailable_after.isoformat(),
+                        }
+                        if load_balancer_type.deprecation is not None
+                        else None
+                    ),
                 }
             )
         return tmp

--- a/tests/unit/module_utils/test_deprecation.py
+++ b/tests/unit/module_utils/test_deprecation.py
@@ -6,7 +6,11 @@ from unittest import mock
 import pytest
 
 from plugins.module_utils._deprecation import (
+    deprecated_load_balancer_type_warning,
     deprecated_server_type_warning,
+)
+from plugins.module_utils._vendor.hcloud.load_balancer_types import (
+    BoundLoadBalancerType,
 )
 from plugins.module_utils._vendor.hcloud.locations import (
     BoundLocation,
@@ -256,4 +260,43 @@ DEPRECATION_UNAVAILABLE = {
 def test_deprecated_server_type_warning(server_type, location, calls):
     m = mock.Mock()
     deprecated_server_type_warning(m, server_type, location)
+    m.warn.assert_has_calls(calls)
+
+
+@pytest.mark.parametrize(
+    ("load_balancer_type", "calls"),
+    [
+        (
+            BoundLoadBalancerType(
+                mock.Mock(),
+                {"name": "lb11"},
+            ),
+            [],
+        ),
+        # - Deprecated
+        (
+            BoundLoadBalancerType(
+                mock.Mock(),
+                {"name": "lb11", **DEPRECATION_DEPRECATED},
+            ),
+            [
+                mock.call(
+                    "Load Balancer type lb11 is deprecated and will no longer "
+                    f"be available for order as of {FUTURE.strftime('%Y-%m-%d')}."
+                )
+            ],
+        ),
+        # - Unavailable
+        (
+            BoundLoadBalancerType(
+                mock.Mock(),
+                {"name": "lb11", **DEPRECATION_UNAVAILABLE},
+            ),
+            [mock.call("Load Balancer type lb11 is unavailable and can no longer be ordered.")],
+        ),
+    ],
+)
+def test_deprecated_load_balancer_type_warning(load_balancer_type, calls):
+    m = mock.Mock()
+    deprecated_load_balancer_type_warning(m, load_balancer_type)
     m.warn.assert_has_calls(calls)


### PR DESCRIPTION
##### SUMMARY
- Print warning about deprecated load balancer types
- Return the load balancer type deprecation info in the `load_balancer_type_info` module.

