### PR TITLE
feat!: drop support for Python 3.10

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ For more information about communication, see the [Ansible communication guide](
 
 ## Python version compatibility
 
-This collection depends on the [hcloud](https://github.com/hetznercloud/hcloud-python) library. Due to the [hcloud](https://github.com/hetznercloud/hcloud-python) Python Support Policy this collection requires Python 3.10 or greater.
+This collection depends on the [hcloud](https://github.com/hetznercloud/hcloud-python) library. Due to the [hcloud](https://github.com/hetznercloud/hcloud-python) Python Support Policy this collection requires Python 3.11 or greater.
 
 ## Release notes
 

--- a/changelogs/fragments/drop-python-3.10.yml
+++ b/changelogs/fragments/drop-python-3.10.yml
@@ -1,0 +1,2 @@
+breaking_changes:
+  - Drop support for Python 3.10

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ combine_as_imports = true
 add_imports = ["from __future__ import annotations"]
 
 [tool.pylint.main]
-py-version = "3.10"
+py-version = "3.11"
 recursive = true
 jobs = 0
 

--- a/tests/config.yml
+++ b/tests/config.yml
@@ -1,3 +1,3 @@
 ---
 modules:
-  python_requires: ">=3.10"
+  python_requires: ">=3.11"


### PR DESCRIPTION
SUMMARY

Python 3.10 will be EOL in Oct 2026.

https://devguide.python.org/versions/

While being a bit ahead of the Python3.10 EOL schedule, we prefer not to release yet another major release in October just to drop this version of Python.
