### PR TITLE
feat: revert all changes from the 6.11.0 release

### DIFF
--- a/changelogs/fragments/revert-6.11.yaml
+++ b/changelogs/fragments/revert-6.11.yaml
@@ -1,0 +1,12 @@
+release_summary: |
+  This release is reverting all the changes made in 6.11.
+
+  In the 6.11.0 release, we removed some features from this collection without marking
+  the change as breaking (i.e., without a new major release). We didn't mark it as
+  breaking because the removal originated in the Hetzner Cloud API itself, the features
+  stopped working there regardless of what we did on our end, so not removing them would
+  have caused some breakage anyway.
+
+  However, to comply with the community package collection requirements, such removals
+  must be released as breaking changes. We will therefore revert the 6.11.0 changes in the
+  6.12.0 release, and then re-introduce them as a new major release 7.0.0.

--- a/plugins/inventory/hcloud.py
+++ b/plugins/inventory/hcloud.py
@@ -173,6 +173,10 @@ plugin: hetzner.hcloud.hcloud
 #   hcloud_image_os_flavor: "debian"
 ## Location
 #   hcloud_location: "hel1"
+#   # The hcloud_datacenter variable is deprecated and will be removed after 1 July 2026.
+#   # Please use the hcloud_location variable instead.
+#   # See https://docs.hetzner.cloud/changelog#2025-12-16-phasing-out-datacenters.
+#   hcloud_datacenter: "hel1-dc2"
 ## Network
 #   hcloud_ipv4: "65.109.140.95" # Value is optional!
 #   hcloud_ipv6: "2a01:4f9:c011:b83f::1" # Value is optional!
@@ -188,6 +192,7 @@ hostname: "my-prefix-{{ hcloud_location }}-{{ hcloud_name }}-{{ hcloud_server_ty
 """
 
 import sys
+import warnings
 from ipaddress import IPv6Network
 
 from ansible.errors import AnsibleError
@@ -228,7 +233,8 @@ if sys.version_info >= (3, 11):
         server_type: str
         architecture: str
 
-        # Location
+        # Datacenter
+        datacenter: str  # Deprecated!
         location: str
 
         # Labels
@@ -365,6 +371,14 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
 
         # Location
         server_dict["location"] = server.location.name
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", category=DeprecationWarning)
+            self.display.warning(
+                "The `hcloud_datacenter` variable is deprecated and will be removed "
+                "after 1 July 2026. Please use the `hcloud_location` variable instead. "
+                "See https://docs.hetzner.cloud/changelog#2025-12-16-phasing-out-datacenters."
+            )
+            server_dict["datacenter"] = server.datacenter and server.datacenter.name
 
         # Image
         if server.image is not None:

--- a/plugins/module_utils/_deprecation.py
+++ b/plugins/module_utils/_deprecation.py
@@ -8,7 +8,6 @@ from datetime import datetime, timezone
 
 from ansible.module_utils.basic import AnsibleModule
 
-from ._vendor.hcloud.load_balancer_types import BoundLoadBalancerType
 from ._vendor.hcloud.locations import BoundLocation
 from ._vendor.hcloud.server_types import BoundServerType, ServerTypeLocation
 
@@ -23,11 +22,6 @@ def deprecated_server_type_warning(
     server_type: BoundServerType,
     location: BoundLocation | None = None,
 ) -> bool:
-    """
-    Print a warning when the Server Type is either deprecated or unavailable. Returns
-    whether any warning was printed. Without location, some deprecation cannot be
-    checked.
-    """
     with warnings.catch_warnings():
         warnings.simplefilter("ignore")
         if server_type.deprecation is not None:
@@ -133,33 +127,3 @@ def deprecated_server_type_warning(
         )
 
     return True
-
-
-def deprecated_load_balancer_type_warning(
-    module: AnsibleModule,
-    load_balancer_type: BoundLoadBalancerType,
-) -> bool:
-    """
-    Print a warning when the Load Balancer Type is either deprecated or unavailable.
-    Returns whether any warning was printed.
-    """
-    if load_balancer_type.deprecation is not None:
-        if load_balancer_type.deprecation.unavailable_after < datetime.now(timezone.utc):
-            module.warn(
-                str.format(
-                    "Load Balancer type {load_balancer_type} is unavailable and can no longer be ordered.",
-                    load_balancer_type=load_balancer_type.name,
-                ),
-            )
-        else:
-            module.warn(
-                str.format(
-                    "Load Balancer type {load_balancer_type} is deprecated and will no longer be available "
-                    "for order as of {unavailable_after}.",
-                    load_balancer_type=load_balancer_type.name,
-                    unavailable_after=load_balancer_type.deprecation.unavailable_after.strftime("%Y-%m-%d"),
-                ),
-            )
-        return True
-
-    return False

--- a/plugins/module_utils/_primary_ip.py
+++ b/plugins/module_utils/_primary_ip.py
@@ -15,6 +15,7 @@ def prepare_result(o: BoundPrimaryIP):
         "ip": o.ip,
         "type": o.type,
         "location": o.location.name,
+        "datacenter": o.datacenter and o.datacenter.name,
         "labels": o.labels,
         "delete_protection": o.protection["delete"],
         "assignee_id": o.assignee_id,

--- a/plugins/module_utils/_vendor/hcloud/_client.py
+++ b/plugins/module_utils/_vendor/hcloud/_client.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import time
-import warnings
 from http import HTTPStatus
 from random import uniform
 from typing import Any, Protocol
@@ -185,10 +184,11 @@ class Client:
             timeout=timeout,
         )
 
-        with warnings.catch_warnings():
-            warnings.filterwarnings("ignore", category=DeprecationWarning)
-            self.datacenters = DatacentersClient(self)
+        self.datacenters = DatacentersClient(self)
+        """DatacentersClient Instance
 
+        :type: :class:`DatacentersClient <hcloud.datacenters.client.DatacentersClient>`
+        """
         self.locations = LocationsClient(self)
         """LocationsClient Instance
 
@@ -305,28 +305,6 @@ class Client:
         :param timeout: Requests timeout in seconds.
         """
         return self._client.request(method, url, **kwargs)
-
-    @property
-    def datacenters(self) -> DatacentersClient:
-        """DatacentersClient Instance
-
-        .. deprecated:: 2.22.0
-            The datacenters client is deprecated and will be removed after the 2026-10-01.
-            See https://docs.hetzner.cloud/changelog#2026-06-02-datacenters-deprecated.
-
-        :type: :class:`DatacentersClient <hcloud.datacenters.client.DatacentersClient>`
-        """
-        warnings.warn(
-            "The datacenters client is deprecated and will be removed after the 2026-10-01. "
-            "See https://docs.hetzner.cloud/changelog#2026-06-02-datacenters-deprecated.",
-            DeprecationWarning,
-            stacklevel=2,
-        )
-        return self._datacenters
-
-    @datacenters.setter
-    def datacenters(self, value: DatacentersClient) -> None:
-        self._datacenters = value
 
 
 class ClientBase:

--- a/plugins/module_utils/_vendor/hcloud/_version.py
+++ b/plugins/module_utils/_vendor/hcloud/_version.py
@@ -1,3 +1,3 @@
 from __future__ import annotations
 
-__version__ = "2.23.0"  # x-releaser-pleaser-version
+__version__ = "2.21.0"  # x-releaser-pleaser-version

--- a/plugins/module_utils/_vendor/hcloud/core/client.py
+++ b/plugins/module_utils/_vendor/hcloud/core/client.py
@@ -109,10 +109,7 @@ class BoundModelBase(Generic[Domain]):
         """
         self._client = client
         self.complete = complete
-
-        with warnings.catch_warnings():
-            warnings.filterwarnings("ignore", category=DeprecationWarning)
-            self.data_model: Domain = self.model.from_dict(data)
+        self.data_model: Domain = self.model.from_dict(data)
 
     def __getattr__(self, name: str):  # type: ignore[no-untyped-def]
         """Allow magical access to the properties of the model

--- a/plugins/module_utils/_vendor/hcloud/datacenters/client.py
+++ b/plugins/module_utils/_vendor/hcloud/datacenters/client.py
@@ -1,15 +1,11 @@
 from __future__ import annotations
 
-import warnings
-from typing import TYPE_CHECKING, Any, NamedTuple
+from typing import Any, NamedTuple
 
 from ..core import BoundModelBase, Meta, ResourceClientBase
 from ..locations import BoundLocation
 from ..server_types import BoundServerType
 from .domain import Datacenter, DatacenterServerTypes
-
-if TYPE_CHECKING:
-    from .._client import Client
 
 __all__ = [
     "BoundDatacenter",
@@ -19,12 +15,6 @@ __all__ = [
 
 
 class BoundDatacenter(BoundModelBase[Datacenter], Datacenter):
-    """
-    .. deprecated:: 2.22.0
-        The bound datacenter class is deprecated and will be removed after the 2026-10-01.
-        See https://docs.hetzner.cloud/changelog#2026-06-02-datacenters-deprecated.
-    """
-
     _client: DatacentersClient
 
     model = Datacenter
@@ -64,33 +54,12 @@ class BoundDatacenter(BoundModelBase[Datacenter], Datacenter):
 
 
 class DatacentersPageResult(NamedTuple):
-    """
-    .. deprecated:: 2.22.0
-        The datacenters page result class is deprecated and will be removed after the 2026-10-01.
-        See https://docs.hetzner.cloud/changelog#2026-06-02-datacenters-deprecated.
-    """
-
     datacenters: list[BoundDatacenter]
     meta: Meta
 
 
 class DatacentersClient(ResourceClientBase):
-    """
-    .. deprecated:: 2.22.0
-        The datacenters client class is deprecated and will be removed after the 2026-10-01.
-        See https://docs.hetzner.cloud/changelog#2026-06-02-datacenters-deprecated.
-    """
-
     _base_url = "/datacenters"
-
-    def __init__(self, client: Client):
-        warnings.warn(
-            "The datacenters client class is deprecated and will be removed after the 2026-10-01. "
-            "See https://docs.hetzner.cloud/changelog#2026-06-02-datacenters-deprecated.",
-            DeprecationWarning,
-            stacklevel=2,
-        )
-        super().__init__(client)
 
     def get_by_id(self, id: int) -> BoundDatacenter:
         """Get a specific datacenter by its ID.

--- a/plugins/module_utils/_vendor/hcloud/datacenters/domain.py
+++ b/plugins/module_utils/_vendor/hcloud/datacenters/domain.py
@@ -18,10 +18,6 @@ __all__ = [
 class Datacenter(BaseDomain, DomainIdentityMixin):
     """Datacenter Domain
 
-    .. deprecated:: 2.22.0
-        The datacenters domain class is deprecated and will be removed after the 2026-10-01.
-        See https://docs.hetzner.cloud/changelog#2026-06-02-datacenters-deprecated.
-
     :param id: int ID of Datacenter
     :param name: str Name of Datacenter
     :param description: str Description of Datacenter
@@ -41,12 +37,6 @@ class Datacenter(BaseDomain, DomainIdentityMixin):
         location: Location | None = None,
         server_types: DatacenterServerTypes | None = None,
     ):
-        warnings.warn(
-            "The datacenter domain class is deprecated and will be removed after the 2026-10-01. "
-            "See https://docs.hetzner.cloud/changelog#2026-06-02-datacenters-deprecated.",
-            DeprecationWarning,
-            stacklevel=2,
-        )
         self.id = id
         self.name = name
         self.description = description
@@ -78,10 +68,6 @@ class Datacenter(BaseDomain, DomainIdentityMixin):
 
 class DatacenterServerTypes(BaseDomain):
     """DatacenterServerTypes Domain
-
-    .. deprecated:: 2.22.0
-        The datacenters domain class is deprecated and will be removed after the 2026-10-01.
-        See https://docs.hetzner.cloud/changelog#2026-06-02-datacenters-deprecated.
 
     :param available: List[:class:`BoundServerTypes <hcloud.server_types.client.BoundServerTypes>`]
            All available server types for this datacenter

--- a/plugins/module_utils/_vendor/hcloud/load_balancer_types/domain.py
+++ b/plugins/module_utils/_vendor/hcloud/load_balancer_types/domain.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 from typing import Any
 
 from ..core import BaseDomain, DomainIdentityMixin
-from ..deprecation import DeprecationInfo
 
 __all__ = [
     "LoadBalancerType",
@@ -29,7 +28,7 @@ class LoadBalancerType(BaseDomain, DomainIdentityMixin):
            Max amount of certificates the Load Balancer can serve
     :param prices: List of dict
            Prices in different locations
-    :param deprecation: Define if and when the Load Balancer Type is deprecated.
+
     """
 
     __api_properties__ = (
@@ -41,7 +40,6 @@ class LoadBalancerType(BaseDomain, DomainIdentityMixin):
         "max_targets",
         "max_assigned_certificates",
         "prices",
-        "deprecation",
     )
     __slots__ = __api_properties__
 
@@ -55,7 +53,6 @@ class LoadBalancerType(BaseDomain, DomainIdentityMixin):
         max_targets: int | None = None,
         max_assigned_certificates: int | None = None,
         prices: list[dict[str, Any]] | None = None,
-        deprecation: dict[str, Any] | None = None,
     ):
         self.id = id
         self.name = name
@@ -65,4 +62,3 @@ class LoadBalancerType(BaseDomain, DomainIdentityMixin):
         self.max_targets = max_targets
         self.max_assigned_certificates = max_assigned_certificates
         self.prices = prices
-        self.deprecation = deprecation and DeprecationInfo.from_dict(deprecation)

--- a/plugins/module_utils/_vendor/hcloud/primary_ips/client.py
+++ b/plugins/module_utils/_vendor/hcloud/primary_ips/client.py
@@ -16,6 +16,7 @@ from .domain import CreatePrimaryIPResponse, PrimaryIP
 
 if TYPE_CHECKING:
     from .._client import Client
+    from ..datacenters import BoundDatacenter, Datacenter
     from ..locations import BoundLocation, Location
 
 
@@ -38,7 +39,12 @@ class BoundPrimaryIP(BoundModelBase[PrimaryIP], PrimaryIP):
         complete: bool = True,
     ):
         # pylint: disable=import-outside-toplevel
+        from ..datacenters import BoundDatacenter
         from ..locations import BoundLocation
+
+        raw = data.get("datacenter", {})
+        if raw:
+            data["datacenter"] = BoundDatacenter(client._parent.datacenters, raw)
 
         raw = data.get("location", {})
         if raw:
@@ -303,6 +309,7 @@ class PrimaryIPsClient(
         self,
         type: str,
         name: str,
+        datacenter: Datacenter | BoundDatacenter | None = None,
         location: Location | BoundLocation | None = None,
         assignee_type: str | None = None,
         assignee_id: int | None = None,
@@ -313,6 +320,7 @@ class PrimaryIPsClient(
 
         :param type: str Primary IP type Choices: ipv4, ipv6
         :param name: str
+        :param datacenter: Datacenter (optional)
         :param location: Location (optional)
         :param assignee_type: str (optional)
         :param assignee_id: int (optional)
@@ -326,6 +334,15 @@ class PrimaryIPsClient(
             "auto_delete": auto_delete,
         }
 
+        if datacenter is not None:
+            warnings.warn(
+                "The 'datacenter' argument is deprecated and will be removed after 1 July 2026. "
+                "Please use the 'location' argument instead. "
+                "See https://docs.hetzner.cloud/changelog#2025-12-16-phasing-out-datacenters",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+            data["datacenter"] = datacenter.id_or_name
         if location is not None:
             data["location"] = location.id_or_name
         if assignee_id is not None:

--- a/plugins/module_utils/_vendor/hcloud/primary_ips/domain.py
+++ b/plugins/module_utils/_vendor/hcloud/primary_ips/domain.py
@@ -1,11 +1,13 @@
 from __future__ import annotations
 
+import warnings
 from typing import TYPE_CHECKING, TypedDict
 
 from ..core import BaseDomain, DomainIdentityMixin
 
 if TYPE_CHECKING:
     from ..actions import BoundAction
+    from ..datacenters import BoundDatacenter
     from ..locations import BoundLocation
     from ..rdns import DNSPtr
     from .client import BoundPrimaryIP
@@ -28,6 +30,14 @@ class PrimaryIP(BaseDomain, DomainIdentityMixin):
            Type of Primary IP. Choices: `ipv4`, `ipv6`
     :param dns_ptr: List[Dict]
            Array of reverse DNS entries
+    :param datacenter: :class:`Datacenter <hcloud.datacenters.client.BoundDatacenter>`
+        Datacenter the Primary IP was created in.
+
+        This property is deprecated and will be removed after 1 July 2026.
+        Please use the ``location`` property instead.
+
+        See https://docs.hetzner.cloud/changelog#2025-12-16-phasing-out-datacenters.
+
     :param location: :class:`Location <hcloud.locations.client.BoundLocation>`
            Location the Primary IP was created in.
     :param blocked: boolean
@@ -48,7 +58,7 @@ class PrimaryIP(BaseDomain, DomainIdentityMixin):
            Delete the Primary IP when the Assignee it is assigned to is deleted.
     """
 
-    __api_properties__ = (
+    __properties__ = (
         "id",
         "ip",
         "type",
@@ -63,7 +73,14 @@ class PrimaryIP(BaseDomain, DomainIdentityMixin):
         "assignee_type",
         "auto_delete",
     )
-    __slots__ = __api_properties__
+    __api_properties__ = (
+        *__properties__,
+        "datacenter",
+    )
+    __slots__ = (
+        *__properties__,
+        "_datacenter",
+    )
 
     def __init__(
         self,
@@ -71,6 +88,7 @@ class PrimaryIP(BaseDomain, DomainIdentityMixin):
         type: str | None = None,
         ip: str | None = None,
         dns_ptr: list[DNSPtr] | None = None,
+        datacenter: BoundDatacenter | None = None,
         location: BoundLocation | None = None,
         blocked: bool | None = None,
         protection: PrimaryIPProtection | None = None,
@@ -85,6 +103,7 @@ class PrimaryIP(BaseDomain, DomainIdentityMixin):
         self.type = type
         self.ip = ip
         self.dns_ptr = dns_ptr
+        self.datacenter = datacenter
         self.location = location
         self.blocked = blocked
         self.protection = protection
@@ -94,6 +113,24 @@ class PrimaryIP(BaseDomain, DomainIdentityMixin):
         self.assignee_id = assignee_id
         self.assignee_type = assignee_type
         self.auto_delete = auto_delete
+
+    @property
+    def datacenter(self) -> BoundDatacenter | None:
+        """
+        :meta private:
+        """
+        warnings.warn(
+            "The 'datacenter' property is deprecated and will be removed after 1 July 2026. "
+            "Please use the 'location' property instead. "
+            "See https://docs.hetzner.cloud/changelog#2025-12-16-phasing-out-datacenters.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return self._datacenter
+
+    @datacenter.setter
+    def datacenter(self, value: BoundDatacenter | None) -> None:
+        self._datacenter = value
 
 
 class PrimaryIPProtection(TypedDict):

--- a/plugins/module_utils/_vendor/hcloud/servers/client.py
+++ b/plugins/module_utils/_vendor/hcloud/servers/client.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import warnings
 from datetime import datetime
 from typing import TYPE_CHECKING, Any, NamedTuple
 
@@ -17,6 +18,7 @@ from ..actions import (
 )
 from ..actions.client import ResourceClientBaseActionsMixin
 from ..core import BoundModelBase, Meta, ResourceClientBase
+from ..datacenters import BoundDatacenter
 from ..firewalls import BoundFirewall
 from ..floating_ips import BoundFloatingIP
 from ..images import BoundImage, CreateImageResponse
@@ -45,6 +47,7 @@ from .domain import (
 
 if TYPE_CHECKING:
     from .._client import Client
+    from ..datacenters import Datacenter
     from ..firewalls import Firewall
     from ..images import Image
     from ..isos import Iso
@@ -75,6 +78,10 @@ class BoundServer(BoundModelBase[Server], Server):
         data: dict[str, Any],
         complete: bool = True,
     ):
+        raw = data.get("datacenter")
+        if raw:
+            data["datacenter"] = BoundDatacenter(client._parent.datacenters, raw)
+
         raw = data.get("location")
         if raw:
             data["location"] = BoundLocation(client._parent.locations, raw)
@@ -630,6 +637,7 @@ class ServersClient(
         user_data: str | None = None,
         labels: dict[str, str] | None = None,
         location: Location | BoundLocation | None = None,
+        datacenter: Datacenter | BoundDatacenter | None = None,
         start_after_create: bool | None = True,
         automount: bool | None = None,
         placement_group: PlacementGroup | BoundPlacementGroup | None = None,
@@ -654,6 +662,7 @@ class ServersClient(
         :param labels: Dict[str,str] (optional)
                User-defined labels (key-value pairs)
         :param location: :class:`BoundLocation <hcloud.locations.client.BoundLocation>` or :class:`Location <hcloud.locations.domain.Location>`
+        :param datacenter: :class:`BoundDatacenter <hcloud.datacenters.client.BoundDatacenter>` or :class:`Datacenter <hcloud.datacenters.domain.Datacenter>`
         :param start_after_create: boolean (optional)
                Start Server right after creation. Defaults to True.
         :param automount: boolean (optional)
@@ -673,6 +682,15 @@ class ServersClient(
 
         if location is not None:
             data["location"] = location.id_or_name
+        if datacenter is not None:
+            warnings.warn(
+                "The 'datacenter' argument is deprecated and will be removed after 1 July 2026. "
+                "Please use the 'location' argument instead. "
+                "See https://docs.hetzner.cloud/changelog#2025-12-16-phasing-out-datacenters",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+            data["datacenter"] = datacenter.id_or_name
         if ssh_keys is not None:
             data["ssh_keys"] = [ssh_key.id_or_name for ssh_key in ssh_keys]
         if volumes is not None:

--- a/plugins/module_utils/_vendor/hcloud/servers/domain.py
+++ b/plugins/module_utils/_vendor/hcloud/servers/domain.py
@@ -1,11 +1,13 @@
 from __future__ import annotations
 
+import warnings
 from typing import TYPE_CHECKING, Literal, TypedDict
 
 from ..core import BaseDomain, DomainIdentityMixin
 
 if TYPE_CHECKING:
     from ..actions import BoundAction
+    from ..datacenters import BoundDatacenter
     from ..firewalls import BoundFirewall
     from ..floating_ips import BoundFloatingIP
     from ..images import BoundImage
@@ -54,6 +56,12 @@ class Server(BaseDomain, DomainIdentityMixin):
     :param public_net: :class:`PublicNetwork <hcloud.servers.domain.PublicNetwork>`
            Public network information.
     :param server_type: :class:`BoundServerType <hcloud.server_types.client.BoundServerType>`
+    :param datacenter: :class:`BoundDatacenter <hcloud.datacenters.client.BoundDatacenter>`
+
+        This property is deprecated and will be removed after 1 July 2026.
+        Please use the ``location`` property instead.
+
+        See https://docs.hetzner.cloud/changelog#2025-12-16-phasing-out-datacenters.
     :param location: :class:`BoundLocation <hcloud.locations.client.BoundLocation>`
     :param image: :class:`BoundImage <hcloud.images.client.BoundImage>`, None
     :param iso: :class:`BoundIso <hcloud.isos.client.BoundIso>`, None
@@ -100,7 +108,7 @@ class Server(BaseDomain, DomainIdentityMixin):
     STATUS_UNKNOWN = "unknown"
     """Server Status unknown"""
 
-    __api_properties__ = (
+    __properties__ = (
         "id",
         "name",
         "status",
@@ -123,7 +131,14 @@ class Server(BaseDomain, DomainIdentityMixin):
         "primary_disk_size",
         "placement_group",
     )
-    __slots__ = __api_properties__
+    __api_properties__ = (
+        *__properties__,
+        "datacenter",
+    )
+    __slots__ = (
+        *__properties__,
+        "_datacenter",
+    )
 
     # pylint: disable=too-many-locals
     def __init__(
@@ -134,6 +149,7 @@ class Server(BaseDomain, DomainIdentityMixin):
         created: str | None = None,
         public_net: PublicNetwork | None = None,
         server_type: BoundServerType | None = None,
+        datacenter: BoundDatacenter | None = None,
         location: BoundLocation | None = None,
         image: BoundImage | None = None,
         iso: BoundIso | None = None,
@@ -156,6 +172,7 @@ class Server(BaseDomain, DomainIdentityMixin):
         self.created = self._parse_datetime(created)
         self.public_net = public_net
         self.server_type = server_type
+        self.datacenter = datacenter
         self.location = location
         self.image = image
         self.iso = iso
@@ -181,6 +198,24 @@ class Server(BaseDomain, DomainIdentityMixin):
             if o.network.id == network.id:
                 return o
         return None
+
+    @property
+    def datacenter(self) -> BoundDatacenter | None:
+        """
+        :meta private:
+        """
+        warnings.warn(
+            "The 'datacenter' property is deprecated and will be removed after 1 July 2026. "
+            "Please use the 'location' property instead. "
+            "See https://docs.hetzner.cloud/changelog#2025-12-16-phasing-out-datacenters.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return self._datacenter
+
+    @datacenter.setter
+    def datacenter(self, value: BoundDatacenter | None) -> None:
+        self._datacenter = value
 
 
 class ServerProtection(TypedDict):

--- a/plugins/modules/load_balancer.py
+++ b/plugins/modules/load_balancer.py
@@ -150,7 +150,6 @@ hcloud_load_balancer:
 from ansible.module_utils.basic import AnsibleModule
 
 from ..module_utils._base import AnsibleHCloud
-from ..module_utils._deprecation import deprecated_load_balancer_type_warning
 from ..module_utils._vendor.hcloud import HCloudException
 from ..module_utils._vendor.hcloud.load_balancers import (
     BoundLoadBalancer,
@@ -192,18 +191,14 @@ class AnsibleHCloudLoadBalancer(AnsibleHCloud):
     def _create_load_balancer(self):
         self.module.fail_on_missing_params(required_params=["name", "load_balancer_type"])
         try:
-            load_balancer_type = self.client.load_balancer_types.get_by_name(
-                self.module.params.get("load_balancer_type")
-            )
-
             params = {
                 "name": self.module.params.get("name"),
                 "algorithm": LoadBalancerAlgorithm(type=self.module.params.get("algorithm", "round_robin")),
-                "load_balancer_type": load_balancer_type,
+                "load_balancer_type": self.client.load_balancer_types.get_by_name(
+                    self.module.params.get("load_balancer_type")
+                ),
                 "labels": self.module.params.get("labels"),
             }
-
-            deprecated_load_balancer_type_warning(self.module, load_balancer_type)
 
             if self.module.params.get("location") is None and self.module.params.get("network_zone") is None:
                 self.module.fail_json(msg="one of the following is required: location, network_zone")

--- a/plugins/modules/load_balancer_type_info.py
+++ b/plugins/modules/load_balancer_type_info.py
@@ -85,26 +85,6 @@ hcloud_load_balancer_type_info:
             returned: always
             type: int
             sample: 5
-        deprecation:
-            description: |
-              Describes if, when & how the resources was deprecated.
-              If this field is set to None the resource is not deprecated. If it has a value, it is considered deprecated.
-            returned: when deprecated
-            type: dict
-            contains:
-                announced:
-                    description: Date of when the deprecation was announced.
-                    returned: when deprecated
-                    type: str
-                    sample: "2026-03-09T09:00:00Z"
-                unavailable_after:
-                    description: |
-                      After the time in this field, the resource will not be available from the general listing
-                      endpoint of the resource type, and it can not be used in new resources. For example, if this is
-                      an image, you can not create new servers with this image after the mentioned date.
-                    returned: when deprecated
-                    type: str
-                    sample: "2026-06-09T09:00:00Z"
 """
 
 from ansible.module_utils.basic import AnsibleModule
@@ -135,14 +115,6 @@ class AnsibleHCloudLoadBalancerTypeInfo(AnsibleHCloud):
                     "max_services": load_balancer_type.max_services,
                     "max_targets": load_balancer_type.max_targets,
                     "max_assigned_certificates": load_balancer_type.max_assigned_certificates,
-                    "deprecation": (
-                        {
-                            "announced": load_balancer_type.deprecation.announced.isoformat(),
-                            "unavailable_after": load_balancer_type.deprecation.unavailable_after.isoformat(),
-                        }
-                        if load_balancer_type.deprecation is not None
-                        else None
-                    ),
                 }
             )
         return tmp

--- a/plugins/modules/network_info.py
+++ b/plugins/modules/network_info.py
@@ -154,6 +154,16 @@ hcloud_network_info:
                     returned: always
                     type: str
                     sample: fsn1
+                datacenter:
+                    description: |
+                        Name of the datacenter of the server
+
+                        B(Deprecated:) The RV(hcloud_network_info[].servers[].datacenter) value is deprecated and will be removed
+                        after 1 July 2026. Please use the RV(hcloud_network_info[].servers[].location) value instead.
+                        See https://docs.hetzner.cloud/changelog#2025-12-16-phasing-out-datacenters.
+                    returned: always
+                    type: str
+                    sample: fsn1-dc14
                 rescue_enabled:
                     description: True if rescue mode is enabled, Server will then boot into rescue system on next reboot
                     returned: always
@@ -222,6 +232,7 @@ class AnsibleHCloudNetworkInfo(AnsibleHCloud):
                     "ipv6": server.public_net.ipv6.ip if server.public_net.ipv6 is not None else None,
                     "image": server.image.name if server.image is not None else None,
                     "server_type": server.server_type.name,
+                    "datacenter": server.datacenter and server.datacenter.name,
                     "location": server.location.name,
                     "rescue_enabled": server.rescue_enabled,
                     "backup_window": server.backup_window,

--- a/plugins/modules/primary_ip.py
+++ b/plugins/modules/primary_ip.py
@@ -34,13 +34,21 @@ options:
     location:
         description:
             - ID or name of the Location the Hetzner Cloud Primary IP will be bound to.
-            - Required if no O(server) is given and Primary IP does not exist.
+            - Required if no O(server) or O(datacenter) is given and Primary IP does not exist.
+        type: str
+    datacenter:
+        description:
+            - B(Deprecated:) The O(datacenter) argument is deprecated and will be removed
+              after 1 July 2026. Please use the O(location) argument instead.
+              See https://docs.hetzner.cloud/changelog#2025-12-16-phasing-out-datacenters.
+            - Home Location of the Hetzner Cloud Primary IP.
+            - Required if no O(server) or O(location) is given and Primary IP does not exist.
         type: str
     server:
         description:
             - Name or ID of the Hetzner Cloud Server the Primary IP should be assigned to.
             - The Primary IP cannot be assigned to a running server.
-            - Required if no O(location) is given and the Primary IP does not exist.
+            - Required if no O(datacenter) is given and the Primary IP does not exist.
             - Use C(null) to unassign the Primary IP from the server.
         type: str
     type:
@@ -147,6 +155,16 @@ hcloud_primary_ip:
             type: str
             returned: Always
             sample: fsn1
+        datacenter:
+            description: |
+                Name of the datacenter of the Primary IP
+
+                B(Deprecated:) The RV(hcloud_primary_ip.datacenter) value is deprecated and will be removed
+                after 1 July 2026. Please use the RV(hcloud_primary_ip.location) value instead.
+                See https://docs.hetzner.cloud/changelog#2025-12-16-phasing-out-datacenters.
+            type: str
+            returned: Always
+            sample: fsn1-dc14
         delete_protection:
             description: True if Primary IP is protected for deletion
             type: bool
@@ -206,7 +224,7 @@ class AnsiblePrimaryIP(AnsibleHCloud):
     def _create(self):
         self.fail_on_invalid_params(
             required=["name", "type"],
-            required_one_of=[["server", "location"]],
+            required_one_of=[["server", "location", "datacenter"]],
         )
         params = {
             "name": self.module.params.get("name"),
@@ -215,6 +233,17 @@ class AnsiblePrimaryIP(AnsibleHCloud):
 
         if (value := self.module.params.get("location")) is not None:
             params["location"] = self._client_get_by_name_or_id("locations", value)
+        elif (value := self.module.params.get("datacenter")) is not None:
+            self.module.warn(
+                "The `datacenter` argument is deprecated and will be removed "
+                "after 1 July 2026. Please use the `location` argument instead. "
+                "See https://docs.hetzner.cloud/changelog#2025-12-16-phasing-out-datacenters."
+            )
+            # Backward compatible datacenter argument.
+            # datacenter hel1-dc2 => location hel1
+            # pylint: disable=disallowed-name
+            part1, _, _ = str(value).partition("-")
+            params["location"] = self.client.locations.get_by_name(part1)
         elif (value := self.module.params.get("server")) is not None:
             server: BoundServer = self._client_get_by_name_or_id("servers", value)
             params["assignee_id"] = server.id
@@ -335,6 +364,11 @@ class AnsiblePrimaryIP(AnsibleHCloud):
                 id={"type": "int"},
                 name={"type": "str"},
                 location={"type": "str"},
+                datacenter={
+                    "type": "str",
+                    "removed_at_date": "2026-07-01",
+                    "removed_from_collection": "hetzner.hcloud",
+                },
                 server={"type": "str"},
                 auto_delete={"type": "bool", "default": False},
                 type={"choices": ["ipv4", "ipv6"]},

--- a/plugins/modules/primary_ip_info.py
+++ b/plugins/modules/primary_ip_info.py
@@ -104,6 +104,16 @@ hcloud_primary_ip_info:
             returned: always
             type: str
             sample: fsn1
+        home_location:
+            description: |
+                Datacenter where the Primary IP was created in.
+
+                B(Deprecated:) The RV(hcloud_primary_ip_info[].home_location) value is deprecated and will be removed
+                after 1 July 2026. Please use the RV(hcloud_primary_ip_info[].location) value instead.
+                See https://docs.hetzner.cloud/changelog#2025-12-16-phasing-out-datacenters.
+            returned: always
+            type: str
+            sample: fsn1-dc1
         dns_ptr:
             description: Shows the DNS PTR Record for Primary IP.
             returned: always
@@ -153,6 +163,7 @@ class AnsibleHCloudPrimaryIPInfo(AnsibleHCloud):
                     "assignee_type": primary_ip.assignee_type,
                     "auto_delete": primary_ip.auto_delete,
                     "location": primary_ip.location.name,
+                    "home_location": primary_ip.datacenter and primary_ip.datacenter.name,
                     "dns_ptr": primary_ip.dns_ptr[0]["dns_ptr"] if len(primary_ip.dns_ptr) else None,
                     "labels": primary_ip.labels,
                     "delete_protection": primary_ip.protection["delete"],

--- a/plugins/modules/server.py
+++ b/plugins/modules/server.py
@@ -70,6 +70,15 @@ options:
             - Required if the server does not exist.
             - Only used during the server creation.
         type: str
+    datacenter:
+        description:
+            - B(Deprecated:) The O(datacenter) argument is deprecated and will be removed
+              after 1 July 2026. Please use the O(location) argument instead.
+              See https://docs.hetzner.cloud/changelog#2025-12-16-phasing-out-datacenters.
+            - Hetzner Cloud Datacenter (name or ID) to create the server in.
+            - Required if no O(location) is given and the server does not exist.
+            - Only used during the server creation.
+        type: str
     backups:
         description:
             - Enable or disable Backups for the given Server.
@@ -307,6 +316,16 @@ hcloud_server:
             returned: always
             sample: 4711
             version_added: "1.5.0"
+        datacenter:
+            description: |
+                Name of the datacenter of the server.
+
+                B(Deprecated:) The RV(hcloud_server.datacenter) value is deprecated and will be removed
+                after 1 July 2026. Please use the RV(hcloud_server.location) value instead.
+                See https://docs.hetzner.cloud/changelog#2025-12-16-phasing-out-datacenters.
+            returned: always
+            type: str
+            sample: fsn1-dc14
         rescue_enabled:
             description: True if rescue mode is enabled, Server will then boot into rescue system on next reboot
             returned: always
@@ -384,6 +403,7 @@ class AnsibleHCloudServer(AnsibleHCloud):
             ],
             "image": self.hcloud_server.image.name if self.hcloud_server.image is not None else None,
             "server_type": self.hcloud_server.server_type.name,
+            "datacenter": self.hcloud_server.datacenter and self.hcloud_server.datacenter.name,
             "location": self.hcloud_server.location.name,
             "placement_group": (
                 self.hcloud_server.placement_group.name if self.hcloud_server.placement_group is not None else None
@@ -459,9 +479,31 @@ class AnsibleHCloudServer(AnsibleHCloud):
             ]
 
         server_type_location = None
-        if self.module.params.get("location") is not None:
+
+        if self.module.params.get("location") is None and self.module.params.get("datacenter") is None:
+            # When not given, the API will choose the location.
+            params["location"] = None
+            params["datacenter"] = None
+        elif self.module.params.get("location") is not None and self.module.params.get("datacenter") is None:
             params["location"] = self._client_get_by_name_or_id("locations", self.module.params.get("location"))
             server_type_location = params["location"]
+        elif self.module.params.get("location") is None and self.module.params.get("datacenter") is not None:
+            self.module.warn(
+                "The `datacenter` argument is deprecated and will be removed "
+                "after 1 July 2026. Please use the `location` argument instead. "
+                "See https://docs.hetzner.cloud/changelog#2025-12-16-phasing-out-datacenters."
+            )
+            value: str = self.module.params.get("datacenter")
+            # Backward compatible datacenter argument.
+            # datacenter hel1-dc2 => location hel1
+            if value and not value.isdigit():
+                # pylint: disable=disallowed-name
+                part1, _, _ = value.partition("-")
+                params["location"] = self.client.locations.get_by_name(part1)
+                server_type_location = params["location"]
+            else:
+                params["datacenter"] = self._client_get_by_name_or_id("datacenters", value)
+                server_type_location = params["datacenter"].location
 
         if self.module.params.get("state") == "stopped" or self.module.params.get("state") == "created":
             params["start_after_create"] = False
@@ -932,6 +974,11 @@ class AnsibleHCloudServer(AnsibleHCloud):
                 image_allow_deprecated={"type": "bool", "default": False, "aliases": ["allow_deprecated_image"]},
                 server_type={"type": "str"},
                 location={"type": "str"},
+                datacenter={
+                    "type": "str",
+                    "removed_at_date": "2026-07-01",
+                    "removed_from_collection": "hetzner.hcloud",
+                },
                 user_data={"type": "str"},
                 ssh_keys={"type": "list", "elements": "str", "no_log": False},
                 volumes={"type": "list", "elements": "str"},
@@ -956,6 +1003,7 @@ class AnsibleHCloudServer(AnsibleHCloud):
                 **super().base_module_arguments(),
             ),
             required_one_of=[["id", "name"]],
+            mutually_exclusive=[["location", "datacenter"]],
             required_together=[["delete_protection", "rebuild_protection"]],
             supports_check_mode=True,
         )

--- a/plugins/modules/server_info.py
+++ b/plugins/modules/server_info.py
@@ -112,6 +112,16 @@ hcloud_server_info:
             returned: always
             sample: 4711
             version_added: "1.5.0"
+        datacenter:
+            description: |
+                Name of the datacenter of the server.
+
+                B(Deprecated:) The RV(hcloud_server_info[].datacenter) value is deprecated and will be removed
+                after 1 July 2026. Please use the RV(hcloud_server_info[].location) value instead.
+                See https://docs.hetzner.cloud/changelog#2025-12-16-phasing-out-datacenters.
+            returned: always
+            type: str
+            sample: fsn1-dc14
         rescue_enabled:
             description: True if rescue mode is enabled, Server will then boot into rescue system on next reboot
             returned: always
@@ -170,6 +180,7 @@ class AnsibleHCloudServerInfo(AnsibleHCloud):
                     "private_networks_info": [{"name": net.network.name, "ip": net.ip} for net in server.private_net],
                     "image": server.image.name if server.image is not None else None,
                     "server_type": server.server_type.name,
+                    "datacenter": server.datacenter and server.datacenter.name,
                     "location": server.location.name,
                     "placement_group": server.placement_group.name if server.placement_group is not None else None,
                     "rescue_enabled": server.rescue_enabled,

--- a/scripts/vendor.py
+++ b/scripts/vendor.py
@@ -22,7 +22,7 @@ from textwrap import dedent
 logger = logging.getLogger("vendor")
 
 HCLOUD_SOURCE_URL = "https://github.com/hetznercloud/hcloud-python"
-HCLOUD_VERSION = "v2.23.0"
+HCLOUD_VERSION = "v2.21.0"
 HCLOUD_VENDOR_PATH = "plugins/module_utils/_vendor/hcloud"
 
 

--- a/tests/integration/common/defaults/main/common.yml
+++ b/tests/integration/common/defaults/main/common.yml
@@ -20,6 +20,8 @@ hcloud_image_id: 114690389 # architecture=arm
 
 hcloud_location_name: hel1
 hcloud_location_id: 3
+hcloud_datacenter_name: hel1-dc2
+hcloud_datacenter_id: 3
 
 hcloud_network_zone_name: eu-central
 

--- a/tests/integration/targets/certificate/defaults/main/common.yml
+++ b/tests/integration/targets/certificate/defaults/main/common.yml
@@ -23,6 +23,8 @@ hcloud_image_id: 114690389 # architecture=arm
 
 hcloud_location_name: hel1
 hcloud_location_id: 3
+hcloud_datacenter_name: hel1-dc2
+hcloud_datacenter_id: 3
 
 hcloud_network_zone_name: eu-central
 

--- a/tests/integration/targets/certificate_info/defaults/main/common.yml
+++ b/tests/integration/targets/certificate_info/defaults/main/common.yml
@@ -23,6 +23,8 @@ hcloud_image_id: 114690389 # architecture=arm
 
 hcloud_location_name: hel1
 hcloud_location_id: 3
+hcloud_datacenter_name: hel1-dc2
+hcloud_datacenter_id: 3
 
 hcloud_network_zone_name: eu-central
 

--- a/tests/integration/targets/datacenter_info/defaults/main/common.yml
+++ b/tests/integration/targets/datacenter_info/defaults/main/common.yml
@@ -23,6 +23,8 @@ hcloud_image_id: 114690389 # architecture=arm
 
 hcloud_location_name: hel1
 hcloud_location_id: 3
+hcloud_datacenter_name: hel1-dc2
+hcloud_datacenter_id: 3
 
 hcloud_network_zone_name: eu-central
 

--- a/tests/integration/targets/datacenter_info/defaults/main/main.yml
+++ b/tests/integration/targets/datacenter_info/defaults/main/main.yml
@@ -1,2 +1,0 @@
-hcloud_datacenter_name: hel1-dc2
-hcloud_datacenter_id: 3

--- a/tests/integration/targets/filter_all/defaults/main/common.yml
+++ b/tests/integration/targets/filter_all/defaults/main/common.yml
@@ -23,6 +23,8 @@ hcloud_image_id: 114690389 # architecture=arm
 
 hcloud_location_name: hel1
 hcloud_location_id: 3
+hcloud_datacenter_name: hel1-dc2
+hcloud_datacenter_id: 3
 
 hcloud_network_zone_name: eu-central
 

--- a/tests/integration/targets/firewall/defaults/main/common.yml
+++ b/tests/integration/targets/firewall/defaults/main/common.yml
@@ -23,6 +23,8 @@ hcloud_image_id: 114690389 # architecture=arm
 
 hcloud_location_name: hel1
 hcloud_location_id: 3
+hcloud_datacenter_name: hel1-dc2
+hcloud_datacenter_id: 3
 
 hcloud_network_zone_name: eu-central
 

--- a/tests/integration/targets/firewall_info/defaults/main/common.yml
+++ b/tests/integration/targets/firewall_info/defaults/main/common.yml
@@ -23,6 +23,8 @@ hcloud_image_id: 114690389 # architecture=arm
 
 hcloud_location_name: hel1
 hcloud_location_id: 3
+hcloud_datacenter_name: hel1-dc2
+hcloud_datacenter_id: 3
 
 hcloud_network_zone_name: eu-central
 

--- a/tests/integration/targets/firewall_resource/defaults/main/common.yml
+++ b/tests/integration/targets/firewall_resource/defaults/main/common.yml
@@ -23,6 +23,8 @@ hcloud_image_id: 114690389 # architecture=arm
 
 hcloud_location_name: hel1
 hcloud_location_id: 3
+hcloud_datacenter_name: hel1-dc2
+hcloud_datacenter_id: 3
 
 hcloud_network_zone_name: eu-central
 

--- a/tests/integration/targets/floating_ip/defaults/main/common.yml
+++ b/tests/integration/targets/floating_ip/defaults/main/common.yml
@@ -23,6 +23,8 @@ hcloud_image_id: 114690389 # architecture=arm
 
 hcloud_location_name: hel1
 hcloud_location_id: 3
+hcloud_datacenter_name: hel1-dc2
+hcloud_datacenter_id: 3
 
 hcloud_network_zone_name: eu-central
 

--- a/tests/integration/targets/floating_ip_info/defaults/main/common.yml
+++ b/tests/integration/targets/floating_ip_info/defaults/main/common.yml
@@ -23,6 +23,8 @@ hcloud_image_id: 114690389 # architecture=arm
 
 hcloud_location_name: hel1
 hcloud_location_id: 3
+hcloud_datacenter_name: hel1-dc2
+hcloud_datacenter_id: 3
 
 hcloud_network_zone_name: eu-central
 

--- a/tests/integration/targets/image_info/defaults/main/common.yml
+++ b/tests/integration/targets/image_info/defaults/main/common.yml
@@ -23,6 +23,8 @@ hcloud_image_id: 114690389 # architecture=arm
 
 hcloud_location_name: hel1
 hcloud_location_id: 3
+hcloud_datacenter_name: hel1-dc2
+hcloud_datacenter_id: 3
 
 hcloud_network_zone_name: eu-central
 

--- a/tests/integration/targets/iso_info/defaults/main/common.yml
+++ b/tests/integration/targets/iso_info/defaults/main/common.yml
@@ -23,6 +23,8 @@ hcloud_image_id: 114690389 # architecture=arm
 
 hcloud_location_name: hel1
 hcloud_location_id: 3
+hcloud_datacenter_name: hel1-dc2
+hcloud_datacenter_id: 3
 
 hcloud_network_zone_name: eu-central
 

--- a/tests/integration/targets/load_balancer/defaults/main/common.yml
+++ b/tests/integration/targets/load_balancer/defaults/main/common.yml
@@ -23,6 +23,8 @@ hcloud_image_id: 114690389 # architecture=arm
 
 hcloud_location_name: hel1
 hcloud_location_id: 3
+hcloud_datacenter_name: hel1-dc2
+hcloud_datacenter_id: 3
 
 hcloud_network_zone_name: eu-central
 

--- a/tests/integration/targets/load_balancer_info/defaults/main/common.yml
+++ b/tests/integration/targets/load_balancer_info/defaults/main/common.yml
@@ -23,6 +23,8 @@ hcloud_image_id: 114690389 # architecture=arm
 
 hcloud_location_name: hel1
 hcloud_location_id: 3
+hcloud_datacenter_name: hel1-dc2
+hcloud_datacenter_id: 3
 
 hcloud_network_zone_name: eu-central
 

--- a/tests/integration/targets/load_balancer_network/defaults/main/common.yml
+++ b/tests/integration/targets/load_balancer_network/defaults/main/common.yml
@@ -23,6 +23,8 @@ hcloud_image_id: 114690389 # architecture=arm
 
 hcloud_location_name: hel1
 hcloud_location_id: 3
+hcloud_datacenter_name: hel1-dc2
+hcloud_datacenter_id: 3
 
 hcloud_network_zone_name: eu-central
 

--- a/tests/integration/targets/load_balancer_service/defaults/main/common.yml
+++ b/tests/integration/targets/load_balancer_service/defaults/main/common.yml
@@ -23,6 +23,8 @@ hcloud_image_id: 114690389 # architecture=arm
 
 hcloud_location_name: hel1
 hcloud_location_id: 3
+hcloud_datacenter_name: hel1-dc2
+hcloud_datacenter_id: 3
 
 hcloud_network_zone_name: eu-central
 

--- a/tests/integration/targets/load_balancer_target/defaults/main/common.yml
+++ b/tests/integration/targets/load_balancer_target/defaults/main/common.yml
@@ -23,6 +23,8 @@ hcloud_image_id: 114690389 # architecture=arm
 
 hcloud_location_name: hel1
 hcloud_location_id: 3
+hcloud_datacenter_name: hel1-dc2
+hcloud_datacenter_id: 3
 
 hcloud_network_zone_name: eu-central
 

--- a/tests/integration/targets/load_balancer_type_info/defaults/main/common.yml
+++ b/tests/integration/targets/load_balancer_type_info/defaults/main/common.yml
@@ -23,6 +23,8 @@ hcloud_image_id: 114690389 # architecture=arm
 
 hcloud_location_name: hel1
 hcloud_location_id: 3
+hcloud_datacenter_name: hel1-dc2
+hcloud_datacenter_id: 3
 
 hcloud_network_zone_name: eu-central
 

--- a/tests/integration/targets/location_info/defaults/main/common.yml
+++ b/tests/integration/targets/location_info/defaults/main/common.yml
@@ -23,6 +23,8 @@ hcloud_image_id: 114690389 # architecture=arm
 
 hcloud_location_name: hel1
 hcloud_location_id: 3
+hcloud_datacenter_name: hel1-dc2
+hcloud_datacenter_id: 3
 
 hcloud_network_zone_name: eu-central
 

--- a/tests/integration/targets/network/defaults/main/common.yml
+++ b/tests/integration/targets/network/defaults/main/common.yml
@@ -23,6 +23,8 @@ hcloud_image_id: 114690389 # architecture=arm
 
 hcloud_location_name: hel1
 hcloud_location_id: 3
+hcloud_datacenter_name: hel1-dc2
+hcloud_datacenter_id: 3
 
 hcloud_network_zone_name: eu-central
 

--- a/tests/integration/targets/network_info/defaults/main/common.yml
+++ b/tests/integration/targets/network_info/defaults/main/common.yml
@@ -23,6 +23,8 @@ hcloud_image_id: 114690389 # architecture=arm
 
 hcloud_location_name: hel1
 hcloud_location_id: 3
+hcloud_datacenter_name: hel1-dc2
+hcloud_datacenter_id: 3
 
 hcloud_network_zone_name: eu-central
 

--- a/tests/integration/targets/placement_group/defaults/main/common.yml
+++ b/tests/integration/targets/placement_group/defaults/main/common.yml
@@ -23,6 +23,8 @@ hcloud_image_id: 114690389 # architecture=arm
 
 hcloud_location_name: hel1
 hcloud_location_id: 3
+hcloud_datacenter_name: hel1-dc2
+hcloud_datacenter_id: 3
 
 hcloud_network_zone_name: eu-central
 

--- a/tests/integration/targets/primary_ip/defaults/main/common.yml
+++ b/tests/integration/targets/primary_ip/defaults/main/common.yml
@@ -23,6 +23,8 @@ hcloud_image_id: 114690389 # architecture=arm
 
 hcloud_location_name: hel1
 hcloud_location_id: 3
+hcloud_datacenter_name: hel1-dc2
+hcloud_datacenter_id: 3
 
 hcloud_network_zone_name: eu-central
 

--- a/tests/integration/targets/primary_ip_info/defaults/main/common.yml
+++ b/tests/integration/targets/primary_ip_info/defaults/main/common.yml
@@ -23,6 +23,8 @@ hcloud_image_id: 114690389 # architecture=arm
 
 hcloud_location_name: hel1
 hcloud_location_id: 3
+hcloud_datacenter_name: hel1-dc2
+hcloud_datacenter_id: 3
 
 hcloud_network_zone_name: eu-central
 

--- a/tests/integration/targets/rdns/defaults/main/common.yml
+++ b/tests/integration/targets/rdns/defaults/main/common.yml
@@ -23,6 +23,8 @@ hcloud_image_id: 114690389 # architecture=arm
 
 hcloud_location_name: hel1
 hcloud_location_id: 3
+hcloud_datacenter_name: hel1-dc2
+hcloud_datacenter_id: 3
 
 hcloud_network_zone_name: eu-central
 

--- a/tests/integration/targets/route/defaults/main/common.yml
+++ b/tests/integration/targets/route/defaults/main/common.yml
@@ -23,6 +23,8 @@ hcloud_image_id: 114690389 # architecture=arm
 
 hcloud_location_name: hel1
 hcloud_location_id: 3
+hcloud_datacenter_name: hel1-dc2
+hcloud_datacenter_id: 3
 
 hcloud_network_zone_name: eu-central
 

--- a/tests/integration/targets/server/defaults/main/common.yml
+++ b/tests/integration/targets/server/defaults/main/common.yml
@@ -23,6 +23,8 @@ hcloud_image_id: 114690389 # architecture=arm
 
 hcloud_location_name: hel1
 hcloud_location_id: 3
+hcloud_datacenter_name: hel1-dc2
+hcloud_datacenter_id: 3
 
 hcloud_network_zone_name: eu-central
 

--- a/tests/integration/targets/server/tasks/test.yml
+++ b/tests/integration/targets/server/tasks/test.yml
@@ -3,6 +3,7 @@
 ---
 #- ansible.builtin.include_tasks: test_validation.yml
 - ansible.builtin.include_tasks: test_basic.yml
+- ansible.builtin.include_tasks: test_datacenter.yml
 #- ansible.builtin.include_tasks: test_firewalls.yml
 - ansible.builtin.include_tasks: test_primary_ips.yml
 - ansible.builtin.include_tasks: test_private_network_only.yml

--- a/tests/integration/targets/server/tasks/test_datacenter.yml
+++ b/tests/integration/targets/server/tasks/test_datacenter.yml
@@ -1,0 +1,20 @@
+# Copyright: (c) 2019, Hetzner Cloud GmbH <info@hetzner-cloud.de>
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+---
+- name: Test create server with datacenter (deprecated)
+  hetzner.hcloud.server:
+    name: "{{ hcloud_server_name }}"
+    server_type: "{{ hcloud_server_type_name }}"
+    image: "{{ hcloud_image_name }}"
+    datacenter: "{{ hcloud_datacenter_name }}"
+    state: created
+  register: result
+- name: Verify create server with datacenter (deprecated)
+  ansible.builtin.assert:
+    that:
+      - result is changed
+
+- name: Cleanup server with datacenter (deprecated)
+  hetzner.hcloud.server:
+    name: "{{ hcloud_server_name }}"
+    state: absent

--- a/tests/integration/targets/server_info/defaults/main/common.yml
+++ b/tests/integration/targets/server_info/defaults/main/common.yml
@@ -23,6 +23,8 @@ hcloud_image_id: 114690389 # architecture=arm
 
 hcloud_location_name: hel1
 hcloud_location_id: 3
+hcloud_datacenter_name: hel1-dc2
+hcloud_datacenter_id: 3
 
 hcloud_network_zone_name: eu-central
 

--- a/tests/integration/targets/server_network/defaults/main/common.yml
+++ b/tests/integration/targets/server_network/defaults/main/common.yml
@@ -23,6 +23,8 @@ hcloud_image_id: 114690389 # architecture=arm
 
 hcloud_location_name: hel1
 hcloud_location_id: 3
+hcloud_datacenter_name: hel1-dc2
+hcloud_datacenter_id: 3
 
 hcloud_network_zone_name: eu-central
 

--- a/tests/integration/targets/server_type_info/defaults/main/common.yml
+++ b/tests/integration/targets/server_type_info/defaults/main/common.yml
@@ -23,6 +23,8 @@ hcloud_image_id: 114690389 # architecture=arm
 
 hcloud_location_name: hel1
 hcloud_location_id: 3
+hcloud_datacenter_name: hel1-dc2
+hcloud_datacenter_id: 3
 
 hcloud_network_zone_name: eu-central
 

--- a/tests/integration/targets/ssh_key/defaults/main/common.yml
+++ b/tests/integration/targets/ssh_key/defaults/main/common.yml
@@ -23,6 +23,8 @@ hcloud_image_id: 114690389 # architecture=arm
 
 hcloud_location_name: hel1
 hcloud_location_id: 3
+hcloud_datacenter_name: hel1-dc2
+hcloud_datacenter_id: 3
 
 hcloud_network_zone_name: eu-central
 

--- a/tests/integration/targets/ssh_key_info/defaults/main/common.yml
+++ b/tests/integration/targets/ssh_key_info/defaults/main/common.yml
@@ -23,6 +23,8 @@ hcloud_image_id: 114690389 # architecture=arm
 
 hcloud_location_name: hel1
 hcloud_location_id: 3
+hcloud_datacenter_name: hel1-dc2
+hcloud_datacenter_id: 3
 
 hcloud_network_zone_name: eu-central
 

--- a/tests/integration/targets/storage_box/defaults/main/common.yml
+++ b/tests/integration/targets/storage_box/defaults/main/common.yml
@@ -23,6 +23,8 @@ hcloud_image_id: 114690389 # architecture=arm
 
 hcloud_location_name: hel1
 hcloud_location_id: 3
+hcloud_datacenter_name: hel1-dc2
+hcloud_datacenter_id: 3
 
 hcloud_network_zone_name: eu-central
 

--- a/tests/integration/targets/storage_box_info/defaults/main/common.yml
+++ b/tests/integration/targets/storage_box_info/defaults/main/common.yml
@@ -23,6 +23,8 @@ hcloud_image_id: 114690389 # architecture=arm
 
 hcloud_location_name: hel1
 hcloud_location_id: 3
+hcloud_datacenter_name: hel1-dc2
+hcloud_datacenter_id: 3
 
 hcloud_network_zone_name: eu-central
 

--- a/tests/integration/targets/storage_box_snapshot/defaults/main/common.yml
+++ b/tests/integration/targets/storage_box_snapshot/defaults/main/common.yml
@@ -23,6 +23,8 @@ hcloud_image_id: 114690389 # architecture=arm
 
 hcloud_location_name: hel1
 hcloud_location_id: 3
+hcloud_datacenter_name: hel1-dc2
+hcloud_datacenter_id: 3
 
 hcloud_network_zone_name: eu-central
 

--- a/tests/integration/targets/storage_box_snapshot_info/defaults/main/common.yml
+++ b/tests/integration/targets/storage_box_snapshot_info/defaults/main/common.yml
@@ -23,6 +23,8 @@ hcloud_image_id: 114690389 # architecture=arm
 
 hcloud_location_name: hel1
 hcloud_location_id: 3
+hcloud_datacenter_name: hel1-dc2
+hcloud_datacenter_id: 3
 
 hcloud_network_zone_name: eu-central
 

--- a/tests/integration/targets/storage_box_subaccount/defaults/main/common.yml
+++ b/tests/integration/targets/storage_box_subaccount/defaults/main/common.yml
@@ -23,6 +23,8 @@ hcloud_image_id: 114690389 # architecture=arm
 
 hcloud_location_name: hel1
 hcloud_location_id: 3
+hcloud_datacenter_name: hel1-dc2
+hcloud_datacenter_id: 3
 
 hcloud_network_zone_name: eu-central
 

--- a/tests/integration/targets/storage_box_subaccount_info/defaults/main/common.yml
+++ b/tests/integration/targets/storage_box_subaccount_info/defaults/main/common.yml
@@ -23,6 +23,8 @@ hcloud_image_id: 114690389 # architecture=arm
 
 hcloud_location_name: hel1
 hcloud_location_id: 3
+hcloud_datacenter_name: hel1-dc2
+hcloud_datacenter_id: 3
 
 hcloud_network_zone_name: eu-central
 

--- a/tests/integration/targets/storage_box_type_info/defaults/main/common.yml
+++ b/tests/integration/targets/storage_box_type_info/defaults/main/common.yml
@@ -23,6 +23,8 @@ hcloud_image_id: 114690389 # architecture=arm
 
 hcloud_location_name: hel1
 hcloud_location_id: 3
+hcloud_datacenter_name: hel1-dc2
+hcloud_datacenter_id: 3
 
 hcloud_network_zone_name: eu-central
 

--- a/tests/integration/targets/subnetwork/defaults/main/common.yml
+++ b/tests/integration/targets/subnetwork/defaults/main/common.yml
@@ -23,6 +23,8 @@ hcloud_image_id: 114690389 # architecture=arm
 
 hcloud_location_name: hel1
 hcloud_location_id: 3
+hcloud_datacenter_name: hel1-dc2
+hcloud_datacenter_id: 3
 
 hcloud_network_zone_name: eu-central
 

--- a/tests/integration/targets/volume/defaults/main/common.yml
+++ b/tests/integration/targets/volume/defaults/main/common.yml
@@ -23,6 +23,8 @@ hcloud_image_id: 114690389 # architecture=arm
 
 hcloud_location_name: hel1
 hcloud_location_id: 3
+hcloud_datacenter_name: hel1-dc2
+hcloud_datacenter_id: 3
 
 hcloud_network_zone_name: eu-central
 

--- a/tests/integration/targets/volume_attachment/defaults/main/common.yml
+++ b/tests/integration/targets/volume_attachment/defaults/main/common.yml
@@ -23,6 +23,8 @@ hcloud_image_id: 114690389 # architecture=arm
 
 hcloud_location_name: hel1
 hcloud_location_id: 3
+hcloud_datacenter_name: hel1-dc2
+hcloud_datacenter_id: 3
 
 hcloud_network_zone_name: eu-central
 

--- a/tests/integration/targets/volume_info/defaults/main/common.yml
+++ b/tests/integration/targets/volume_info/defaults/main/common.yml
@@ -23,6 +23,8 @@ hcloud_image_id: 114690389 # architecture=arm
 
 hcloud_location_name: hel1
 hcloud_location_id: 3
+hcloud_datacenter_name: hel1-dc2
+hcloud_datacenter_id: 3
 
 hcloud_network_zone_name: eu-central
 

--- a/tests/integration/targets/zone/defaults/main/common.yml
+++ b/tests/integration/targets/zone/defaults/main/common.yml
@@ -23,6 +23,8 @@ hcloud_image_id: 114690389 # architecture=arm
 
 hcloud_location_name: hel1
 hcloud_location_id: 3
+hcloud_datacenter_name: hel1-dc2
+hcloud_datacenter_id: 3
 
 hcloud_network_zone_name: eu-central
 

--- a/tests/integration/targets/zone_info/defaults/main/common.yml
+++ b/tests/integration/targets/zone_info/defaults/main/common.yml
@@ -23,6 +23,8 @@ hcloud_image_id: 114690389 # architecture=arm
 
 hcloud_location_name: hel1
 hcloud_location_id: 3
+hcloud_datacenter_name: hel1-dc2
+hcloud_datacenter_id: 3
 
 hcloud_network_zone_name: eu-central
 

--- a/tests/integration/targets/zone_rrset/defaults/main/common.yml
+++ b/tests/integration/targets/zone_rrset/defaults/main/common.yml
@@ -23,6 +23,8 @@ hcloud_image_id: 114690389 # architecture=arm
 
 hcloud_location_name: hel1
 hcloud_location_id: 3
+hcloud_datacenter_name: hel1-dc2
+hcloud_datacenter_id: 3
 
 hcloud_network_zone_name: eu-central
 

--- a/tests/integration/targets/zone_rrset_info/defaults/main/common.yml
+++ b/tests/integration/targets/zone_rrset_info/defaults/main/common.yml
@@ -23,6 +23,8 @@ hcloud_image_id: 114690389 # architecture=arm
 
 hcloud_location_name: hel1
 hcloud_location_id: 3
+hcloud_datacenter_name: hel1-dc2
+hcloud_datacenter_id: 3
 
 hcloud_network_zone_name: eu-central
 

--- a/tests/unit/inventory/test_hcloud.py
+++ b/tests/unit/inventory/test_hcloud.py
@@ -52,6 +52,14 @@ def test_build_inventory_server():
                 "id": 3,
                 "name": "hel1",
             },
+            "datacenter": {
+                "id": 3,
+                "name": "hel1-dc2",
+                "location": {
+                    "id": 3,
+                    "name": "hel1",
+                },
+            },
             "image": {
                 "id": 114690387,
                 "name": "debian-12",
@@ -74,6 +82,7 @@ def test_build_inventory_server():
         "server_type": "cpx22",
         "architecture": "x86",
         "location": "hel1",
+        "datacenter": "hel1-dc2",
         "labels": {},
         "ipv4": "127.0.0.1",
         "ipv6": "2001:db8::1",

--- a/tests/unit/module_utils/test_deprecation.py
+++ b/tests/unit/module_utils/test_deprecation.py
@@ -6,11 +6,7 @@ from unittest import mock
 import pytest
 
 from plugins.module_utils._deprecation import (
-    deprecated_load_balancer_type_warning,
     deprecated_server_type_warning,
-)
-from plugins.module_utils._vendor.hcloud.load_balancer_types import (
-    BoundLoadBalancerType,
 )
 from plugins.module_utils._vendor.hcloud.locations import (
     BoundLocation,
@@ -260,43 +256,4 @@ DEPRECATION_UNAVAILABLE = {
 def test_deprecated_server_type_warning(server_type, location, calls):
     m = mock.Mock()
     deprecated_server_type_warning(m, server_type, location)
-    m.warn.assert_has_calls(calls)
-
-
-@pytest.mark.parametrize(
-    ("load_balancer_type", "calls"),
-    [
-        (
-            BoundLoadBalancerType(
-                mock.Mock(),
-                {"name": "lb11"},
-            ),
-            [],
-        ),
-        # - Deprecated
-        (
-            BoundLoadBalancerType(
-                mock.Mock(),
-                {"name": "lb11", **DEPRECATION_DEPRECATED},
-            ),
-            [
-                mock.call(
-                    "Load Balancer type lb11 is deprecated and will no longer "
-                    f"be available for order as of {FUTURE.strftime('%Y-%m-%d')}."
-                )
-            ],
-        ),
-        # - Unavailable
-        (
-            BoundLoadBalancerType(
-                mock.Mock(),
-                {"name": "lb11", **DEPRECATION_UNAVAILABLE},
-            ),
-            [mock.call("Load Balancer type lb11 is unavailable and can no longer be ordered.")],
-        ),
-    ],
-)
-def test_deprecated_load_balancer_type_warning(load_balancer_type, calls):
-    m = mock.Mock()
-    deprecated_load_balancer_type_warning(m, load_balancer_type)
     m.warn.assert_has_calls(calls)


### PR DESCRIPTION
##### SUMMARY

Closes #851 

In the 6.11.0 release, we removed some features from this collection without marking the change as breaking (i.e., without a new major release). We didn't mark it as breaking because the removal originated in the Hetzner Cloud API itself, the features stopped working there regardless of what we did on our end, so not removing them would have caused some breakage anyway.

However, to comply with the community package collection requirements, such removals must be released as breaking changes. We will therefore revert the 6.11.0 changes in the 6.12.0 release, and then re-introduce them as a new major release 7.0.0.

Reverted changes:
- https://github.com/ansible-collections/hetzner.hcloud/pull/847
- https://github.com/ansible-collections/hetzner.hcloud/pull/848

Related API changelog:
- https://docs.hetzner.cloud/changelog#2025-12-16-phasing-out-datacenters
- https://docs.hetzner.cloud/changelog#2026-07-01-removing-datacenters